### PR TITLE
MAINT: Add default constructor for global policy context

### DIFF
--- a/cpp/oneapi/dal/detail/global_context.hpp
+++ b/cpp/oneapi/dal/detail/global_context.hpp
@@ -31,6 +31,8 @@ class global_context : public global_context_iface {
 public:
     static const global_context_iface& get_global_context();
 
+    virtual ~global_context() = default;
+
     global_context(const global_context& ctx) = delete;
     global_context& operator=(const global_context& ctx) = delete;
 


### PR DESCRIPTION
## Description

This PR adds a default destructor for the global policy context class.

It shouldn't make any kind of difference, since this class doesn't hold any members in need of destruction and it's used as a global variable, but it should decrease the number of false-positive findings from static code analyzers.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
