### PR TITLE
Fix min, max and sum_squares computations in low order moments

### DIFF
--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_impl.i
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_impl.i
@@ -522,7 +522,7 @@ Status computeMinMaxAndSumOfSquared(const size_t nFeatures, const size_t nVector
         const size_t startRows = iBlock * numRowsInBlock;
         const size_t chunkRows = (iBlock < (nBlocks - 1)) ? numRowsInBlock : numRowsInLastBlock;
 
-        for (size_t i = startRows; i < chunkRows; i++)
+        for (size_t i = startRows; i < startRows + chunkRows; i++)
         {
             PRAGMA_IVDEP
             PRAGMA_VECTOR_ALWAYS


### PR DESCRIPTION
<!--
  ~ Copyright 2019 Intel Corporation
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
  ~
  ~     http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-->

Adjust number of iterations in a loop to fix "min", "max" and "sum_squares" computations.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- All CI jobs are green or I have provided justification why they aren't.
The failures in internal CI are not related to this change.
- [x] I have extended testing suite if new functionality was introduced in this PR.
New tests are added here: https://github.com/uxlfoundation/scikit-learn-intelex/pull/2253

**Performance**

Performance of low order moments computations might be affected by this change. Because previously part of the computations was skipped producing incorrect results.