### PR TITLE
DOC: Update doc and internal links after uxl transfer

### DIFF
--- a/.ci/env/tbb.bat
+++ b/.ci/env/tbb.bat
@@ -18,7 +18,7 @@ rem ============================================================================
 rem req: PowerShell 3.0+
 powershell.exe -command "if ($PSVersionTable.PSVersion.Major -ge 3) {exit 1} else {Write-Host \"The script requires PowerShell 3.0 or above (current version: $($PSVersionTable.PSVersion.Major).$($PSVersionTable.PSVersion.Minor))\"}" && goto Error_load
 
-set TBBURLROOT=https://github.com/oneapi-src/oneTBB/releases/download/v2021.5.0/
+set TBBURLROOT=https://github.com/uxlfoundation/oneTBB/releases/download/v2021.5.0/
 set TBBVERSION=oneapi-tbb-2021.5.0
 set TBBPACKAGE=%TBBVERSION%-win
 

--- a/.ci/env/tbb.sh
+++ b/.ci/env/tbb.sh
@@ -120,7 +120,7 @@ sudo apt-get install build-essential gcc gfortran cmake -y
 tbb_src=${tbb_src:-${ONEDAL_DIR}/__work/onetbb-src}
 if [[ ! -d "${tbb_src}" ]] ; then
   TBB_VERSION="${TBB_VERSION:-${TBB_DEFAULT_VERSION}}"
-  git clone --depth 1 --branch "${TBB_VERSION}" https://github.com/oneapi-src/oneTBB.git "${tbb_src}"
+  git clone --depth 1 --branch "${TBB_VERSION}" https://github.com/uxlfoundation/oneTBB.git "${tbb_src}"
 fi
 
 rm -rf "${tbb_prefix}"

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -605,7 +605,7 @@ jobs:
       conda create -q -y -n CB -c conda-forge python=$(python.version) mpich
     displayName: 'Conda create'
   - script: |
-      git clone https://github.com/intel/scikit-learn-intelex.git sklearnex
+      git clone https://github.com/uxlfoundation/scikit-learn-intelex.git sklearnex
     displayName: Clone sklearnex
   - script: |
       source /usr/share/miniconda/etc/profile.d/conda.sh

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,8 +28,8 @@ cpp/           @Alexsandruss @samir-nasibli @Alexandr-Solovev
 dtrees         @razdoburdin @ahuber21 @avolkov-intel @icfaust
 
 # Governance and process
-/.github/CODEOWNERS @oneapi-src/oneDAL-maintainer
-/SECURITY.md @oneapi-src/oneDAL-maintainer
-/MAINTAINERS.md @oneapi-src/oneDAL-maintainer
-/CONTRIBUTING.md @oneapi-src/oneDAL-maintainer
-/CODE_OF_CONDUCT.md @oneapi-src/oneDAL-maintainer
+/.github/CODEOWNERS @uxlfoundation/oneDAL-maintainer
+/SECURITY.md @uxlfoundation/oneDAL-maintainer
+/MAINTAINERS.md @uxlfoundation/oneDAL-maintainer
+/CONTRIBUTING.md @uxlfoundation/oneDAL-maintainer
+/CODE_OF_CONDUCT.md @uxlfoundation/oneDAL-maintainer

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,8 +28,8 @@ cpp/           @Alexsandruss @samir-nasibli @Alexandr-Solovev
 dtrees         @razdoburdin @ahuber21 @avolkov-intel @icfaust
 
 # Governance and process
-/.github/CODEOWNERS @uxlfoundation/oneDAL-maintainer
-/SECURITY.md @uxlfoundation/oneDAL-maintainer
-/MAINTAINERS.md @uxlfoundation/oneDAL-maintainer
-/CONTRIBUTING.md @uxlfoundation/oneDAL-maintainer
-/CODE_OF_CONDUCT.md @uxlfoundation/oneDAL-maintainer
+/.github/CODEOWNERS @uxlfoundation/oneDAL-maintain
+/SECURITY.md @uxlfoundation/oneDAL-maintain
+/MAINTAINERS.md @uxlfoundation/oneDAL-maintain
+/CONTRIBUTING.md @uxlfoundation/oneDAL-maintain
+/CODE_OF_CONDUCT.md @uxlfoundation/oneDAL-maintain

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,7 @@ Checklist to comply with **before moving PR from draft**:
 - [ ] I have reviewed my changes thoroughly before submitting this pull request.
 - [ ] I have commented my code, particularly in hard-to-understand areas.
 - [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
-- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
+- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
 - [ ] I have added a respective label(s) to PR if I have a permission for that.
 - [ ] I have resolved any merge conflicts that might occur with the base branch.
 

--- a/.github/workflows/docker-validation-nightly.yml
+++ b/.github/workflows/docker-validation-nightly.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   validate:
     name: Docker validation
-    if: github.repository == 'oneapi-src/oneDAL'
+    if: github.repository == 'uxlfoundation/oneDAL'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/label-enforcement.yml
+++ b/.github/workflows/label-enforcement.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: test
         run: |
-          LABELS=`gh api -H "Accept: application/vnd.github+json" /repos/oneapi-src/oneDAL/issues/${{ github.event.pull_request.number }}/labels | jq '[.[].name]'`
+          LABELS=`gh api -H "Accept: application/vnd.github+json" /repos/uxlfoundation/oneDAL/issues/${{ github.event.pull_request.number }}/labels | jq '[.[].name]'`
           echo $LABELS
           if [[ $LABELS == "[]" ]] || [[ $LABELS == "[\"RFC\"]" ]]; then
             echo "::error::No label set on the pull request"

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -16,7 +16,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    if: github.repository == 'oneapi-src/oneDAL'
+    if: github.repository == 'uxlfoundation/oneDAL'
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,14 +18,14 @@
 # How to Contribute
 We welcome community contributions to Intel(R) oneAPI Data Analytics Library. You can:
 
-- Submit your changes directly with a [pull request](https://github.com/oneapi-src/oneDAL/pulls).
-- Log a bug or make a feature request with an [issue](https://github.com/oneapi-src/oneDAL/issues).
+- Submit your changes directly with a [pull request](https://github.com/uxlfoundation/oneDAL/pulls).
+- Log a bug or make a feature request with an [issue](https://github.com/uxlfoundation/oneDAL/issues).
 
 Refer to our guidelines on [pull requests](#pull-requests) and [issues](#issues) before you proceed.
 
 ## Contacting maintainers
 You may reach out to Intel project maintainers privately at onedal.maintainers@intel.com.
-[Codeowners](https://github.com/oneapi-src/oneDAL/blob/main/.github/CODEOWNERS) configuration defines specific maintainers for corresponding code sections, however it's currently limited to Intel members. With further migration to UXL we will be changing this, but here are non-Intel contacts:
+[Codeowners](https://github.com/uxlfoundation/oneDAL/blob/main/.github/CODEOWNERS) configuration defines specific maintainers for corresponding code sections, however it's currently limited to Intel members. With further migration to UXL we will be changing this, but here are non-Intel contacts:
 
 For ARM specifics you may contact: [@rakshithgb-fujitsu](https://github.com/rakshithgb-fujitsu/)
 
@@ -33,7 +33,7 @@ For RISC-V specifics you may contact: [@keeranroth](https://github.com/keeranrot
 
 ## Issues
 
-Use [GitHub issues](https://github.com/oneapi-src/oneDAL/issues) to:
+Use [GitHub issues](https://github.com/uxlfoundation/oneDAL/issues) to:
 - report an issue
 - make a feature request
 
@@ -43,11 +43,11 @@ Use [GitHub issues](https://github.com/oneapi-src/oneDAL/issues) to:
 
 To contribute your changes directly to the repository, do the following:
 - Make sure you can build the product and run all the examples with your patch.
-- Product uses bazel for validation and your changes should pass tests. Please add new tests as necessary. [Bazel Guide for oneDAL](https://github.com/oneapi-src/oneDAL/tree/main/dev/bazel)
+- Product uses bazel for validation and your changes should pass tests. Please add new tests as necessary. [Bazel Guide for oneDAL](https://github.com/uxlfoundation/oneDAL/tree/main/dev/bazel)
 - Make sure your code is in line with our [coding style](#code-style) as `clang-format` is one of the checks in our public CI.
 - For a larger feature, provide a relevant example, and tests.
 - [Document](#documentation-guidelines) your code.
-- [Submit](https://github.com/oneapi-src/oneDAL/pulls) a pull request into the `main` branch.
+- [Submit](https://github.com/uxlfoundation/oneDAL/pulls) a pull request into the `main` branch.
 
 Public and private CIs are enabled for the repository. Your PR should pass all of our checks. We will review your contribution and, if any additional fixes or modifications are necessary, we may give some feedback to guide you. When accepted, your pull request will be merged into our GitHub* repository.
 
@@ -57,7 +57,7 @@ Public and private CIs are enabled for the repository. Your PR should pass all o
 
 **Prerequisites:** ClangFormat `9.0.0` or later
 
-Our repository contains [clang-format configurations](https://github.com/oneapi-src/oneDAL/blob/main/.clang-format) that you should use on your code. To do this, run:
+Our repository contains [clang-format configurations](https://github.com/uxlfoundation/oneDAL/blob/main/.clang-format) that you should use on your code. To do this, run:
 
 ```
 clang-format style=file <your file>
@@ -67,7 +67,7 @@ Refer to [ClangFormat documentation](https://clang.llvm.org/docs/ClangFormat.htm
 
 ### editorconfig-checker
 
-We also recommend using [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker) to ensure your code adheres to the project's coding style. EditorConfig-Checker is a command-line tool that checks your code against the rules defined in the [.editorconfig](https://github.com/oneapi-src/oneDAL/blob/main/.editorconfig) file.
+We also recommend using [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker) to ensure your code adheres to the project's coding style. EditorConfig-Checker is a command-line tool that checks your code against the rules defined in the [.editorconfig](https://github.com/uxlfoundation/oneDAL/blob/main/.editorconfig) file.
 
 To use it, follow these steps:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ editorconfig-checker
 
 ### Coding Guidelines
 
-For your convenience we also added [coding guidelines](http://uxlfoundation.github.io/oneDAL/contribution/coding_guide.html) with examples and detailed descriptions of the coding style oneDAL follows. We encourage you to consult them when writing your code.
+For your convenience we also added [coding guidelines](https://uxlfoundation.github.io/oneDAL/contribution/coding_guide.html) with examples and detailed descriptions of the coding style oneDAL follows. We encourage you to consult them when writing your code.
 
 ## Custom Components
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ editorconfig-checker
 
 ### Coding Guidelines
 
-For your convenience we also added [coding guidelines](http://oneapi-src.github.io/oneDAL/contribution/coding_guide.html) with examples and detailed descriptions of the coding style oneDAL follows. We encourage you to consult them when writing your code.
+For your convenience we also added [coding guidelines](http://uxlfoundation.github.io/oneDAL/contribution/coding_guide.html) with examples and detailed descriptions of the coding style oneDAL follows. We encourage you to consult them when writing your code.
 
 ## Custom Components
 
@@ -89,15 +89,15 @@ For your convenience we also added [coding guidelines](http://oneapi-src.github.
 
 oneDAL provides binaries that can contain code targeting different architectural extensions of a base instruction set architecture (ISA). For example, code paths can exist for Intel(R) SSE2, Intel(R) AVX2, Intel(R) AVX-512, etc. extensions, on top of the x86-64 base architecture.
 When run on a specific hardware implementation like Haswell, Skylake-X, etc., oneDAL chooses the code path which is most suitable for that implementation.
-Contributors should leverage [CPU Features Dispatching](http://oneapi-src.github.io/oneDAL/contribution/cpu_features.html) mechanism to implement the code of the algorithms that can perform most optimally on various hardware implementations.
+Contributors should leverage [CPU Features Dispatching](http://uxlfoundation.github.io/oneDAL/contribution/cpu_features.html) mechanism to implement the code of the algorithms that can perform most optimally on various hardware implementations.
 
 ### Threading Layer
 
-In the source code of the algorithms, oneDAL does not use threading primitives directly. All the threading primitives used within oneDAL form are called the [threading layer](http://oneapi-src.github.io/oneDAL/contribution/threading.html). Contributors should leverage the primitives from the layer to implement parallel algorithms.
+In the source code of the algorithms, oneDAL does not use threading primitives directly. All the threading primitives used within oneDAL form are called the [threading layer](http://uxlfoundation.github.io/oneDAL/contribution/threading.html). Contributors should leverage the primitives from the layer to implement parallel algorithms.
 
 ## Documentation Guidelines
 
-oneDAL uses `Doxygen` for inline comments in public header files that are used to build the API reference and  `reStructuredText` for the Developer Guide. See [oneDAL documentation](https://oneapi-src.github.io/oneDAL/) for reference.
+oneDAL uses `Doxygen` for inline comments in public header files that are used to build the API reference and  `reStructuredText` for the Developer Guide. See [oneDAL documentation](https://uxlfoundation.github.io/oneDAL/) for reference.
 
 ---
 **Note:** oneDAL is licensed under [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0). By contributing to the project, you agree to the license and copyright terms therein and release your contribution under these terms.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -164,7 +164,7 @@ On **Linux\*** it is possible to build debug version of oneDAL or the version th
 
 ---
 
-After having built the library, if one wishes to use it for building [scikit-learn-intelex](https://github.com/intel/scikit-learn-intelex/tree/main) or for executing the usage examples, one can set the required environment variables to point to the generated build by sourcing the script that it creates under the `env` folder. The script will be located under `__release_{os_name}[_{compiler_name}]/daal/latest/env/vars.sh` and can be sourced with a POSIX-compliant shell such as `bash`, by executing something like the following from inside the `__release*` folder:
+After having built the library, if one wishes to use it for building [scikit-learn-intelex](https://github.com/uxlfoundation/scikit-learn-intelex/tree/main) or for executing the usage examples, one can set the required environment variables to point to the generated build by sourcing the script that it creates under the `env` folder. The script will be located under `__release_{os_name}[_{compiler_name}]/daal/latest/env/vars.sh` and can be sourced with a POSIX-compliant shell such as `bash`, by executing something like the following from inside the `__release*` folder:
 
 ```shell
 cd daal/latest

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,13 +37,13 @@ https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html
 
 ## Docker Development Environment
 
-[Docker file](https://github.com/oneapi-src/oneDAL/tree/main/dev/docker) with the oneDAL development environment
+[Docker file](https://github.com/uxlfoundation/oneDAL/tree/main/dev/docker) with the oneDAL development environment
 is available as an alternative to the manual setup.
 
 ## Installation Steps
 1. Clone the sources from GitHub\* as follows:
 
-        git clone https://github.com/oneapi-src/oneDAL.git
+        git clone https://github.com/uxlfoundation/oneDAL.git
 
 2. Set the PATH environment variable to the MSYS2\* bin directory (Windows\* only). For example:
 
@@ -171,7 +171,7 @@ cd daal/latest
 source env/vars.sh
 ```
 
-The provided unit tests for the library can be executed through the Bazel system - see the [Bazel docs](https://github.com/oneapi-src/oneDAL/tree/main/dev/bazel) for more information.
+The provided unit tests for the library can be executed through the Bazel system - see the [Bazel docs](https://github.com/uxlfoundation/oneDAL/tree/main/dev/bazel) for more information.
 
 Examples of library usage will also be auto-generated as part of the build under path `daal/latest/examples/daal/cpp/source`. These can be built through CMake - assuming one starts from the release path `__release_{os_name}[_{compiler_name}]`, the following would do:
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -124,7 +124,7 @@ opening a PR against MAINTAINERS.md file.
 
 ## oneDAL core
 
-Team: @oneapi-src/onedal-write
+Team: @uxlfoundation/onedal-write
 
 Currently entire Intel oneDAL team serves at contributor level and have corresponding rights
 with additional separation of roles coming with repository migration to UXL

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ oneDAL documentation:
 
 - [Release Notes](https://github.com/uxlfoundation/oneDAL/releases)
 - [Get Started Guide](https://uxlfoundation.github.io/oneDAL/quick-start.html)
-- [Developer Guide and Reference](http://uxlfoundation.github.io/oneDAL/)
+- [Developer Guide and Reference](https://uxlfoundation.github.io/oneDAL/)
 
 Other related documentation:
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The oneDAL is part of the [UXL Foundation](http://www.uxlfoundation.org) and is 
 There are different ways for you to build high-performance data science applications that use the advantages of oneDAL:
 - Use oneDAL C++ interfaces with or without SYCL support ([learn more](https://oneapi-src.github.io/oneDAL/#oneapi-vs-daal-interfaces))
 - Use [Intel(R) Extension for Scikit-learn*](https://uxlfoundation.github.io/scikit-learn-intelex/) to accelerate existing scikit-learn code without changing it
-- Use [daal4py](https://github.com/intel/scikit-learn-intelex/tree/main/daal4py), a standalone package with Python API for oneDAL
+- Use [daal4py](https://github.com/uxlfoundation/scikit-learn-intelex/tree/main/daal4py), a standalone package with Python API for oneDAL
 Deprecation Notice: The Java interfaces are removed from the oneDAL library.
 
 
@@ -70,8 +70,8 @@ C++ Examples:
 - [DAAL interfaces](https://github.com/oneapi-src/oneDAL/tree/main/examples/daal/cpp)
 
 Python Examples:
-- [scikit-learn-intelex](https://github.com/intel/scikit-learn-intelex/tree/main/examples/notebooks)
-- [daal4py](https://github.com/intel/scikit-learn-intelex/tree/main/examples/daal4py)
+- [scikit-learn-intelex](https://github.com/uxlfoundation/scikit-learn-intelex/tree/main/examples/notebooks)
+- [daal4py](https://github.com/uxlfoundation/scikit-learn-intelex/tree/main/examples/daal4py)
 
 <details><summary>Other Examples</summary>
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 
 [Installation](#installation)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Documentation](#documentation)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Support](#support)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Examples](#examples)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[How to Contribute](CONTRIBUTING.md)&nbsp;&nbsp;&nbsp;
 
-[![Build Status](https://dev.azure.com/daal/DAAL/_apis/build/status/oneapi-src.oneDAL?branchName=main)](https://dev.azure.com/daal/DAAL/_build/latest?definitionId=5&branchName=main)
-[![License](https://img.shields.io/github/license/oneapi-src/oneDAL.svg)](https://github.com/uxlfoundation/oneDAL/blob/main/LICENSE)
+[![Build Status](https://dev.azure.com/daal/DAAL/_apis/build/status/uxlfoundation.oneDAL?branchName=main)](https://dev.azure.com/daal/DAAL/_build/latest?definitionId=5&branchName=main)
+[![License](https://img.shields.io/github/license/uxlfoundation/oneDAL.svg)](https://github.com/uxlfoundation/oneDAL/blob/main/LICENSE)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8859/badge)](https://www.bestpractices.dev/projects/8859)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/uxlfoundation/oneDAL/badge)](https://securityscorecards.dev/viewer/?uri=github.com/uxlfoundation/oneDAL)
 [![Join the community on GitHub Discussions](https://badgen.net/badge/join%20the%20discussion/on%20github/black?icon=github)](https://github.com/uxlfoundation/oneDAL/discussions)

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@
 [Installation](#installation)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Documentation](#documentation)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Support](#support)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[Examples](#examples)&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;[How to Contribute](CONTRIBUTING.md)&nbsp;&nbsp;&nbsp;
 
 [![Build Status](https://dev.azure.com/daal/DAAL/_apis/build/status/oneapi-src.oneDAL?branchName=main)](https://dev.azure.com/daal/DAAL/_build/latest?definitionId=5&branchName=main)
-[![License](https://img.shields.io/github/license/oneapi-src/oneDAL.svg)](https://github.com/oneapi-src/oneDAL/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/oneapi-src/oneDAL.svg)](https://github.com/uxlfoundation/oneDAL/blob/main/LICENSE)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8859/badge)](https://www.bestpractices.dev/projects/8859)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/oneapi-src/oneDAL/badge)](https://securityscorecards.dev/viewer/?uri=github.com/oneapi-src/oneDAL)
-[![Join the community on GitHub Discussions](https://badgen.net/badge/join%20the%20discussion/on%20github/black?icon=github)](https://github.com/oneapi-src/oneDAL/discussions)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/uxlfoundation/oneDAL/badge)](https://securityscorecards.dev/viewer/?uri=github.com/uxlfoundation/oneDAL)
+[![Join the community on GitHub Discussions](https://badgen.net/badge/join%20the%20discussion/on%20github/black?icon=github)](https://github.com/uxlfoundation/oneDAL/discussions)
 
 oneAPI Data Analytics Library (oneDAL) is a powerful machine learning library that helps you accelerate big data analysis at all stages: **preprocessing**, **transformation**, **analysis**, **modeling**, **validation**, and **decision making**.
 
@@ -58,16 +58,16 @@ There are several options available for installing oneDAL:
 
     - [NuGet](https://www.nuget.org/packages/inteldal.devel.linux-x64)
 
-- **Source Distribution**: You can build the library from source. To do this, [download the specific version of oneDAL](https://github.com/oneapi-src/oneDAL/releases) from the official GitHub repository and follow the instructions in the [INSTALL.md](INSTALL.md).
+- **Source Distribution**: You can build the library from source. To do this, [download the specific version of oneDAL](https://github.com/uxlfoundation/oneDAL/releases) from the official GitHub repository and follow the instructions in the [INSTALL.md](INSTALL.md).
 
 
 ## Examples
 
 C++ Examples:
 
-- [oneAPI interfaces with SYCL support](https://github.com/oneapi-src/oneDAL/tree/main/examples/oneapi/dpc)
-- [oneAPI interfaces without SYCL support](https://github.com/oneapi-src/oneDAL/tree/main/examples/oneapi/cpp)
-- [DAAL interfaces](https://github.com/oneapi-src/oneDAL/tree/main/examples/daal/cpp)
+- [oneAPI interfaces with SYCL support](https://github.com/uxlfoundation/oneDAL/tree/main/examples/oneapi/dpc)
+- [oneAPI interfaces without SYCL support](https://github.com/uxlfoundation/oneDAL/tree/main/examples/oneapi/cpp)
+- [DAAL interfaces](https://github.com/uxlfoundation/oneDAL/tree/main/examples/daal/cpp)
 
 Python Examples:
 - [scikit-learn-intelex](https://github.com/uxlfoundation/scikit-learn-intelex/tree/main/examples/notebooks)
@@ -75,8 +75,8 @@ Python Examples:
 
 <details><summary>Other Examples</summary>
 
-- [MPI](https://github.com/oneapi-src/oneDAL/tree/main/samples/daal/cpp/mpi)
-- [MySQL](https://github.com/oneapi-src/oneDAL/tree/main/samples/daal/cpp/mysql)
+- [MPI](https://github.com/uxlfoundation/oneDAL/tree/main/samples/daal/cpp/mpi)
+- [MySQL](https://github.com/uxlfoundation/oneDAL/tree/main/samples/daal/cpp/mysql)
 
 </details>
 
@@ -84,7 +84,7 @@ Python Examples:
 
 oneDAL documentation:
 
-- [Release Notes](https://github.com/oneapi-src/oneDAL/releases)
+- [Release Notes](https://github.com/uxlfoundation/oneDAL/releases)
 - [Get Started Guide](https://oneapi-src.github.io/oneDAL/quick-start.html)
 - [Developer Guide and Reference](http://oneapi-src.github.io/oneDAL/)
 
@@ -125,7 +125,7 @@ You can contribute to this project and also contribute to the specification for 
 
 Ask questions and engage in discussions with oneDAL developers, contributers, and other users through the following channels:
 
-- [GitHub Discussions](https://github.com/oneapi-src/oneDAL/discussions)
+- [GitHub Discussions](https://github.com/uxlfoundation/oneDAL/discussions)
 - [Community Forum](https://community.intel.com/t5/Intel-oneAPI-Data-Analytics/bd-p/oneapi-data-analytics-library)
 
 You may reach out to project maintainers privately at onedal.maintainers@intel.com.
@@ -146,6 +146,6 @@ We welcome community contributions. Check our [contributing guidelines](CONTRIBU
 
 oneDAL is distributed under the Apache License 2.0 license. See [LICENSE](LICENSE) for more information.
 
-[oneMKL FPK microlibs](https://github.com/oneapi-src/oneDAL/releases/tag/Dependencies)
+[oneMKL FPK microlibs](https://github.com/uxlfoundation/oneDAL/releases/tag/Dependencies)
 are distributed under Intel Simplified Software License.
 Refer to [third-party-programs-mkl.txt](third-party-programs-mkl.txt) for details.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The oneDAL is part of the [UXL Foundation](http://www.uxlfoundation.org) and is 
 ## Usage
 
 There are different ways for you to build high-performance data science applications that use the advantages of oneDAL:
-- Use oneDAL C++ interfaces with or without SYCL support ([learn more](https://oneapi-src.github.io/oneDAL/#oneapi-vs-daal-interfaces))
+- Use oneDAL C++ interfaces with or without SYCL support ([learn more](https://uxlfoundation.github.io/oneDAL/#oneapi-vs-daal-interfaces))
 - Use [Intel(R) Extension for Scikit-learn*](https://uxlfoundation.github.io/scikit-learn-intelex/) to accelerate existing scikit-learn code without changing it
 - Use [daal4py](https://github.com/uxlfoundation/scikit-learn-intelex/tree/main/daal4py), a standalone package with Python API for oneDAL
 Deprecation Notice: The Java interfaces are removed from the oneDAL library.
@@ -42,7 +42,7 @@ Deprecation Notice: The Java interfaces are removed from the oneDAL library.
 
 ## Installation
 
-Check the [System Requirements](https://oneapi-src.github.io/oneDAL/system-requirements.html) before installing to ensure compatibility with your system.
+Check the [System Requirements](https://uxlfoundation.github.io/oneDAL/system-requirements.html) before installing to ensure compatibility with your system.
 
 There are several options available for installing oneDAL:
 
@@ -85,8 +85,8 @@ Python Examples:
 oneDAL documentation:
 
 - [Release Notes](https://github.com/uxlfoundation/oneDAL/releases)
-- [Get Started Guide](https://oneapi-src.github.io/oneDAL/quick-start.html)
-- [Developer Guide and Reference](http://oneapi-src.github.io/oneDAL/)
+- [Get Started Guide](https://uxlfoundation.github.io/oneDAL/quick-start.html)
+- [Developer Guide and Reference](http://uxlfoundation.github.io/oneDAL/)
 
 Other related documentation:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The oneDAL is part of the [UXL Foundation](http://www.uxlfoundation.org) and is 
 
 There are different ways for you to build high-performance data science applications that use the advantages of oneDAL:
 - Use oneDAL C++ interfaces with or without SYCL support ([learn more](https://oneapi-src.github.io/oneDAL/#oneapi-vs-daal-interfaces))
-- Use [Intel(R) Extension for Scikit-learn*](https://intel.github.io/scikit-learn-intelex/) to accelerate existing scikit-learn code without changing it
+- Use [Intel(R) Extension for Scikit-learn*](https://uxlfoundation.github.io/scikit-learn-intelex/) to accelerate existing scikit-learn code without changing it
 - Use [daal4py](https://github.com/intel/scikit-learn-intelex/tree/main/daal4py), a standalone package with Python API for oneDAL
 Deprecation Notice: The Java interfaces are removed from the oneDAL library.
 
@@ -91,7 +91,7 @@ oneDAL documentation:
 Other related documentation:
 
 - [daal4py documentation](https://intelpython.github.io/daal4py/)
-- [Intel(R) Extension for Scikit-learn* documentation](https://intel.github.io/scikit-learn-intelex/)
+- [Intel(R) Extension for Scikit-learn* documentation](https://uxlfoundation.github.io/scikit-learn-intelex/)
 - [oneDAL Specifications](https://spec.oneapi.com/versions/latest/elements/oneDAL/source/index.html)
 
 ## Apache Spark MLlib

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -88,6 +88,6 @@ If you have any suggestions on how this Policy could be improved, submit
 an issue or a pull request to this repository. **Do not** report
 potential vulnerabilities or security flaws via a pull request.
 
-[1]: https://github.com/oneapi-src/oneDAL/releases
-[2]: https://github.com/oneapi-src/oneDAL/security/advisories/new
-[3]: https://github.com/oneapi-src/oneDAL/security/advisories
+[1]: https://github.com/uxlfoundation/oneDAL/releases
+[2]: https://github.com/uxlfoundation/oneDAL/security/advisories/new
+[3]: https://github.com/uxlfoundation/oneDAL/security/advisories

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
@@ -163,7 +163,7 @@ Status KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
     auto oldThreads = services::Environment::getInstance()->getNumberOfThreads();
     DAAL_CHECK_STATUS(status, buildFirstPartOfKDTree(q, bboxQ, *x, *r, indexes, engine));
     // Temporary workaround for threading issues in `buildSecondPartOfKDTree()`
-    // Fix to be provided in https://github.com/oneapi-src/oneDAL/pull/2925
+    // Fix to be provided in https://github.com/uxlfoundation/oneDAL/pull/2925
     services::Environment::getInstance()->setNumberOfThreads(1);
     DAAL_CHECK_STATUS(status, buildSecondPartOfKDTree(q, bboxQ, *x, *r, indexes, engine));
     services::Environment::getInstance()->setNumberOfThreads(oldThreads);

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -273,7 +273,7 @@ inline void threader_for_int64(int64_t n, const F & func)
 /// This means the threading layer tries to assign consecutive iterations to
 /// different threads, if possible.
 /// In case of oneTBB threading backend this means that `simple_partitioner`
-/// (https://oneapi-src.github.io/oneTBB/main/tbb_userguide/Partitioner_Summary.html)
+/// (https://uxlfoundation.github.io/oneTBB/main/tbb_userguide/Partitioner_Summary.html)
 /// with chunk size 1 is used to produce iteration to threads mappings.
 ///
 /// Data dependencies between the iterations are allowed, but may requre the use

--- a/deploy/nuget/inteldal.nuspec.tpl
+++ b/deploy/nuget/inteldal.nuspec.tpl
@@ -7,7 +7,7 @@
     <owners>Intel Corporation</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="file">LICENSE</license>
-    <projectUrl>https://github.com/oneapi-src/oneDAL</projectUrl>
+    <projectUrl>https://github.com/uxlfoundation/oneDAL</projectUrl>
     <iconUrl>https://software.intel.com/sites/products/vtune/assets/brand-intel-transparent-64x64.png</iconUrl>
     <description>Intel(R) oneAPI Data Analytics Library helps speed up big data analysis by providing highly optimized algorithmic building blocks for all stages of data analytics (preprocessing, transformation, analysis, modeling, validation, and decision making) in batch, online, and distributed processing modes of computation.</description>
     <summary>Package includes __PLATFORM__ __CONTENT__</summary>

--- a/dev/download_tbb.sh
+++ b/dev/download_tbb.sh
@@ -17,7 +17,7 @@
 #===============================================================================
 
 TBB_VERSION="2021.10.0"
-TBB_URL_ROOT="https://github.com/oneapi-src/oneTBB/releases/download/v${TBB_VERSION}"
+TBB_URL_ROOT="https://github.com/uxlfoundation/oneTBB/releases/download/v${TBB_VERSION}"
 
 os=$(uname)
 if [ "${os}" = "Linux" ]; then

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ To build oneDAL documentation locally:
 
 1. Clone the repository:
 
-		git clone https://github.com/oneapi-src/oneDAL.git
+		git clone https://github.com/uxlfoundation/oneDAL.git
 
 2. Go to `docs` folder:
 

--- a/docs/source/404.rst
+++ b/docs/source/404.rst
@@ -24,5 +24,5 @@ Unfortunately, we could not find the page you were looking for. Try:
 
 - using :ref:`search <search>` to browse documentation
 - checking the table of contents on the left
-- filing an `issue <https://github.com/oneapi-src/oneDAL/issues>`_ or
-  starting a `discussion <https://github.com/oneapi-src/oneDAL/discussions>`_ on GitHub
+- filing an `issue <https://github.com/uxlfoundation/oneDAL/issues>`_ or
+  starting a `discussion <https://github.com/uxlfoundation/oneDAL/discussions>`_ on GitHub

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,10 +81,10 @@ exclude_patterns = ["opt-notice.rst", 'daal/data-management/numeric-tables/*.rst
                     'daal/includes/*', 'onedal/algorithms/.*/includes/*', 'index-toc.rst']
 
 extlinks = {
-    'cpp_example': ('https://github.com/oneapi-src/oneDAL/tree/main/examples/daal/cpp/source/%s', None),
+    'cpp_example': ('https://github.com/uxlfoundation/oneDAL/tree/main/examples/daal/cpp/source/%s', None),
     'daal4py_example': ('https://github.com/uxlfoundation/scikit-learn-intelex/tree/main/examples/daal4py/%s', None),
     'daal4py_sklearnex_example': ('https://github.com/uxlfoundation/scikit-learn-intelex/tree/main/examples/sklearnex/%s', None),
-    'cpp_sample': ('https://github.com/oneapi-src/oneDAL/tree/main/samples/daal/cpp/%s', None)
+    'cpp_sample': ('https://github.com/uxlfoundation/oneDAL/tree/main/samples/daal/cpp/%s', None)
 }
 
 # -- Options for HTML output -------------------------------------------------
@@ -101,7 +101,7 @@ html_favicon = '_static/favicons.png'
 
 # Theme options
 html_theme_options = {
-    'repository_url': 'https://github.com/oneapi-src/oneDAL',
+    'repository_url': 'https://github.com/uxlfoundation/oneDAL',
     'path_to_docs': 'docs/source',
     'use_issues_button': True,
     'use_edit_page_button': True,
@@ -115,7 +115,7 @@ html_theme_options = {
 }
 
 html_theme_options = {
-    "extra_footer": "<div><a href='https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html' data-cookie-notice='true'>Cookies</a> <a href='https://www.intel.com/content/www/us/en/privacy/intel-privacy-notice.html'>| Privacy</a> <a data-wap_ref='dns' id='wap_dns' href='https://www.intel.com/content/www/us/en/privacy/intel-cookie- notice.html'>| Do Not Share My Personal Information</a> </div><div>&copy; Intel Corporation. Intel, the Intel logo, and other Intel marks are trademarks of Intel Corporation or its subsidiaries. Other names and brands may be claimed as the property of others. No license (express or implied, by estoppel or otherwise) to any intellectual property rights is granted by this document, with the sole exception that code included in this document is licensed subject to the Zero-Clause BSD open source license (OBSD), <a href='http://opensource.org/licenses/0BSD'>http://opensource.org/licenses/0BSD</a>. </div><br><div>oneDAL is licensed under Apache License Version 2.0. Refer to the <a href='https://github.com/oneapi-src/oneDAL/blob/main/LICENSE'>LICENSE </a> file for the full license text and copyright notice.</div>"
+    "extra_footer": "<div><a href='https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html' data-cookie-notice='true'>Cookies</a> <a href='https://www.intel.com/content/www/us/en/privacy/intel-privacy-notice.html'>| Privacy</a> <a data-wap_ref='dns' id='wap_dns' href='https://www.intel.com/content/www/us/en/privacy/intel-cookie- notice.html'>| Do Not Share My Personal Information</a> </div><div>&copy; Intel Corporation. Intel, the Intel logo, and other Intel marks are trademarks of Intel Corporation or its subsidiaries. Other names and brands may be claimed as the property of others. No license (express or implied, by estoppel or otherwise) to any intellectual property rights is granted by this document, with the sole exception that code included in this document is licensed subject to the Zero-Clause BSD open source license (OBSD), <a href='http://opensource.org/licenses/0BSD'>http://opensource.org/licenses/0BSD</a>. </div><br><div>oneDAL is licensed under Apache License Version 2.0. Refer to the <a href='https://github.com/uxlfoundation/oneDAL/blob/main/LICENSE'>LICENSE </a> file for the full license text and copyright notice.</div>"
 }
 
 # oneDAL project directory is needed for `dalapi` extension

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -82,8 +82,8 @@ exclude_patterns = ["opt-notice.rst", 'daal/data-management/numeric-tables/*.rst
 
 extlinks = {
     'cpp_example': ('https://github.com/oneapi-src/oneDAL/tree/main/examples/daal/cpp/source/%s', None),
-    'daal4py_example': ('https://github.com/intel/scikit-learn-intelex/tree/main/examples/daal4py/%s', None),
-    'daal4py_sklearnex_example': ('https://github.com/intel/scikit-learn-intelex/tree/main/examples/sklearnex/%s', None),
+    'daal4py_example': ('https://github.com/uxlfoundation/scikit-learn-intelex/tree/main/examples/daal4py/%s', None),
+    'daal4py_sklearnex_example': ('https://github.com/uxlfoundation/scikit-learn-intelex/tree/main/examples/sklearnex/%s', None),
     'cpp_sample': ('https://github.com/oneapi-src/oneDAL/tree/main/samples/daal/cpp/%s', None)
 }
 

--- a/docs/source/contribution/coding_guide.rst
+++ b/docs/source/contribution/coding_guide.rst
@@ -25,7 +25,7 @@ Any developer should be able to quickly understand the code written by another d
 By ensuring **consistency** in the code base you save time and effort for both yourself and others.
 
 These guidelines cover our coding style along with more practical issues.
-To learn more about contribution process, see `How to Contribute <https://github.com/oneapi-src/oneDAL/blob/main/CONTRIBUTING.md>`_.
+To learn more about contribution process, see `How to Contribute <https://github.com/uxlfoundation/oneDAL/blob/main/CONTRIBUTING.md>`_.
 
 Coding Style
 ============
@@ -1436,7 +1436,7 @@ Below we discuss conversion between integer types in different cases:
 
 .. note:: Conversion of floating point data types is not a security problem.
 
-.. important:: It is required to add error code into `error_handling.cpp <https://github.com/oneapi-src/oneDAL/blob/main/cpp/daal/src/services/error_handling.cpp>`_.
+.. important:: It is required to add error code into `error_handling.cpp <https://github.com/uxlfoundation/oneDAL/blob/main/cpp/daal/src/services/error_handling.cpp>`_.
 
 Code is performance-oriented
 ++++++++++++++++++++++++++++

--- a/docs/source/contribution/cpu_features.rst
+++ b/docs/source/contribution/cpu_features.rst
@@ -51,8 +51,8 @@ Computational Tasks
 
 An algorithm might have various tasks to compute. The most common options are:
 
-- `Classification <https://oneapi-src.github.io/oneDAL/onedal/glossary.html#term-Classification>`_,
-- `Regression <https://oneapi-src.github.io/oneDAL/onedal/glossary.html#term-Regression>`_.
+- `Classification <https://uxlfoundation.github.io/oneDAL/onedal/glossary.html#term-Classification>`_,
+- `Regression <https://uxlfoundation.github.io/oneDAL/onedal/glossary.html#term-Regression>`_.
 
 Computational Stages
 --------------------
@@ -65,15 +65,15 @@ Computational Methods
 
 An algorithm can support several methods for the same type of computations.
 For example, kNN algorithm supports
-`brute_force <https://oneapi-src.github.io/oneDAL/onedal/algorithms/nearest-neighbors/knn.html#knn-t-math-brute-force>`_
-and `kd_tree <https://oneapi-src.github.io/oneDAL/onedal/algorithms/nearest-neighbors/knn.html#knn-t-math-kd-tree>`_
+`brute_force <https://uxlfoundation.github.io/oneDAL/onedal/algorithms/nearest-neighbors/knn.html#knn-t-math-brute-force>`_
+and `kd_tree <https://uxlfoundation.github.io/oneDAL/onedal/algorithms/nearest-neighbors/knn.html#knn-t-math-kd-tree>`_
 methods for algorithm training and inference.
 
 Computational Modes
 -------------------
 
 |short_name| can provide several computational modes for an algorithm.
-See `Computational Modes <https://oneapi-src.github.io/oneDAL/onedal/programming-model/computational-modes.html>`_
+See `Computational Modes <https://uxlfoundation.github.io/oneDAL/onedal/programming-model/computational-modes.html>`_
 chapter for details.
 
 Folders and Files

--- a/docs/source/contribution/cpu_features.rst
+++ b/docs/source/contribution/cpu_features.rst
@@ -15,11 +15,11 @@
 .. *******************************************************************************/
 
 .. |32e_make| replace:: 32e.mk
-.. _32e_make: https://github.com/oneapi-src/oneDAL/blob/main/dev/make/function_definitions/32e.mk
+.. _32e_make: https://github.com/uxlfoundation/oneDAL/blob/main/dev/make/function_definitions/32e.mk
 .. |riscv_make| replace:: riscv64.mk
-.. _riscv_make: https://github.com/oneapi-src/oneDAL/blob/main/dev/make/function_definitions/riscv64.mk
+.. _riscv_make: https://github.com/uxlfoundation/oneDAL/blob/main/dev/make/function_definitions/riscv64.mk
 .. |arm_make| replace:: arm.mk
-.. _arm_make: https://github.com/oneapi-src/oneDAL/blob/main/dev/make/function_definitions/arm.mk
+.. _arm_make: https://github.com/uxlfoundation/oneDAL/blob/main/dev/make/function_definitions/arm.mk
 
 .. highlight:: cpp
 
@@ -183,7 +183,7 @@ instruction set specific code. The implementation is located in the file `abc_cl
 Although the implementation of the ``method1`` does not contain any instruction set specific code, it is
 expected that the developers leverage SIMD related macros available in |short_name|.
 For example, ``PRAGMA_IVDEP``, ``PRAGMA_VECTOR_ALWAYS``, ``PRAGMA_VECTOR_ALIGNED`` and other pragmas defined in
-`service_defines.h <https://github.com/oneapi-src/oneDAL/blob/main/cpp/daal/src/services/service_defines.h>`_.
+`service_defines.h <https://github.com/uxlfoundation/oneDAL/blob/main/cpp/daal/src/services/service_defines.h>`_.
 This will guide the compiler to generate more efficient code for the target architecture.
 
 Consider that the implementation of the ``method2`` for the same algorithm will be different and will contain
@@ -264,9 +264,9 @@ To add a new architectural extension into |32e_make| file, ``CPUs`` and ``CPUs.f
 The functions like ``set_uarch_options_for_compiler`` and others should also be updated accordingly.
 
 The compiler options for the new architectural extension should be added to the respective file in the
-`compiler_definitions <https://github.com/oneapi-src/oneDAL/tree/main/dev/make/compiler_definitions>`_ folder.
+`compiler_definitions <https://github.com/uxlfoundation/oneDAL/tree/main/dev/make/compiler_definitions>`_ folder.
 
-For example, `gnu.32e.mk <https://github.com/oneapi-src/oneDAL/blob/main/dev/make/compiler_definitions/gnu.32e.mk>`_
+For example, `gnu.32e.mk <https://github.com/uxlfoundation/oneDAL/blob/main/dev/make/compiler_definitions/gnu.32e.mk>`_
 file contains the compiler options for the GNU compiler for x86-64 architecture in the form
 ``option_name.compiler_name``:
 
@@ -281,16 +281,16 @@ Bazel
 -----
 
 For now, Bazel build is supported only for Linux x86-64 platform
-It provides ``cpu`` `option <https://github.com/oneapi-src/oneDAL/tree/main/dev/bazel#bazel-options>`_
+It provides ``cpu`` `option <https://github.com/uxlfoundation/oneDAL/tree/main/dev/bazel#bazel-options>`_
 that allows to specify the list of target architectural extensions.
 
 To add a new architectural extension into Bazel configuration, following steps should be done:
 
 - Add the new extension to the list of allowed values in the ``_ISA_EXTENSIONS`` variable in the
-  `config.bzl <https://github.com/oneapi-src/oneDAL/blob/main/dev/bazel/config/config.bzl>`_ file;
+  `config.bzl <https://github.com/uxlfoundation/oneDAL/blob/main/dev/bazel/config/config.bzl>`_ file;
 - Update the ``get_cpu_flags`` function in the
-  `flags.bzl <https://github.com/oneapi-src/oneDAL/blob/main/dev/bazel/flags.bzl>`_
+  `flags.bzl <https://github.com/uxlfoundation/oneDAL/blob/main/dev/bazel/flags.bzl>`_
   file to provide the compiler flags for the new extension;
 - Update the ``cpu_defines`` dictionaries in
-  `dal.bzl <https://github.com/oneapi-src/oneDAL/blob/main/dev/bazel/dal.bzl>`_ and
-  `daal.bzl <https://github.com/oneapi-src/oneDAL/blob/main/dev/bazel/daal.bzl>`_ files accordingly.
+  `dal.bzl <https://github.com/uxlfoundation/oneDAL/blob/main/dev/bazel/dal.bzl>`_ and
+  `daal.bzl <https://github.com/uxlfoundation/oneDAL/blob/main/dev/bazel/daal.bzl>`_ files accordingly.

--- a/docs/source/contribution/threading.rst
+++ b/docs/source/contribution/threading.rst
@@ -28,7 +28,7 @@ This is done in order not to be dependent on possible oneTBB API changes and eve
 on the particular threading technology like oneTBB, C++11 standard threads, etc.
 
 The API of the layer is defined in
-`threading.h <https://github.com/oneapi-src/oneDAL/blob/main/cpp/daal/src/threading/threading.h>`_.
+`threading.h <https://github.com/uxlfoundation/oneDAL/blob/main/cpp/daal/src/threading/threading.h>`_.
 Please be aware that the threading API is not a part of |short_name| product API.
 This is the product internal API that aimed to be used only by |short_name| developers, and can be changed at any time
 without any prior notification.

--- a/docs/source/contribution/threading.rst
+++ b/docs/source/contribution/threading.rst
@@ -112,7 +112,7 @@ Static Work Scheduling
 **********************
 
 By default, oneTBB uses
-`dynamic work scheduling <https://oneapi-src.github.io/oneTBB/main/tbb_userguide/How_Task_Scheduler_Works.html>`_
+`dynamic work scheduling <https://uxlfoundation.github.io/oneTBB/main/tbb_userguide/How_Task_Scheduler_Works.html>`_
 and work stealing.
 It means that two different runs of the same parallel loop can produce different
 mappings of the loop's iteration space to the available threads.

--- a/docs/source/daal-interfaces.rst
+++ b/docs/source/daal-interfaces.rst
@@ -39,4 +39,4 @@ Examples
 You can find examples on Github*:
 
 - `C++ <https://github.com/oneapi-src/oneDAL/tree/main/examples/daal/cpp/source>`_ (CPU)
-- `Python* <https://github.com/intel/scikit-learn-intelex/tree/main/examples/daal4py>`_
+- `Python* <https://github.com/uxlfoundation/scikit-learn-intelex/tree/main/examples/daal4py>`_

--- a/docs/source/daal-interfaces.rst
+++ b/docs/source/daal-interfaces.rst
@@ -19,7 +19,7 @@
 DAAL Interfaces
 ===============
 
-This chapter documents algorithms implemented in `DAAL interfaces <https://github.com/oneapi-src/oneDAL/tree/main/cpp/daal>`_.
+This chapter documents algorithms implemented in `DAAL interfaces <https://github.com/uxlfoundation/oneDAL/tree/main/cpp/daal>`_.
 See :ref:`oneapi_dal_guide` to find documentation on oneAPI interfaces.
 Refer to :ref:`oneapi_vs_daal` to learn the difference between them.
 
@@ -38,5 +38,5 @@ Examples
 
 You can find examples on Github*:
 
-- `C++ <https://github.com/oneapi-src/oneDAL/tree/main/examples/daal/cpp/source>`_ (CPU)
+- `C++ <https://github.com/uxlfoundation/oneDAL/tree/main/examples/daal/cpp/source>`_ (CPU)
 - `Python* <https://github.com/uxlfoundation/scikit-learn-intelex/tree/main/examples/daal4py>`_

--- a/docs/source/daal/algorithms/logistic_regression/logistic-regression.rst
+++ b/docs/source/daal/algorithms/logistic_regression/logistic-regression.rst
@@ -120,7 +120,7 @@ Examples
 
   .. tab:: Python*
 
-    - :daal4py_example:`log_reg_model_builder.py <https://github.com/intel/scikit-learn-intelex/blob/main/examples/mb/log_reg_model_builder.py>`
+    - :daal4py_example:`log_reg_model_builder.py <https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/examples/mb/log_reg_model_builder.py>`
 
 Batch Processing
 ****************

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -26,4 +26,4 @@ oneAPI Examples
    DPC++ <examples/dpc.rst>
    C++ <examples/cpp.rst>
 
-.. note:: Explore the complete list of oneAPI code samples in the `oneAPI Samples Catalog <https://oneapi-src.github.io/oneAPI-samples/>`_. These samples were designed to help you develop, offload, and optimize multiarchitecture applications targeting CPUs, GPUs, and FPGAs. 
+.. note:: Explore the complete list of oneAPI code samples in the `oneAPI Samples Catalog <https://uxlfoundation.github.io/oneAPI-samples/>`_. These samples were designed to help you develop, offload, and optimize multiarchitecture applications targeting CPUs, GPUs, and FPGAs. 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -26,4 +26,4 @@ oneAPI Examples
    DPC++ <examples/dpc.rst>
    C++ <examples/cpp.rst>
 
-.. note:: Explore the complete list of oneAPI code samples in the `oneAPI Samples Catalog <https://uxlfoundation.github.io/oneAPI-samples/>`_. These samples were designed to help you develop, offload, and optimize multiarchitecture applications targeting CPUs, GPUs, and FPGAs. 
+.. note:: Explore the complete list of oneAPI code samples in the `oneAPI Samples Catalog <https://oneapi-src.github.io/oneAPI-samples/>`_. These samples were designed to help you develop, offload, and optimize multiarchitecture applications targeting CPUs, GPUs, and FPGAs. 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -16,10 +16,10 @@
 
 
 .. |github_rls| replace:: Download a binary file with the specific version of |short_name|
-.. _github_rls: https://github.com/oneapi-src/oneDAL/releases
+.. _github_rls: https://github.com/uxlfoundation/oneDAL/releases
 
 .. |install_sources| replace:: Install |short_name| from sources
-.. _install_sources: https://github.com/oneapi-src/oneDAL/blob/main/INSTALL.md
+.. _install_sources: https://github.com/uxlfoundation/oneDAL/blob/main/INSTALL.md
 
 Installation
 ============

--- a/docs/source/substitutions_specific.txt
+++ b/docs/source/substitutions_specific.txt
@@ -1,3 +1,3 @@
 .. |full_name| replace:: oneAPI Data Analytics Library
 .. |onedal-landing| replace:: |short_name| GitHub\* repository
-.. _onedal-landing: https://github.com/oneapi-src/oneDAL
+.. _onedal-landing: https://github.com/uxlfoundation/oneDAL


### PR DESCRIPTION
## Description

Similar to https://github.com/uxlfoundation/scikit-learn-intelex/pull/2203

After this repository got transferred to uxlfoundation, the doc links for github do not work anymore as they do not redirect to the new URL.

This PR changes all the instances of string "intel.github.io" to "uxlfoundation.github.io" which should be the new URL for these docs.

It also modifies internal links to files within the repository to point to `uxlfoundation/scikit-learn-intelex` instead.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
