### PR TITLE
MAINT: Delete unused operators for spmatrix handle class

### DIFF
--- a/cpp/oneapi/dal/detail/sparse_matrix_handle_impl.hpp
+++ b/cpp/oneapi/dal/detail/sparse_matrix_handle_impl.hpp
@@ -33,6 +33,10 @@ public:
 
     virtual ~sparse_matrix_handle_impl();
 
+    sparse_matrix_handle_impl(sparse_matrix_handle_impl& other) = delete;
+
+    sparse_matrix_handle_impl& operator=(sparse_matrix_handle_impl& other) = delete;
+
     inline mkl::sparse::matrix_handle_t& get() {
         return handle_;
     }


### PR DESCRIPTION
## Description

This PR deletes the copy and copy-assignment operators for the sparse matrix handle class, in order to clear warnings from static code analyzers.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
