### PR TITLE
Add proper CPUID eax checking

### DIFF
--- a/cpp/daal/src/services/compiler/generic/env_detect_features.cpp
+++ b/cpp/daal/src/services/compiler/generic/env_detect_features.cpp
@@ -71,6 +71,19 @@ void run_cpuid(uint32_t eax, uint32_t ecx, uint32_t * abcd)
     #endif
 }
 
+uint32_t __daal_internal_get_max_extension_support()
+{
+    uint32_t abcd[4];
+    run_cpuid(0x80000000, 0, abcd);
+    return abcd[0];
+}
+
+uint32_t daal_get_max_extension_support()
+{
+    static const uint32_t result = __daal_internal_get_max_extension_support();
+    return result;
+}
+
 bool __daal_internal_is_intel_cpu()
 {
     const uint32_t genu = 0x756e6547, inei = 0x49656e69, ntel = 0x6c65746e;
@@ -87,6 +100,11 @@ DAAL_EXPORT bool daal_check_is_intel_cpu()
 
 static int check_cpuid(uint32_t eax, uint32_t ecx, int abcd_index, uint32_t mask)
 {
+    if (daal_get_max_extension_support() < eax)
+    {
+        // need to check that the eax we run here is supported.
+        return 0;
+    }
     uint32_t abcd[4];
 
     run_cpuid(eax, ecx, abcd);
@@ -193,7 +211,7 @@ static int check_sse42_features()
 
 DAAL_EXPORT bool __daal_serv_cpu_extensions_available()
 {
-    return daal_check_is_intel_cpu();
+    return 1;
 }
 
 DAAL_EXPORT int __daal_serv_cpu_detect(int enable)

--- a/cpp/daal/src/services/compiler/generic/env_detect_features.cpp
+++ b/cpp/daal/src/services/compiler/generic/env_detect_features.cpp
@@ -73,6 +73,10 @@ void run_cpuid(uint32_t eax, uint32_t ecx, uint32_t * abcd)
 
 uint32_t __daal_internal_get_max_extension_support()
 {
+    // Running cpuid with a value other than eax=0 and 0x8000000 is an extension
+    // To check that a particular eax value is supported we need to check
+    // maximum extension that is supported by checking the value returned by
+    // cpuid when eax=0x80000000 is given.
     uint32_t abcd[4];
     run_cpuid(0x80000000, 0, abcd);
     return abcd[0];
@@ -80,6 +84,7 @@ uint32_t __daal_internal_get_max_extension_support()
 
 uint32_t daal_get_max_extension_support()
 {
+    // We cache the result in a static variable here.
     static const uint32_t result = __daal_internal_get_max_extension_support();
     return result;
 }
@@ -209,11 +214,6 @@ static int check_sse42_features()
     return 1;
 }
 
-DAAL_EXPORT bool __daal_serv_cpu_extensions_available()
-{
-    return 1;
-}
-
 DAAL_EXPORT int __daal_serv_cpu_detect(int enable)
 {
     #if defined(__APPLE__)
@@ -244,11 +244,6 @@ static bool check_sve_features()
     return (hwcap & HWCAP_SVE) != 0;
 }
 
-DAAL_EXPORT bool __daal_serv_cpu_extensions_available()
-{
-    return 0;
-}
-
 DAAL_EXPORT int __daal_serv_cpu_detect(int enable)
 {
     if (check_sve_features())
@@ -268,11 +263,6 @@ bool daal_check_is_intel_cpu()
     return false;
 }
 #elif defined(TARGET_RISCV64)
-DAAL_EXPORT bool __daal_serv_cpu_extensions_available()
-{
-    return 0;
-}
-
 DAAL_EXPORT int __daal_serv_cpu_detect(int enable)
 {
     return daal::rv64;

--- a/cpp/daal/src/services/service_defines.h
+++ b/cpp/daal/src/services/service_defines.h
@@ -42,7 +42,7 @@ DAAL_EXPORT bool daal_check_is_intel_cpu();
     #define DAAL_BASE_CPU daal::rv64
 #endif
 
-#define DAAL_CHECK_CPU_ENVIRONMENT (daal_check_is_intel_cpu())
+#define DAAL_CHECK_CPU_ENVIRONMENT (__daal_serv_cpu_extensions_available())
 
 #if defined(__INTEL_COMPILER)
     #define PRAGMA_IVDEP            _Pragma("ivdep")

--- a/cpp/daal/src/services/service_defines.h
+++ b/cpp/daal/src/services/service_defines.h
@@ -28,7 +28,6 @@
 #include <stdint.h>
 #include "services/env_detect.h"
 
-DAAL_EXPORT bool __daal_serv_cpu_extensions_available();
 DAAL_EXPORT int __daal_serv_cpu_detect(int);
 
 void run_cpuid(uint32_t eax, uint32_t ecx, uint32_t * abcd);
@@ -42,7 +41,11 @@ DAAL_EXPORT bool daal_check_is_intel_cpu();
     #define DAAL_BASE_CPU daal::rv64
 #endif
 
-#define DAAL_CHECK_CPU_ENVIRONMENT (__daal_serv_cpu_extensions_available())
+#if defined(TARGET_X86_64)
+    #define DAAL_CHECK_CPU_ENVIRONMENT 1
+#else
+    #define DAAL_CHECK_CPU_ENVIRONMENT 0
+#endif
 
 #if defined(__INTEL_COMPILER)
     #define PRAGMA_IVDEP            _Pragma("ivdep")

--- a/cpp/daal/src/services/service_defines.h
+++ b/cpp/daal/src/services/service_defines.h
@@ -41,11 +41,7 @@ DAAL_EXPORT bool daal_check_is_intel_cpu();
     #define DAAL_BASE_CPU daal::rv64
 #endif
 
-#if defined(TARGET_X86_64)
-    #define DAAL_CHECK_CPU_ENVIRONMENT 1
-#else
-    #define DAAL_CHECK_CPU_ENVIRONMENT 0
-#endif
+#define DAAL_CHECK_CPU_ENVIRONMENT (daal_check_is_intel_cpu())
 
 #if defined(__INTEL_COMPILER)
     #define PRAGMA_IVDEP            _Pragma("ivdep")

--- a/cpp/oneapi/dal/detail/cpu.cpp
+++ b/cpp/oneapi/dal/detail/cpu.cpp
@@ -38,15 +38,11 @@ cpu_extension from_daal_cpu_type(int cpu_type) {
 }
 
 cpu_extension detect_top_cpu_extension() {
-    if (!__daal_serv_cpu_extensions_available()) {
-#if defined(TARGET_X86_64)
-        return detail::cpu_extension::sse2;
-#elif defined(TARGET_ARM)
-        return detail::cpu_extension::sve;
+#if defined(TARGET_ARM)
+    return detail::cpu_extension::sve;
 #elif defined(TARGET_RISCV64)
-        return detail::cpu_extension::rv64;
+    return detail::cpu_extension::rv64;
 #endif
-    }
     const auto daal_cpu = __daal_serv_cpu_detect(0);
 
     return from_daal_cpu_type(daal_cpu);


### PR DESCRIPTION
This makes it possible to use the sse42, avx2 code paths on AMD processors

<!--
  ~ Copyright 2019 Intel Corporation
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
  ~
  ~     http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-->

## Description

_Add a comprehensive description of proposed changes_

- Adds proper CPUID extension support checking which was previously done by guarding with a check for Intel CPUs. This allows AMD processors to use the sse42, avx2 code paths instead of the default sse2.

_List associated issue number(s) if exist(s): #6 (for example)_

_Documentation PR (if needed): #1340 (for example)_

_Benchmarks PR (if needed): https://github.com/IntelPython/scikit-learn_bench/pull/155 (for example)_

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
