### PR TITLE
Reproducer for PCA example failures (#3037)

### DIFF
--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -221,6 +221,14 @@ for link_mode in "${link_modes[@]}"; do
             cmake_options+=(-DCMAKE_TOOLCHAIN_FILE="${ONEDAL_DIR}"/.ci/env/"${ARCH}"-"${compiler}"-crosscompile-toolchain.cmake)
         fi
 
+        if [ "$compiler" == "gnu" ] ; then
+            if [ "$TEST_KIND" = "examples" ] ; then
+                # Build examples with -Werror=deprecated-copy enabled to catch deprecated copy constructors
+                # and assignment operators in the code
+                cmake_options+=(-DCMAKE_CXX_FLAGS="-Werror=deprecated-copy")
+            fi
+        fi
+
         echo cmake "${cmake_options[@]}"
         cmake "${cmake_options[@]}"
         err=$?

--- a/.ci/scripts/test.sh
+++ b/.ci/scripts/test.sh
@@ -221,12 +221,10 @@ for link_mode in "${link_modes[@]}"; do
             cmake_options+=(-DCMAKE_TOOLCHAIN_FILE="${ONEDAL_DIR}"/.ci/env/"${ARCH}"-"${compiler}"-crosscompile-toolchain.cmake)
         fi
 
-        if [ "$compiler" == "gnu" ] ; then
-            if [ "$TEST_KIND" = "examples" ] ; then
-                # Build examples with -Werror=deprecated-copy enabled to catch deprecated copy constructors
-                # and assignment operators in the code
-                cmake_options+=(-DCMAKE_CXX_FLAGS="-Werror=deprecated-copy")
-            fi
+        if [ "$TEST_KIND" = "examples" ] ; then
+            # Build examples with -Werror=deprecated-copy enabled to catch deprecated copy constructors
+            # and assignment operators in the code
+            cmake_options+=(-DCMAKE_CXX_FLAGS="-Werror=deprecated-copy")
         fi
 
         echo cmake "${cmake_options[@]}"


### PR DESCRIPTION
<!--
  ~ Copyright 2019 Intel Corporation
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
  ~
  ~     http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-->

Add `-Werror=deprecated-copy` option to GCC examples build to reproduce the validation tests failures.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
