### PR TITLE
MAINT: Add assignment operators for Input and Parameter classes of solvers

### DIFF
--- a/cpp/daal/include/algorithms/optimization_solver/adagrad/adagrad_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/adagrad/adagrad_types.h
@@ -137,6 +137,7 @@ public:
     typedef optimization_solver::iterative_solver::Input super;
     Input();
     Input(const Input & other);
+    Input & operator=(const Input & other);
 
     using super::set;
     using super::get;

--- a/cpp/daal/include/algorithms/optimization_solver/coordinate_descent/coordinate_descent_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/coordinate_descent/coordinate_descent_types.h
@@ -124,6 +124,7 @@ private:
 public:
     Input();
     Input(const Input & other);
+    Input & operator=(const Input & other);
 
     using super::set;
     using super::get;

--- a/cpp/daal/include/algorithms/optimization_solver/iterative_solver/iterative_solver_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/iterative_solver/iterative_solver_types.h
@@ -166,6 +166,7 @@ class DAAL_EXPORT Input : public daal::algorithms::Input
 public:
     Input();
     Input(const Input & other);
+    Input & operator=(const Input & other);
 
     ~Input() DAAL_C11_OVERRIDE {}
 

--- a/cpp/daal/include/algorithms/optimization_solver/lbfgs/lbfgs_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/lbfgs/lbfgs_types.h
@@ -154,6 +154,7 @@ public:
     typedef optimization_solver::iterative_solver::Input super;
     Input();
     Input(const Input & other);
+    Input & operator=(const Input & other);
     using super::set;
     using super::get;
 

--- a/cpp/daal/include/algorithms/optimization_solver/objective_function/cross_entropy_loss_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/objective_function/cross_entropy_loss_types.h
@@ -98,10 +98,17 @@ struct DAAL_EXPORT Parameter : public sum_of_functions::Parameter
               const DAAL_UINT64 resultsToCompute = objective_function::gradient);
 
     /**
-     * Constructs an Parameter by copying input objects and parameters of another Parameter
-     * \param[in] other An object to be used as the source to initialize object
+     * Constructs a Parameter by copying input objects and parameters of another Parameter
+     * \param[in] other An object to be used as the source object to initialize from
      */
     Parameter(const Parameter & other);
+
+    /**
+     * Assigns a Parameter by copying input objects and parameters of another Parameter
+     * \param[in] other An object to be used as the source object to copy from
+     */
+    Parameter & operator=(const Parameter & other);
+
     /**
      * Checks the correctness of the parameter
      *

--- a/cpp/daal/include/algorithms/optimization_solver/objective_function/cross_entropy_loss_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/objective_function/cross_entropy_loss_types.h
@@ -130,6 +130,9 @@ public:
     /** Copy constructor */
     Input(const Input & other);
 
+    /** Assignment operator */
+    Input & operator=(const Input & other);
+
     /** Destructor */
     virtual ~Input() {}
 

--- a/cpp/daal/include/algorithms/optimization_solver/objective_function/logistic_loss_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/objective_function/logistic_loss_types.h
@@ -97,10 +97,16 @@ struct DAAL_EXPORT Parameter : public sum_of_functions::Parameter
               const DAAL_UINT64 resultsToCompute = objective_function::gradient);
 
     /**
-     * Constructs an Parameter by copying input objects and parameters of another Parameter
-     * \param[in] other An object to be used as the source to initialize object
+     * Constructs a Parameter by copying input objects and parameters of another Parameter
+     * \param[in] other An object to be used as the source object to initialize from
      */
     Parameter(const Parameter & other);
+
+    /**
+     * Assigns a Parameter by copying input objects and parameters of another Parameter
+     * \param[in] other An object to be used as the source object to copy from
+     */
+    Parameter & operator=(const Parameter & other);
     /**
      * Checks the correctness of the parameter
      *

--- a/cpp/daal/include/algorithms/optimization_solver/objective_function/logistic_loss_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/objective_function/logistic_loss_types.h
@@ -107,6 +107,7 @@ struct DAAL_EXPORT Parameter : public sum_of_functions::Parameter
      * \param[in] other An object to be used as the source object to copy from
      */
     Parameter & operator=(const Parameter & other);
+
     /**
      * Checks the correctness of the parameter
      *

--- a/cpp/daal/include/algorithms/optimization_solver/objective_function/logistic_loss_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/objective_function/logistic_loss_types.h
@@ -129,6 +129,9 @@ public:
     /** Copy constructor */
     Input(const Input & other);
 
+    /** Assignment operator */
+    Input & operator=(const Input & other);
+
     /** Destructor */
     virtual ~Input() {}
 

--- a/cpp/daal/include/algorithms/optimization_solver/objective_function/mse_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/objective_function/mse_types.h
@@ -155,6 +155,9 @@ public:
     /** Copy constructor */
     Input(const Input & other);
 
+    /** Assignment operator */
+    Input & operator=(const Input & other);
+
     /** Destructor */
     virtual ~Input() {}
 

--- a/cpp/daal/include/algorithms/optimization_solver/objective_function/mse_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/objective_function/mse_types.h
@@ -118,10 +118,17 @@ struct DAAL_EXPORT Parameter : public sum_of_functions::Parameter
               const DAAL_UINT64 resultsToCompute = objective_function::gradient);
 
     /**
-     * Constructs an Parameter by copying input objects and parameters of another Parameter
-     * \param[in] other An object to be used as the source to initialize object
+     * Constructs a Parameter by copying input objects and parameters of another Parameter
+     * \param[in] other An object to be used as the source object to initialize from
      */
     Parameter(const Parameter & other);
+
+    /**
+     * Assigns a Parameter by copying input objects and parameters of another Parameter
+     * \param[in] other An object to be used as the source object to copy from
+     */
+    Parameter & operator=(const Parameter & other);
+
     /**
      * Checks the correctness of the parameter
      *

--- a/cpp/daal/include/algorithms/optimization_solver/objective_function/objective_function_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/objective_function/objective_function_types.h
@@ -120,10 +120,16 @@ struct DAAL_EXPORT Parameter : public daal::algorithms::Parameter
     Parameter(const DAAL_UINT64 resultsToCompute = gradient);
 
     /**
-     * Constructs an Parameter by copying input objects and parameters of another Parameter
-     * \param[in] other An object to be used as the source to initialize object
+     * Constructs a Parameter by copying input objects and parameters of another Parameter
+     * \param[in] other An object to be used as the source object to initialize from
      */
     Parameter(const Parameter & other);
+
+    /**
+     * Assigns a Parameter by copying input objects and parameters of another Parameter
+     * \param[in] other An object to be used as the source object to copy from
+     */
+    Parameter & operator=(const Parameter & other);
 
     virtual ~Parameter() {}
 

--- a/cpp/daal/include/algorithms/optimization_solver/objective_function/objective_function_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/objective_function/objective_function_types.h
@@ -144,6 +144,9 @@ public:
     /** Copy constructor */
     Input(const Input & other);
 
+    /** Assignment operator */
+    Input & operator=(const Input & other);
+
     /** Destructor */
     virtual ~Input() {}
 

--- a/cpp/daal/include/algorithms/optimization_solver/objective_function/sum_of_functions_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/objective_function/sum_of_functions_types.h
@@ -82,10 +82,16 @@ struct DAAL_EXPORT Parameter : public objective_function::Parameter
               const DAAL_UINT64 resultsToCompute = objective_function::gradient);
 
     /**
-     * Constructs an Parameter by copying input objects and parameters of another Parameter
-     * \param[in] other An object to be used as the source to initialize object
+     * Constructs a Parameter by copying input objects and parameters of another Parameter
+     * \param[in] other An object to be used as the source object to initialize from
      */
     Parameter(const Parameter & other);
+
+    /**
+     * Assigns a Parameter by copying input objects and parameters of another Parameter
+     * \param[in] other An object to be used as the source object to copy from
+     */
+    Parameter & operator=(const Parameter & other);
 
     /**
      * Checks the correctness of the parameter

--- a/cpp/daal/include/algorithms/optimization_solver/objective_function/sum_of_functions_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/objective_function/sum_of_functions_types.h
@@ -118,6 +118,9 @@ public:
     /** Copy constructor */
     Input(const Input & other);
 
+    /** Assignment operator */
+    Input & operator=(const Input & other);
+
     /** Destructor */
     virtual ~Input() {}
 

--- a/cpp/daal/include/algorithms/optimization_solver/saga/saga_types.h
+++ b/cpp/daal/include/algorithms/optimization_solver/saga/saga_types.h
@@ -135,6 +135,7 @@ private:
 public:
     Input();
     Input(const Input & other);
+    Input & operator=(const Input & other);
 
     using super::set;
     using super::get;

--- a/cpp/daal/src/algorithms/objective_function/cross_entropy_loss/cross_entropy_loss_types.cpp
+++ b/cpp/daal/src/algorithms/objective_function/cross_entropy_loss/cross_entropy_loss_types.cpp
@@ -66,6 +66,16 @@ Parameter::Parameter(const Parameter & other)
       nClasses(other.nClasses)
 {}
 
+Parameter & Parameter::operator=(const Parameter & other)
+{
+    sum_of_functions::Parameter::operator=(other);
+    this->interceptFlag = other.interceptFlag;
+    this->penaltyL1     = other.penaltyL1;
+    this->penaltyL2     = other.penaltyL2;
+    this->nClasses      = other.nClasses;
+    return *this;
+}
+
 /**
  * Checks the correctness of the parameter
  */

--- a/cpp/daal/src/algorithms/objective_function/cross_entropy_loss/cross_entropy_loss_types.cpp
+++ b/cpp/daal/src/algorithms/objective_function/cross_entropy_loss/cross_entropy_loss_types.cpp
@@ -82,6 +82,12 @@ Input::Input() : sum_of_functions::Input(lastInputId + 1) {}
 
 Input::Input(const Input & other) : sum_of_functions::Input(other) {}
 
+Input & Input::operator=(const Input & other)
+{
+    sum_of_functions::Input::operator=(other);
+    return *this;
+}
+
 /**
  * Sets one input object for Logistic loss objective function
  * \param[in] id    Identifier of the input object

--- a/cpp/daal/src/algorithms/objective_function/logistic_loss/logistic_loss_types.cpp
+++ b/cpp/daal/src/algorithms/objective_function/logistic_loss/logistic_loss_types.cpp
@@ -73,6 +73,12 @@ Input::Input() : sum_of_functions::Input(lastInputId + 1) {}
 
 Input::Input(const Input & other) : sum_of_functions::Input(other) {}
 
+Input & Input::operator=(const Input & other)
+{
+    sum_of_functions::Input::operator=(other);
+    return *this;
+}
+
 /**
  * Sets one input object for Logistic loss objective function
  * \param[in] id    Identifier of the input object

--- a/cpp/daal/src/algorithms/objective_function/logistic_loss/logistic_loss_types.cpp
+++ b/cpp/daal/src/algorithms/objective_function/logistic_loss/logistic_loss_types.cpp
@@ -58,6 +58,15 @@ Parameter::Parameter(const Parameter & other)
     : sum_of_functions::Parameter(other), penaltyL1(other.penaltyL1), penaltyL2(other.penaltyL2), interceptFlag(other.interceptFlag)
 {}
 
+Parameter & Parameter::operator=(const Parameter & other)
+{
+    sum_of_functions::Parameter::operator=(other);
+    this->penaltyL1     = other.penaltyL1;
+    this->penaltyL2     = other.penaltyL2;
+    this->interceptFlag = other.interceptFlag;
+    return *this;
+}
+
 /**
  * Checks the correctness of the parameter
  */

--- a/cpp/daal/src/algorithms/objective_function/mse/mse_types.cpp
+++ b/cpp/daal/src/algorithms/objective_function/mse/mse_types.cpp
@@ -65,7 +65,7 @@ Parameter::Parameter(const Parameter & other)
  * Assigns a Parameter by copying input objects and parameters of another Parameter
  * \param[in] other An object to be used as the source object to copy from
  */
-Parameter & operator=(const Parameter & other);
+Parameter & Parameter::operator=(const Parameter & other);
 {
     sum_of_functions::Parameter::operator=(other);
     this->interceptFlag = other.interceptFlag;

--- a/cpp/daal/src/algorithms/objective_function/mse/mse_types.cpp
+++ b/cpp/daal/src/algorithms/objective_function/mse/mse_types.cpp
@@ -87,6 +87,12 @@ Input::Input() : sum_of_functions::Input(lastInputId + 1) {}
 
 Input::Input(const Input & other) : sum_of_functions::Input(other) {}
 
+Input & Input::operator=(const Input & other)
+{
+    sum_of_functions::Input::operator=(other);
+    return *this;
+}
+
 /**
  * Sets one input object for Mean squared error objective function
  * \param[in] id    Identifier of the input object

--- a/cpp/daal/src/algorithms/objective_function/mse/mse_types.cpp
+++ b/cpp/daal/src/algorithms/objective_function/mse/mse_types.cpp
@@ -54,12 +54,25 @@ Parameter::Parameter(size_t numberOfTerms, data_management::NumericTablePtr batc
 {}
 
 /**
- * Constructs an Parameter by copying input objects and parameters of another Parameter
- * \param[in] other An object to be used as the source to initialize object
+ * Constructs a Parameter by copying input objects and parameters of another Parameter
+ * \param[in] other An object to be used as the source object to initialize from
  */
 Parameter::Parameter(const Parameter & other)
     : sum_of_functions::Parameter(other), interceptFlag(other.interceptFlag), penaltyL1(other.penaltyL1), penaltyL2(other.penaltyL2)
 {}
+
+/**
+ * Assigns a Parameter by copying input objects and parameters of another Parameter
+ * \param[in] other An object to be used as the source object to copy from
+ */
+Parameter & operator=(const Parameter & other);
+{
+    sum_of_functions::Parameter::operator=(other);
+    this->interceptFlag = other.interceptFlag;
+    this->penaltyL1     = other.penaltyL1;
+    this->penaltyL2     = other.penaltyL2;
+    return *this;
+}
 
 /**
  * Checks the correctness of the parameter

--- a/cpp/daal/src/algorithms/objective_function/mse/mse_types.cpp
+++ b/cpp/daal/src/algorithms/objective_function/mse/mse_types.cpp
@@ -65,7 +65,7 @@ Parameter::Parameter(const Parameter & other)
  * Assigns a Parameter by copying input objects and parameters of another Parameter
  * \param[in] other An object to be used as the source object to copy from
  */
-Parameter & Parameter::operator=(const Parameter & other);
+Parameter & Parameter::operator=(const Parameter & other)
 {
     sum_of_functions::Parameter::operator=(other);
     this->interceptFlag = other.interceptFlag;

--- a/cpp/daal/src/algorithms/objective_function/objective_function_types.cpp
+++ b/cpp/daal/src/algorithms/objective_function/objective_function_types.cpp
@@ -44,7 +44,7 @@ Parameter::Parameter(const Parameter & other) : resultsToCompute(other.resultsTo
 
 Parameter & Parameter::operator=(const Parameter & other)
 {
-    resultsToCompute::operator=(other.resultsToCompute);
+    this->resultsToCompute = other.resultsToCompute;
     return *this;
 }
 

--- a/cpp/daal/src/algorithms/objective_function/objective_function_types.cpp
+++ b/cpp/daal/src/algorithms/objective_function/objective_function_types.cpp
@@ -42,6 +42,12 @@ Parameter::Parameter(const DAAL_UINT64 resultsToCompute) : resultsToCompute(resu
 
 Parameter::Parameter(const Parameter & other) : resultsToCompute(other.resultsToCompute) {}
 
+Parameter & Parameter::operator=(const Parameter & other)
+{
+    resultsToCompute::operator=(other.resultsToCompute);
+    return *this;
+}
+
 /** Default constructor */
 Input::Input(size_t n) : daal::algorithms::Input(n) {}
 Input::Input(const Input & other) : daal::algorithms::Input(other) {}

--- a/cpp/daal/src/algorithms/objective_function/objective_function_types.cpp
+++ b/cpp/daal/src/algorithms/objective_function/objective_function_types.cpp
@@ -45,6 +45,11 @@ Parameter::Parameter(const Parameter & other) : resultsToCompute(other.resultsTo
 /** Default constructor */
 Input::Input(size_t n) : daal::algorithms::Input(n) {}
 Input::Input(const Input & other) : daal::algorithms::Input(other) {}
+Input & Input::operator=(const Input & other)
+{
+    daal::algorithms::Input::operator=(other);
+    return *this;
+}
 
 /**
  * Sets one input object for Objective function

--- a/cpp/daal/src/algorithms/objective_function/sum_of_functions_types.cpp
+++ b/cpp/daal/src/algorithms/objective_function/sum_of_functions_types.cpp
@@ -65,6 +65,12 @@ Input::Input(size_t n) : objective_function::Input(n) {}
 
 Input::Input(const Input & other) : objective_function::Input(other) {}
 
+Input & Input::operator=(const Input & other)
+{
+    objective_function::Input::operator=(other);
+    return *this;
+}
+
 /**
  * Sets one input object for Sum of functions
  * \param[in] id    Identifier of the input object

--- a/cpp/daal/src/algorithms/objective_function/sum_of_functions_types.cpp
+++ b/cpp/daal/src/algorithms/objective_function/sum_of_functions_types.cpp
@@ -49,6 +49,15 @@ Parameter::Parameter(const Parameter & other)
       featureId(other.featureId)
 {}
 
+Parameter & Parameter::operator=(const Parameter & other)
+{
+    objective_function::Parameter::operator=(other.resultsToCompute);
+    this->numberOfTerms = other.numberOfTerms;
+    this->batchIndices  = other.batchIndices;
+    this->featureId     = other.featureId;
+    return *this;
+}
+
 /**
  * Checks the correctness of the parameter
  */

--- a/cpp/daal/src/algorithms/optimization_solver/adagrad/adagrad_types.cpp
+++ b/cpp/daal/src/algorithms/optimization_solver/adagrad/adagrad_types.cpp
@@ -66,6 +66,10 @@ services::Status Parameter::check() const
 
 Input::Input() {}
 Input::Input(const Input & other) {}
+Input & Input::operator=(const Input & other)
+{
+    return *this;
+};
 
 data_management::NumericTablePtr Input::get(OptionalDataId id) const
 {

--- a/cpp/daal/src/algorithms/optimization_solver/coordinate_descent/coordinate_descent_types.cpp
+++ b/cpp/daal/src/algorithms/optimization_solver/coordinate_descent/coordinate_descent_types.cpp
@@ -61,6 +61,10 @@ services::Status Parameter::check() const
 
 Input::Input() {}
 Input::Input(const Input & other) {}
+Input & Input::operator=(const Input & other)
+{
+    return *this;
+};
 
 services::Status Input::check(const daal::algorithms::Parameter * par, int method) const
 {

--- a/cpp/daal/src/algorithms/optimization_solver/iterative_solver_types.cpp
+++ b/cpp/daal/src/algorithms/optimization_solver/iterative_solver_types.cpp
@@ -93,6 +93,11 @@ services::Status Parameter::check() const
 
 Input::Input() : daal::algorithms::Input(lastOptionalInputId + 1) {}
 Input::Input(const Input & other) : daal::algorithms::Input(other) {}
+Input & Input::operator=(const Input & other)
+{
+    daal::algorithms::Input::operator=(other);
+    return *this;
+}
 
 data_management::NumericTablePtr Input::get(InputId id) const
 {

--- a/cpp/daal/src/algorithms/optimization_solver/lbfgs/lbfgs_types.cpp
+++ b/cpp/daal/src/algorithms/optimization_solver/lbfgs/lbfgs_types.cpp
@@ -85,6 +85,10 @@ services::Status Parameter::check() const
 
 Input::Input() {}
 Input::Input(const Input & other) {}
+Input & Input::operator=(const Input & other)
+{
+    return *this;
+}
 
 NumericTablePtr Input::get(OptionalDataId id) const
 {

--- a/cpp/daal/src/algorithms/optimization_solver/saga/saga_types.cpp
+++ b/cpp/daal/src/algorithms/optimization_solver/saga/saga_types.cpp
@@ -73,6 +73,7 @@ services::Status Parameter::check() const
 
 Input::Input() {}
 Input::Input(const Input & other) {}
+Input & Input::operator=(const Input & other) {}
 
 data_management::NumericTablePtr Input::get(OptionalDataId id) const
 {

--- a/cpp/daal/src/algorithms/optimization_solver/saga/saga_types.cpp
+++ b/cpp/daal/src/algorithms/optimization_solver/saga/saga_types.cpp
@@ -73,7 +73,10 @@ services::Status Parameter::check() const
 
 Input::Input() {}
 Input::Input(const Input & other) {}
-Input & Input::operator=(const Input & other) {}
+Input & Input::operator=(const Input & other)
+{
+    return *this;
+}
 
 data_management::NumericTablePtr Input::get(OptionalDataId id) const
 {


### PR DESCRIPTION
<!--
  ~ Copyright 2019 Intel Corporation
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
  ~
  ~     http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-->

## Description

Should solve issues with static analyzers pointing out that there are copy constructors without assignment operators for many of the `Input` and `Parameter` class used in optimization routines and which are exported.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
