### PR TITLE
[CI] prepare for ownership change for Nightly-build

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -46,15 +46,13 @@ env:
 jobs:
   build_lnx:
     name: oneDAL Linux nightly build
-    if: github.repository == 'oneapi-src/oneDAL'
+    if: github.repository == 'uxlfoundation/oneDAL'
     runs-on: ubuntu-24.04
     timeout-minutes: 120
 
     steps:
       - name: Checkout oneDAL
         uses: actions/checkout@v4
-        with:
-          repository: oneapi-src/oneDAL
       - name: Install DPC++
         run: .ci/env/apt.sh dpcpp
       - name: Install MKL
@@ -84,15 +82,13 @@ jobs:
 
   build_win:
     name: oneDAL Windows nightly build
-    if: github.repository == 'oneapi-src/oneDAL'
+    if: github.repository == 'uxlfoundation/oneDAL'
     runs-on: windows-2022
     timeout-minutes: 120
 
     steps:
       - name: Checkout oneDAL
         uses: actions/checkout@v4
-        with:
-          repository: oneapi-src/oneDAL
       - name: Install DPC++
         shell: cmd
         run: |


### PR DESCRIPTION
## Description

This PR updates hardcoded values from oneapi-src to uxlfoundation as shown by the change in organization. Performance benchmarks are not necessary.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
