### PR TITLE
DOC: Clear warnings from roxygen build

### DIFF
--- a/cpp/oneapi/dal/algo/jaccard/common.hpp
+++ b/cpp/oneapi/dal/algo/jaccard/common.hpp
@@ -148,7 +148,6 @@ struct ONEDAL_EXPORT caching_builder {
     /// Returns the pointer to the allocated memory of size block_max_size.
     ///
     /// @param [in]   block_max_size  The required size of memory
-    /// @param [in/out]  builder  The caching builder
     void* operator()(std::int64_t block_max_size);
 
     std::shared_ptr<byte_t> result_ptr;

--- a/cpp/oneapi/dal/algo/jaccard/vertex_similarity_types.hpp
+++ b/cpp/oneapi/dal/algo/jaccard/vertex_similarity_types.hpp
@@ -39,7 +39,7 @@ public:
                   "Only undirected_adjacency_vector_graph is supported.");
     /// Constructs the algorithm input initialized with the graph and the caching builder.
     ///
-    /// @param [in]   graph  The input graph
+    /// @param [in]   g  The input graph
     /// @param [in/out]  builder  The caching builder
     vertex_similarity_input(const Graph& g, caching_builder& builder);
 

--- a/cpp/oneapi/dal/graph/service_functions.hpp
+++ b/cpp/oneapi/dal/graph/service_functions.hpp
@@ -90,7 +90,7 @@ constexpr auto get_vertex_outward_neighbors(const Graph &g, vertex_type<Graph> u
 /// Returns the value of an edge (u, v)
 ///
 /// @tparam Graph  Type of the graph
-/// @param [in]   graph  Input graph object
+/// @param [in]   g  Input graph object
 /// @param [in]   u Source vertex index
 /// @param [in]   v Destination vertex index
 ///

--- a/cpp/oneapi/dal/spmd/communicator.hpp
+++ b/cpp/oneapi/dal/spmd/communicator.hpp
@@ -251,18 +251,24 @@ public:
     }
     template <typename D>
     request bcast(const array<D>& ary, std::int64_t root = -1) const;
+
     /// Gathers data from all ranks and distributes the results back to all ranks
     ///
-    /// @param send_buf   The send buffer
-    /// @param send_count The number of elements of `dtype` in `send_buf`
-    /// @param recv_buf   The receiving buffer
-    /// @param recv_count The number of elements of `dtype` in `recv_buf`
-    /// @param dtype      The type of elements in the passed buffers
+    /// @param send   The send buffer
+    /// @param recv   The receiving buffer
+    /// @tparam D     The type of elements in the passed buffers
     ///
     /// @return The object to track the progress of the operation
     template <typename D>
     request allgather(const array<D>& send, const array<D>& recv) const;
 
+    /// Gathers data from all ranks and distributes the results back to all ranks
+    ///
+    /// @param scalar The send element
+    /// @param recv   The receiving buffer
+    /// @tparam D     The type of elements in send / recv
+    ///
+    /// @return The object to track the progress of the operation
     template <typename D>
     request allgather(const D& scalar, const array<D>& recv) const;
     /// Collects data from all the ranks within a communicator into a single buffer
@@ -274,9 +280,9 @@ public:
     /// @param recv_buf   The receiveing buffer, must contain at least
     ///                   `rank_count * recv_count` elements,
     ///                   significant only at `root`
-    /// @param recv_count The number of elements of `dtype` received from
-    ///                   each rank, must contain at least `rank_count` elements,
-    ///                   significant only at `root`
+    /// @param recv_counts The number of elements of `dtype` received from
+    ///                    each rank, must contain at least `rank_count` elements,
+    ///                    significant only at `root`
     /// @param displs     Entry $i$ specifies the displacement relative to
     ///                   `recv_buf` at which to place the incoming data
     ///                   from process $i$, must contain at least `rank_count`


### PR DESCRIPTION
## Description

This PR should clear some warnings that are observed in the CI job that builds the roxygen docs:
```
/home/vsts/work/1/s/cpp/oneapi/dal/graph/service_functions.hpp:90: warning: argument 'graph' of command @param is not found in the argument list of oneapi::dal::preview::get_edge_value(const Graph &g, vertex_type< Graph > u, vertex_type< Graph > v) -> const edge_user_value_type< Graph > &
/home/vsts/work/1/s/cpp/oneapi/dal/graph/service_functions.hpp:158: warning: The following parameter of oneapi::dal::preview::get_edge_value(const Graph &g, vertex_type< Graph > u, vertex_type< Graph > v) -> const edge_user_value_type< Graph > & is not documented:
  parameter 'g'
/home/vsts/work/1/s/cpp/oneapi/dal/algo/jaccard/common.hpp:148: warning: argument 'in' of command @param is not found in the argument list of caching_builder::operator()(std::int64_t block_max_size)
/home/vsts/work/1/s/cpp/oneapi/dal/algo/jaccard/common.hpp:148: warning: argument 'out' of command @param is not found in the argument list of caching_builder::operator()(std::int64_t block_max_size)
/home/vsts/work/1/s/cpp/oneapi/dal/algo/jaccard/vertex_similarity_types.hpp:40: warning: argument 'graph' of command @param is not found in the argument list of vertex_similarity_input< Graph, Task >::vertex_similarity_input(const Graph &g, caching_builder &builder)
/home/vsts/work/1/s/cpp/oneapi/dal/algo/jaccard/vertex_similarity_types.hpp:40: warning: argument 'in' of command @param is not found in the argument list of vertex_similarity_input< Graph, Task >::vertex_similarity_input(const Graph &g, caching_builder &builder)
/home/vsts/work/1/s/cpp/oneapi/dal/algo/jaccard/vertex_similarity_types.hpp:40: warning: argument 'out' of command @param is not found in the argument list of vertex_similarity_input< Graph, Task >::vertex_similarity_input(const Graph &g, caching_builder &builder)
/home/vsts/work/1/s/cpp/oneapi/dal/algo/jaccard/vertex_similarity_types.hpp:44: warning: The following parameters of oneapi::dal::preview::jaccard::vertex_similarity_input::vertex_similarity_input(const Graph &g, caching_builder &builder) are not documented:
  parameter 'g'
  parameter 'builder'
/home/vsts/work/1/s/cpp/oneapi/dal/spmd/communicator.hpp:254: warning: argument 'send_buf' of command @param is not found in the argument list of communicator< MemoryAccessKind >::allgather(const array< D > &send, const array< D > &recv) const
/home/vsts/work/1/s/cpp/oneapi/dal/spmd/communicator.hpp:254: warning: argument 'send_count' of command @param is not found in the argument list of communicator< MemoryAccessKind >::allgather(const array< D > &send, const array< D > &recv) const
/home/vsts/work/1/s/cpp/oneapi/dal/spmd/communicator.hpp:254: warning: argument 'recv_buf' of command @param is not found in the argument list of communicator< MemoryAccessKind >::allgather(const array< D > &send, const array< D > &recv) const
/home/vsts/work/1/s/cpp/oneapi/dal/spmd/communicator.hpp:254: warning: argument 'recv_count' of command @param is not found in the argument list of communicator< MemoryAccessKind >::allgather(const array< D > &send, const array< D > &recv) const
/home/vsts/work/1/s/cpp/oneapi/dal/spmd/communicator.hpp:254: warning: argument 'dtype' of command @param is not found in the argument list of communicator< MemoryAccessKind >::allgather(const array< D > &send, const array< D > &recv) const
/home/vsts/work/1/s/cpp/oneapi/dal/spmd/communicator.hpp:264: warning: The following parameters of oneapi::dal::preview::spmd::v1::communicator::allgather(const array< D > &send, const array< D > &recv) const are not documented:
  parameter 'send'
  parameter 'recv'
/home/vsts/work/1/
```

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
