### PR TITLE
MAINT: Delete unused operators for scoped lock class

### DIFF
--- a/cpp/oneapi/dal/detail/threading.hpp
+++ b/cpp/oneapi/dal/detail/threading.hpp
@@ -472,6 +472,8 @@ public:
     }
     scoped_lock(const scoped_lock &) = delete;
     scoped_lock(scoped_lock &&) = delete;
+    scoped_lock &operator=(scoped_lock &other) = delete;
+    scoped_lock &operator=(scoped_lock &&other) = delete;
     ~scoped_lock() {
         mutex_.unlock();
     }


### PR DESCRIPTION
## Description

This PR deletes the copy-assignment and move-assignment operators for the scoped lock class, in order to clear warnings from static code analyzers.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
