### PR TITLE
Fix coverity hits in boosting algorithms

### DIFF
--- a/cpp/daal/include/algorithms/boosting/adaboost_predict_types.h
+++ b/cpp/daal/include/algorithms/boosting/adaboost_predict_types.h
@@ -55,6 +55,7 @@ class DAAL_EXPORT Input : public classifier::prediction::Input
 public:
     Input() {}
     Input(const Input & other) : classifier::prediction::Input(other) {}
+    Input & operator=(const Input & other) = default;
     virtual ~Input() {}
 
     using super::get;

--- a/cpp/daal/include/algorithms/boosting/brownboost_predict_types.h
+++ b/cpp/daal/include/algorithms/boosting/brownboost_predict_types.h
@@ -62,6 +62,7 @@ class DAAL_EXPORT Input : public classifier::prediction::Input
 public:
     Input() : classifier::prediction::Input() {}
     Input(const Input & other) : classifier::prediction::Input(other) {}
+    Input & operator=(const Input & other) = default;
     virtual ~Input() {}
 
     using super::get;

--- a/cpp/daal/include/algorithms/boosting/logitboost_predict_types.h
+++ b/cpp/daal/include/algorithms/boosting/logitboost_predict_types.h
@@ -63,6 +63,7 @@ class DAAL_EXPORT Input : public classifier::prediction::Input
 public:
     Input() : classifier::prediction::Input() {}
     Input(const Input & other) : classifier::prediction::Input(other) {}
+    Input & operator=(const Input & other) = default;
     virtual ~Input() {}
 
     using super::get;


### PR DESCRIPTION
Default assignment operator was added in `prediction::Input` classes in AdaBoost, BrownBoost and LogitBoost algorithms to fix rule of three violations.

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
