### PR TITLE
FIX: Fix incorrect mapping of thread IDs

### DIFF
--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -427,7 +427,8 @@ DAAL_EXPORT void _daal_parallel_reduce_tls(void * tlsPtr, void * a, daal::tls_re
     size_t n                                    = 0;
     tbb::enumerable_thread_specific<void *> * p = static_cast<tbb::enumerable_thread_specific<void *> *>(tlsPtr);
 
-    for (auto it = p->begin(); it != p->end(); ++it, ++n);
+    for (auto it = p->begin(); it != p->end(); ++it, ++n)
+        ;
     if (n)
     {
         typedef void * mptr;

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -29,7 +29,7 @@
 #define TBB_PREVIEW_TASK_ARENA     1
 
 #include <algorithm> // std::min
-#include <stdlib.h> // malloc and free
+#include <stdlib.h>  // malloc and free
 #include <tbb/tbb.h>
 #include <tbb/spin_mutex.h>
 #include <tbb/scalable_allocator.h>
@@ -427,8 +427,7 @@ DAAL_EXPORT void _daal_parallel_reduce_tls(void * tlsPtr, void * a, daal::tls_re
     size_t n                                    = 0;
     tbb::enumerable_thread_specific<void *> * p = static_cast<tbb::enumerable_thread_specific<void *> *>(tlsPtr);
 
-    for (auto it = p->begin(); it != p->end(); ++it, ++n)
-        ;
+    for (auto it = p->begin(); it != p->end(); ++it, ++n);
     if (n)
     {
         typedef void * mptr;

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -263,9 +263,9 @@ DAAL_EXPORT int64_t _daal_parallel_reduce_int32ptr_int64_simple(const int32_t * 
 
 DAAL_EXPORT void _daal_static_threader_for(size_t n, const void * a, daal::functype_static func)
 {
-    if (daal::threader_env()->getNumberOfThreads() > 1)
+    const size_t nthreads = daal::threader_env()->getNumberOfThreads();
+    if (nthreads > 1)
     {
-        const size_t nthreads           = _daal_threader_get_max_threads();
         const size_t nblocks_per_thread = n / nthreads + !!(n % nthreads);
 
         tbb::parallel_for(

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -28,6 +28,7 @@
 #define TBB_PREVIEW_GLOBAL_CONTROL 1
 #define TBB_PREVIEW_TASK_ARENA     1
 
+#include <algorithm> // std::min
 #include <stdlib.h> // malloc and free
 #include <tbb/tbb.h>
 #include <tbb/spin_mutex.h>
@@ -263,7 +264,7 @@ DAAL_EXPORT int64_t _daal_parallel_reduce_int32ptr_int64_simple(const int32_t * 
 
 DAAL_EXPORT void _daal_static_threader_for(size_t n, const void * a, daal::functype_static func)
 {
-    const size_t nthreads = daal::threader_env()->getNumberOfThreads();
+    const size_t nthreads = std::min(daal::threader_env()->getNumberOfThreads(), static_cast<size_t>(_daal_threader_get_max_threads()));
     if (nthreads > 1)
     {
         const size_t nblocks_per_thread = n / nthreads + !!(n % nthreads);


### PR DESCRIPTION
<!--
  ~ Copyright 2019 Intel Corporation
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
  ~
  ~     http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-->

## Description

We have an issue when calling functions that use the static thread for function being passed `tid` (=thread ID) numbers that can be beyond the number of threads being used, even if the actual computations happen on a lower number of threads.

I _think_ this PR fixes it but I'm not 100% sure yet that it won't break anything else.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
