### PR TITLE
DOC: Instructions for installing with dependencies from `conda`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -222,8 +222,8 @@ conda install -y \
     dpcpp-cpp-rt dpcpp_linux-64 intel-sycl-rt \ `# Intel compiler packages`
     tbb tbb-devel \ `# required TBB packages`
     mkl mkl-devel mkl-static mkl-dpcpp mkl-devel-dpcpp \ `# required MKL packages`
-    impi_rt impi-devel `# required for spmd mode only`
-    cmake \ `# required to build the examples only`
+    impi_rt impi-devel \ `# required for spmd mode only`
+    cmake `# required to build the examples only`
 ```
 
 _(for windows, replace `dpcpp_linux-64` with `dpcpp_win-64`, and remove the comments within backticks)_

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -213,7 +213,7 @@ conda activate onedal_env
 
 Then, install the necessary dependencies from the appropriate channels with `conda`:
 
-* Linux:
+* **Linux\***:
 
 ```shell
 conda install -y \
@@ -226,7 +226,7 @@ conda install -y \
     cmake `# required to build the examples only`
 ```
 
-* Windows:
+* **Windows\***:
 
 ```bat
 conda install -y^
@@ -241,7 +241,7 @@ conda install -y^
 
 Then modify the relevant environment variables to point to the conda-installed libraries:
 
-* Linux:
+* **Linux\***:
 
 ```shell
 export MKLROOT=${CONDA_PREFIX}
@@ -254,7 +254,7 @@ export PKG_CONFIG_PATH="${CONDA_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 export CMAKE_PREFIX_PATH="${CONDA_PREFIX}/lib/cmake:${CMAKE_PREFIX_PATH}"
 ```
 
-* windows:
+* **Windows\***:
 
 ```bat
 set MKLROOT=%CONDA_PREFIX%\Library

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,12 +35,17 @@ Note: the Intel(R) oneAPI components listed here can be installed together throu
 
 https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html
 
+These dependencies can also be installed through the `conda` software, but doing so will require a few additional setup steps - see rest of the instructions for details.
+
 ## Docker Development Environment
 
 [Docker file](https://github.com/uxlfoundation/oneDAL/tree/main/dev/docker) with the oneDAL development environment
 is available as an alternative to the manual setup.
 
 ## Installation Steps
+
+_(If using `conda`, see subsequent sections for instructions)_
+
 1. Clone the sources from GitHub\* as follows:
 
         git clone https://github.com/uxlfoundation/oneDAL.git
@@ -194,4 +199,68 @@ For example, in a Linux platform, assuming one wishes to execute the `adaboost_d
 
 ```shell
 ./_cmake_results/intel_intel64_so/adaboost_dense_batch
+```
+
+## Installation with a conda environment
+
+The previous instructions assumed system-wide installs of the necessary dependencies. These can also be installed at a user-level through the `conda` or [mamba](https://github.com/conda-forge/miniforge) ecosystems.
+
+To create a conda environment for building oneDAL, after `conda` has been installed:
+
+```shell
+conda create -n -y onedal_env
+conda activate onedal_env
+```
+
+To install the necessary dependencies with `conda`, **assuming a linux system**:
+
+```shell
+conda install -y -c https://software.repos.intel.com/python/conda/ \ `# Intel's repository`
+    make python \ `# used by the build system`
+    dpcpp-cpp-rt dpcpp_linux-64 intel-sycl-rt \ `# Intel compiler packages`
+    tbb tbb-devel \ `# required TBB packages`
+    mkl mkl-devel mkl-static mkl-dpcpp mkl-devel-dpcpp \ `# required MKL packages`
+    cmake `# required to build the examples only`
+```
+
+_(for windows, replace `dpcpp_linux-64` with `dpcpp_win-64`)_
+
+Then, one needs to modify environment variables as appropriate to point to the necessary libraries - **assuming a linux system:**
+
+```shell
+export MKLROOT=${CONDA_PREFIX}
+export TBBROOT=${CONDA_PREFIX}
+export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"
+export LIBRARY_PATH="${CONDA_PREFIX}/lib:${LIBRARY_PATH}"
+export CPATH="${CONDA_PREFIX}/include:${CPATH}"
+export PATH="${CONDA_PREFIX}/bin:${PATH}"
+export PKG_CONFIG_PATH="${CONDA_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
+export CMAKE_PREFIX_PATH="${CONDA_PREFIX}/lib/cmake:${CMAKE_PREFIX_PATH}"
+```
+
+Equivalent for windows:
+
+```bat
+set MKLROOT=%CONDA_PREFIX%\Library
+set TBBROOT=%CONDA_PREFIX%\Library
+set "LD_LIBRARY_PATH=%CONDA_PREFIX%\Library\lib;%LD_LIBRARY_PATH%"
+set "LIBRARY_PATH=%CONDA_PREFIX%\Library\lib;%LIBRARY_PATH%"
+set "CPATH=%CONDA_PREFIX%\Library\include;%CPATH%"
+set "PATH=%CONDA_PREFIX%\Library\bin;%PATH%"
+set "PKG_CONFIG_PATH=%CONDA_PREFIX%\Library\lib\pkgconfig;%PKG_CONFIG_PATH%"
+set "CMAKE_PREFIX_PATH=%CONDA_PREFIX%\Library\lib\cmake;%CMAKE_PREFIX_PATH%"
+```
+
+.. And then, previous commands from the Makefile for the Intel compiler should work - e.g.:
+
+* For linux:
+
+```shell
+make -f makefile daal PLAT=lnx32e
+```
+
+* For windows:
+
+```shell
+make -f makefile oneapi PLAT=win32e
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -208,7 +208,7 @@ The previous instructions assumed system-wide installs of the necessary dependen
 To create a conda environment for building oneDAL, after `conda` has been installed:
 
 ```shell
-conda create -n -y onedal_env
+conda create -y -n onedal_env
 conda activate onedal_env
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,7 +35,7 @@ Note: the Intel(R) oneAPI components listed here can be installed together throu
 
 https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html
 
-These dependencies can also be installed through the `conda` software, but doing so will require a few additional setup steps - see rest of the instructions for details.
+All of these dependencies can alternatively be installed through the `conda` software, but doing so will require a few additional setup steps - see [Conda Development Environment Setup](https://github.com/uxlfoundation/oneDAL/blob/main/INSTALL.md#conda-development-environment-setup) for details.
 
 ## Docker Development Environment
 
@@ -44,7 +44,6 @@ is available as an alternative to the manual setup.
 
 ## Installation Steps
 
-_(If using `conda`, see subsequent sections for instructions)_
 
 1. Clone the sources from GitHub\* as follows:
 
@@ -201,33 +200,48 @@ For example, in a Linux platform, assuming one wishes to execute the `adaboost_d
 ./_cmake_results/intel_intel64_so/adaboost_dense_batch
 ```
 
-## Installation with a conda environment
+## Conda Development Environment Setup
 
 The previous instructions assumed system-wide installs of the necessary dependencies. These can also be installed at a user-level through the `conda` or [mamba](https://github.com/conda-forge/miniforge) ecosystems.
 
-To create a conda environment for building oneDAL, after `conda` has been installed:
+First, create a conda environment for building oneDAL, after `conda` has been installed:
 
 ```shell
 conda create -y -n onedal_env
 conda activate onedal_env
 ```
 
-To install the necessary dependencies with `conda`, **assuming a linux system**:
+Then, install the necessary dependencies from the appropriate channels with `conda`:
+
+* Linux:
 
 ```shell
 conda install -y \
     -c https://software.repos.intel.com/python/conda/ \ `# Intel's repository`
     -c conda-forge \ `# conda-forge, for tools like 'make'`
-    make python \ `# used by the build system`
+    make python>=3.9 \ `# used by the build system`
     dpcpp-cpp-rt dpcpp_linux-64 intel-sycl-rt \ `# Intel compiler packages`
     tbb tbb-devel \ `# required TBB packages`
     mkl mkl-devel mkl-static mkl-dpcpp mkl-devel-dpcpp \ `# required MKL packages`
     cmake `# required to build the examples only`
 ```
 
-_(for windows, replace `dpcpp_linux-64` with `dpcpp_win-64`, and remove the comments within backticks)_
+* Windows:
 
-Then, one needs to modify environment variables as appropriate to point to the necessary libraries - **assuming a linux system:**
+```bat
+conda install -y^
+    -c https://software.repos.intel.com/python/conda/^
+    -c conda-forge^
+    make dos2unix python>=3.9^
+    dpcpp-cpp-rt dpcpp_win-64 intel-sycl-rt^
+    tbb tbb-devel^
+    mkl mkl-devel mkl-static mkl-dpcpp mkl-devel-dpcpp^
+    cmake
+```
+
+Then modify the relevant environment variables to point to the conda-installed libraries:
+
+* Linux:
 
 ```shell
 export MKLROOT=${CONDA_PREFIX}
@@ -240,7 +254,7 @@ export PKG_CONFIG_PATH="${CONDA_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 export CMAKE_PREFIX_PATH="${CONDA_PREFIX}/lib/cmake:${CMAKE_PREFIX_PATH}"
 ```
 
-Equivalent for windows:
+* windows:
 
 ```bat
 set MKLROOT=%CONDA_PREFIX%\Library
@@ -253,16 +267,4 @@ set "PKG_CONFIG_PATH=%CONDA_PREFIX%\Library\lib\pkgconfig;%PKG_CONFIG_PATH%"
 set "CMAKE_PREFIX_PATH=%CONDA_PREFIX%\Library\lib\cmake;%CMAKE_PREFIX_PATH%"
 ```
 
-.. And then, previous commands in this document from the Makefile for the Intel compiler should work - e.g.:
-
-* For linux:
-
-```shell
-make -f makefile daal PLAT=lnx32e
-```
-
-* For windows:
-
-```shell
-make -f makefile oneapi PLAT=win32e
-```
+After that, it should be possible to build oneDAL and run the examples using the ICX compiler and the oneMKL libraries as per the instructions.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -222,7 +222,6 @@ conda install -y \
     dpcpp-cpp-rt dpcpp_linux-64 intel-sycl-rt \ `# Intel compiler packages`
     tbb tbb-devel \ `# required TBB packages`
     mkl mkl-devel mkl-static mkl-dpcpp mkl-devel-dpcpp \ `# required MKL packages`
-    impi_rt impi-devel \ `# required for spmd mode only`
     cmake `# required to build the examples only`
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -215,15 +215,18 @@ conda activate onedal_env
 To install the necessary dependencies with `conda`, **assuming a linux system**:
 
 ```shell
-conda install -y -c https://software.repos.intel.com/python/conda/ \ `# Intel's repository`
+conda install -y \
+    -c https://software.repos.intel.com/python/conda/ \ `# Intel's repository`
+    -c conda-forge \ `# conda-forge, for tools like 'make'`
     make python \ `# used by the build system`
     dpcpp-cpp-rt dpcpp_linux-64 intel-sycl-rt \ `# Intel compiler packages`
     tbb tbb-devel \ `# required TBB packages`
     mkl mkl-devel mkl-static mkl-dpcpp mkl-devel-dpcpp \ `# required MKL packages`
-    cmake `# required to build the examples only`
+    impi_rt impi-devel `# required for spmd mode only`
+    cmake \ `# required to build the examples only`
 ```
 
-_(for windows, replace `dpcpp_linux-64` with `dpcpp_win-64`)_
+_(for windows, replace `dpcpp_linux-64` with `dpcpp_win-64`, and remove the comments within backticks)_
 
 Then, one needs to modify environment variables as appropriate to point to the necessary libraries - **assuming a linux system:**
 
@@ -251,7 +254,7 @@ set "PKG_CONFIG_PATH=%CONDA_PREFIX%\Library\lib\pkgconfig;%PKG_CONFIG_PATH%"
 set "CMAKE_PREFIX_PATH=%CONDA_PREFIX%\Library\lib\cmake;%CMAKE_PREFIX_PATH%"
 ```
 
-.. And then, previous commands from the Makefile for the Intel compiler should work - e.g.:
+.. And then, previous commands in this document from the Makefile for the Intel compiler should work - e.g.:
 
 * For linux:
 


### PR DESCRIPTION
## Description

This PR adds instructions for building oneDAL from source using packages from `conda` to satisfy dependencies instead of using system installs. Packages from `conda` don't come with activation scripts, so this adds the necessary instructions for getting them to work with the oneDAL make file.

_Disclaimer: I haven't fully tested the windows instructions._

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.

**Performance**

Not applicable.
