### PR TITLE
Fix GCC build errors in PCA example

### DIFF
--- a/cpp/daal/include/algorithms/algorithm_types.h
+++ b/cpp/daal/include/algorithms/algorithm_types.h
@@ -219,10 +219,16 @@ public:
 
 protected:
     /**
-    * Copy constructor
-    * \param[in] other Instance of the same class to copy
-    */
+     * Copy constructor
+     * \param[in] other Instance of the same class to copy
+     */
     Argument(const Argument & other);
+
+    /**
+     * Copy assignment operator
+     * \param[in] other Instance of the same class to copy
+     */
+    Argument & operator=(const Argument & other);
 
     /**
      * Retrieves specified element
@@ -326,6 +332,8 @@ protected:
     * \param[in] other Instance of the same class to copy
     */
     Input(const Input & other) : Argument(other) {}
+
+    Input & operator=(const Input & other) = default;
 };
 
 /**

--- a/cpp/daal/include/data_management/data/data_dictionary.h
+++ b/cpp/daal/include/data_management/data/data_dictionary.h
@@ -72,10 +72,24 @@ public:
     }
 
     /**
+     * Copy constructor for a data feature
+     */
+    NumericTableFeature(const NumericTableFeature & f)
+    {
+        indexType      = f.indexType;
+        pmmlType       = f.pmmlType;
+        featureType    = f.featureType;
+        typeSize       = f.typeSize;
+        categoryNumber = f.categoryNumber;
+    }
+
+    /**
      *  Copy operator for a data feature
      */
     NumericTableFeature & operator=(const NumericTableFeature & f)
     {
+        if (this == &f) return *this;
+
         indexType      = f.indexType;
         pmmlType       = f.pmmlType;
         featureType    = f.featureType;

--- a/cpp/daal/src/algorithms/algorithm_base_impl.cpp
+++ b/cpp/daal/src/algorithms/algorithm_base_impl.cpp
@@ -55,6 +55,13 @@ algorithms::Argument::Argument(const algorithms::Argument & other)
     : _storage(new internal::ArgumentStorage(*(internal::ArgumentStorage *)other._storage.get())), idx(0)
 {}
 
+algorithms::Argument & algorithms::Argument::operator=(const algorithms::Argument & other) {
+    if (this == &other) return *this;
+    _storage = data_management::DataCollectionPtr(new internal::ArgumentStorage(*(internal::ArgumentStorage *)other._storage.get()));
+    idx = 0;
+    return *this;
+}
+
 const data_management::SerializationIfacePtr & algorithms::Argument::get(size_t index) const
 {
     return (*_storage)[index];

--- a/cpp/daal/src/algorithms/algorithm_base_impl.cpp
+++ b/cpp/daal/src/algorithms/algorithm_base_impl.cpp
@@ -55,10 +55,11 @@ algorithms::Argument::Argument(const algorithms::Argument & other)
     : _storage(new internal::ArgumentStorage(*(internal::ArgumentStorage *)other._storage.get())), idx(0)
 {}
 
-algorithms::Argument & algorithms::Argument::operator=(const algorithms::Argument & other) {
+algorithms::Argument & algorithms::Argument::operator=(const algorithms::Argument & other)
+{
     if (this == &other) return *this;
     _storage = data_management::DataCollectionPtr(new internal::ArgumentStorage(*(internal::ArgumentStorage *)other._storage.get()));
-    idx = 0;
+    idx      = 0;
     return *this;
 }
 


### PR DESCRIPTION
<!--
  ~ Copyright 2019 Intel Corporation
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
  ~
  ~     http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-->

Add missing copy constructor or assignment operators to fix GCC "implicitly-declared `operator=` is deprecated" and similar errors in `pca_cor_dense_batch` example.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
