### PR TITLE
test: remove outdated todos in tests

### DIFF
--- a/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
@@ -100,9 +100,6 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
                      "kmeans block test",
                      "[kmeans][batch][nightly][block]",
                      kmeans_types) {
-    // This test is not stable on CPU
-    // TODO: Remove the following `SKIP_IF` once stability problem is resolved
-    SKIP_IF(this->get_policy().is_cpu());
     SKIP_IF(this->is_sparse_method());
     SKIP_IF(this->not_float64_friendly());
     this->check_on_large_data_with_one_cluster();

--- a/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
@@ -100,6 +100,9 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
                      "kmeans block test",
                      "[kmeans][batch][nightly][block]",
                      kmeans_types) {
+    // This test is not stable on CPU
+    // TODO: Remove the following `SKIP_IF` once stability problem is resolved
+    SKIP_IF(this->get_policy().is_cpu());
     SKIP_IF(this->is_sparse_method());
     SKIP_IF(this->not_float64_friendly());
     this->check_on_large_data_with_one_cluster();

--- a/cpp/oneapi/dal/backend/primitives/blas/test/gemv_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/blas/test/gemv_dpc.cpp
@@ -148,9 +148,6 @@ private:
 using gemv_types = COMBINE_TYPES((float, double), (c_order, f_order));
 
 TEMPLATE_LIST_TEST_M(gemv_test, "ones matrix gemv on small sizes", "[gemv][small]", gemv_types) {
-    // TODO: ensure gemv issue is resolved and remove skip
-    SKIP_IF(true);
-
     // DPC++ GEMV from micro MKL libs is not supported on GPU
     SKIP_IF(this->get_policy().is_cpu());
 
@@ -162,9 +159,6 @@ TEMPLATE_LIST_TEST_M(gemv_test, "ones matrix gemv on small sizes", "[gemv][small
 }
 
 TEMPLATE_LIST_TEST_M(gemv_test, "ones matrix gemv on medium sizes", "[gemv][small]", gemv_types) {
-    // TODO: ensure gemv issue is resolved and remove skip
-    SKIP_IF(true);
-
     // DPC++ GEMV from micro MKL libs is not supported on GPU
     SKIP_IF(this->get_policy().is_cpu());
 

--- a/cpp/oneapi/dal/backend/primitives/selection/test/select_flagged_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/selection/test/select_flagged_dpc.cpp
@@ -225,8 +225,6 @@ TEMPLATE_LIST_TEST_M(select_flagged_test,
                      "select flagged",
                      "[select flagged]",
                      select_flagged_types) {
-    // TODO: Fix problem with incorrect number of total sum on CPU
-    SKIP_IF(this->get_policy().is_cpu());
     SKIP_IF(this->not_float64_friendly());
     std::int64_t elem_count = GENERATE_COPY(2, 15, 16000);
 
@@ -240,8 +238,6 @@ TEMPLATE_LIST_TEST_M(select_flagged_index_test,
                      "select flagged index",
                      "[select flagged]",
                      select_flagged_index_types) {
-    // TODO: Fix problem with incorrect number of total sum on CPU
-    SKIP_IF(this->get_policy().is_cpu());
     SKIP_IF(this->not_float64_friendly());
     std::int64_t elem_count = GENERATE_COPY(2, 15, 16000);
 

--- a/cpp/oneapi/dal/backend/primitives/selection/test/select_indexed_rows_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/selection/test/select_indexed_rows_dpc.cpp
@@ -130,7 +130,6 @@ TEMPLATE_LIST_TEST_M(selection_by_rows_test,
                      "selection indexed rows",
                      "[block select][small]",
                      selection_types) {
-    SKIP_IF(true);
     SKIP_IF(this->not_float64_friendly());
     this->generate();
     this->check_full();


### PR DESCRIPTION
<!--
  ~ Copyright 2019 Intel Corporation
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
  ~
  ~     http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-->

## Description

Removes some TODOs in various parts of oneDAL testing as the issues are no longer leading to failed tests locally or in CI

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
