### PR TITLE
DOC: Fix typo in documentation

### DIFF
--- a/docs/source/get-started/build-and-run-examples.rst
+++ b/docs/source/get-started/build-and-run-examples.rst
@@ -100,7 +100,7 @@ basic usage scenarios of |short_name| with DPCPP. Go to
       Otherwise, you need to copy :file:`examples/oneapi/dpc` and :file:`examples/oneapi/data` folders
       to the directory with right permissions. These two folders must be retained
       in the same directory level relative to each other.
-      If you want to build examples from /examples/oneapi/cpp you can set CC and CXX with other compliers as well.
+      If you want to build examples from /examples/oneapi/cpp you can set CC and CXX to other compilers as well.
 
    .. tabs::
 


### PR DESCRIPTION
<!--
  ~ Copyright 2019 Intel Corporation
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
  ~
  ~     http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-->

## Description

Fixes a small typo that was left unmerged from this PR: https://github.com/uxlfoundation/oneDAL/pull/3009

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

Not applicable.

**Performance**

Not applicable.
