### PR TITLE
ENH: Non-batched linear regression for high-dimensional problems

### DIFF
--- a/cpp/daal/src/algorithms/linear_model/linear_model_hyperparameter_impl.h
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_hyperparameter_impl.h
@@ -41,8 +41,11 @@ namespace internal
  */
 enum HyperparameterId
 {
-    denseUpdateStepBlockSize = 0,
-    hyperparameterIdCount    = denseUpdateStepBlockSize + 1
+    denseUpdateStepBlockSize     = 0,
+    denseUpdateMaxColsBatched    = 1,
+    denseSmallRowsThreshold      = 2,
+    denseSmallRowsMaxColsBatched = 3,
+    hyperparameterIdCount        = 4
 };
 
 enum DoubleHyperparameterId

--- a/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
@@ -277,7 +277,7 @@ Status UpdateKernel<algorithmFPType, cpu>::compute(const NumericTable & xTable, 
         DAAL_CHECK_BLOCK_STATUS(yBlock);
         const algorithmFPType * xPtr = xBlock.get();
         const algorithmFPType * yPtr = yBlock.get();
-        return computeNonBatchedAggregates<algorithmFPType, cpu>(nRows, nCols, nResponses, true, interceptFlag, xPtr, yPtr, xtx, xty);
+        return computeNonBatchedAggregates<algorithmFPType, cpu>(nRows, nCols, nResponses, initializeResult, interceptFlag, xPtr, yPtr, xtx, xty);
     }
 
     /* Initialize output arrays by zero in case of batch mode */

--- a/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
@@ -259,7 +259,7 @@ Status UpdateKernel<algorithmFPType, cpu>::compute(const NumericTable & xTable, 
     //                              && (nResponses == 1 || yTable.getDataLayout() == NumericTable::StorageLayout::aos);
     /// For testing purposes, will enable it regardless of input sizes, but this should be changed later.
     bool use_non_batched_route =
-        getDataLayout() == NumericTable::StorageLayout::aos && (nResponses == 1 || yTable.getDataLayout() == NumericTable::StorageLayout::aos);
+        xTable.getDataLayout() == NumericTable::StorageLayout::aos && (nResponses == 1 || yTable.getDataLayout() == NumericTable::StorageLayout::aos);
     if (use_non_batched_route)
     {
         /// Note: this is only implemented for row-major arrays, because there's

--- a/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
@@ -194,7 +194,11 @@ Status computeNonBatchedAggregates(const DAAL_INT nRows, const DAAL_INT nCols, c
     {
         BlasInst<algorithmFPType, cpu>::xgemv("N", &nCols, &nRows, &one, xPtr, &nCols, ones.get(), &one_int, mult_current_data,
                                               xtx + static_cast<size_t>(nBetasIntercept) * static_cast<size_t>(nCols), &one_int);
-        xtx[static_cast<size_t>(nBetasIntercept) * static_cast<size_t>(nBetasIntercept) - 1] = nRows;
+        const size_t idx_last = static_cast<size_t>(nBetasIntercept) * static_cast<size_t>(nBetasIntercept) - 1;
+        if (initializeResult)
+            xtx[idx_last] = nRows;
+        else
+            xtx[idx_last] += nRows;
     }
 
     if (nResponses == 1)

--- a/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
@@ -28,7 +28,6 @@
 #include "src/algorithms/service_error_handling.h"
 #include "src/threading/threading.h"
 #include "src/externals/service_profiler.h"
-#include <memory>
 
 namespace daal
 {
@@ -183,10 +182,10 @@ Status computeNonBatchedAggregates(const DAAL_INT nRows, const DAAL_INT nCols, c
     algorithmFPType one                 = 1;
     algorithmFPType zero                = 0;
     algorithmFPType * mult_current_data = initializeResult ? &zero : &one;
-    std::unique_ptr<algorithmFPType[]> ones;
+    daal::services::internal::TArray<algorithmFPType, cpu> ones;
     if (interceptFlag)
     {
-        ones = std::unique_ptr<algorithmFPType[]>(new algorithmFPType[nRows]);
+        ones = daal::services::internal::TArray<algorithmFPType, cpu>(nRows);
         std::fill(ones.get(), ones.get() + nRows, algorithmFPType(1));
     }
 

--- a/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
@@ -277,11 +277,6 @@ Status UpdateKernel<algorithmFPType, cpu>::compute(const NumericTable & xTable, 
     const bool use_non_batched_route = nBetas >= maxColsBatched || (nRows >= smallRowsThreshold && nBetas >= smallRowsMaxColsBatched);
     if (use_non_batched_route)
     {
-        /// Note: this is only implemented for row-major arrays, because there's
-        /// currently to mechanism to know if a NumericTable is backed by a single
-        /// continuous column-major array. But if such a mechanism is added, there
-        /// shouldn't be any issue in creating a column-major version of this procedure
-        /// or extending it to more than one response.
         const DAAL_INT nCols = xTable.getNumberOfColumns();
         ReadRowsType xBlock(const_cast<NumericTable &>(xTable), 0, nRows);
         DAAL_CHECK_BLOCK_STATUS(xBlock);

--- a/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
@@ -258,11 +258,9 @@ Status UpdateKernel<algorithmFPType, cpu>::compute(const NumericTable & xTable, 
     /// being faster.
 
     /// These are the thresholds where the non-batched route should be used.
-    // bool use_non_batched_route = (nBetas >= 4096 || (nRows <= 10000 && nBetas >= 1024)) && getDataLayout() == NumericTable::StorageLayout::aos
-    //                              && (nResponses == 1 || yTable.getDataLayout() == NumericTable::StorageLayout::aos);
+    // bool use_non_batched_route = nBetas >= 4096 || (nRows <= 10000 && nBetas >= 1024);
     /// For testing purposes, will enable it regardless of input sizes, but this should be changed later.
-    bool use_non_batched_route =
-        xTable.getDataLayout() == NumericTable::StorageLayout::aos && (nResponses == 1 || yTable.getDataLayout() == NumericTable::StorageLayout::aos);
+    bool use_non_batched_route = true;
     if (use_non_batched_route)
     {
         /// Note: this is only implemented for row-major arrays, because there's

--- a/cpp/daal/src/algorithms/linear_regression/linear_regression_hyperparameter.cpp
+++ b/cpp/daal/src/algorithms/linear_regression/linear_regression_hyperparameter.cpp
@@ -64,16 +64,39 @@ services::Status convert(const Hyperparameter * params, services::SharedPtr<Line
 
     if (params != nullptr)
     {
-        DAAL_INT64 denseUpdateStepBlockSize = 0l;
+        DAAL_INT64 denseUpdateStepBlockSize     = 0l;
+        DAAL_INT64 denseUpdateMaxColsBatched    = 0l;
+        DAAL_INT64 denseSmallRowsThreshold      = 0l;
+        DAAL_INT64 denseSmallRowsMaxColsBatched = 0l;
 
         auto * const resultPtr = new LinearModelHyperparameter();
         DAAL_CHECK_MALLOC(resultPtr);
         result.reset(resultPtr);
 
+        /// Getters
         st |= params->find(HyperparameterId::denseUpdateStepBlockSize, denseUpdateStepBlockSize);
         DAAL_CHECK(st, services::ErrorHyperparameterNotFound);
 
+        st |= params->find(HyperparameterId::denseUpdateMaxColsBatched, denseUpdateMaxColsBatched);
+        DAAL_CHECK(st, services::ErrorHyperparameterNotFound);
+
+        st |= params->find(HyperparameterId::denseSmallRowsThreshold, denseSmallRowsThreshold);
+        DAAL_CHECK(st, services::ErrorHyperparameterNotFound);
+
+        st |= params->find(HyperparameterId::denseSmallRowsMaxColsBatched, denseSmallRowsMaxColsBatched);
+        DAAL_CHECK(st, services::ErrorHyperparameterNotFound);
+
+        /// Setters
         st |= result->set(LinearModelHyperparameterId::denseUpdateStepBlockSize, denseUpdateStepBlockSize);
+        DAAL_CHECK(st, services::ErrorHyperparameterCanNotBeSet);
+
+        st |= result->set(LinearModelHyperparameterId::denseUpdateMaxColsBatched, denseUpdateMaxColsBatched);
+        DAAL_CHECK(st, services::ErrorHyperparameterCanNotBeSet);
+
+        st |= result->set(LinearModelHyperparameterId::denseSmallRowsThreshold, denseSmallRowsThreshold);
+        DAAL_CHECK(st, services::ErrorHyperparameterCanNotBeSet);
+
+        st |= result->set(LinearModelHyperparameterId::denseSmallRowsMaxColsBatched, denseSmallRowsMaxColsBatched);
         DAAL_CHECK(st, services::ErrorHyperparameterCanNotBeSet);
     }
     else

--- a/cpp/daal/src/algorithms/linear_regression/linear_regression_hyperparameter_impl.h
+++ b/cpp/daal/src/algorithms/linear_regression/linear_regression_hyperparameter_impl.h
@@ -45,8 +45,11 @@ typedef linear_model::internal::Hyperparameter LinearModelHyperparameter;
  */
 enum HyperparameterId
 {
-    denseUpdateStepBlockSize = 0,
-    hyperparameterIdCount    = denseUpdateStepBlockSize + 1
+    denseUpdateStepBlockSize     = 0,
+    denseUpdateMaxColsBatched    = 1,
+    denseSmallRowsThreshold      = 2,
+    denseSmallRowsMaxColsBatched = 3,
+    hyperparameterIdCount        = 4
 };
 
 enum DoubleHyperparameterId

--- a/cpp/daal/src/externals/service_blas.h
+++ b/cpp/daal/src/externals/service_blas.h
@@ -103,14 +103,14 @@ struct Blas
 {
     typedef typename _impl<fpType, cpu>::SizeType SizeType;
 
-    static void xsyrk(const char * uplo, const char * trans, const SizeType * p, const SizeType * n, const fpType * alpha, const fpType * a, const SizeType * lda, const fpType * beta, fpType * ata,
-                      const SizeType * ldata)
+    static void xsyrk(const char * uplo, const char * trans, const SizeType * p, const SizeType * n, const fpType * alpha, const fpType * a,
+                      const SizeType * lda, const fpType * beta, fpType * ata, const SizeType * ldata)
     {
         _impl<fpType, cpu>::xsyrk(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);
     }
 
-    static void xxsyrk(const char * uplo, const char * trans, SizeType * p, SizeType * n, fpType * alpha, fpType * a, SizeType * lda, fpType * beta, fpType * ata,
-                       const SizeType * ldata)
+    static void xxsyrk(const char * uplo, const char * trans, SizeType * p, SizeType * n, fpType * alpha, fpType * a, SizeType * lda, fpType * beta,
+                       fpType * ata, const SizeType * ldata)
     {
         _impl<fpType, cpu>::xxsyrk(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);
     }

--- a/cpp/daal/src/externals/service_blas.h
+++ b/cpp/daal/src/externals/service_blas.h
@@ -103,14 +103,14 @@ struct Blas
 {
     typedef typename _impl<fpType, cpu>::SizeType SizeType;
 
-    static void xsyrk(char * uplo, char * trans, SizeType * p, SizeType * n, fpType * alpha, fpType * a, SizeType * lda, fpType * beta, fpType * ata,
-                      SizeType * ldata)
+    static void xsyrk(const char * uplo, const char * trans, const SizeType * p, const SizeType * n, const fpType * alpha, const fpType * a, const SizeType * lda, const fpType * beta, fpType * ata,
+                      const SizeType * ldata)
     {
         _impl<fpType, cpu>::xsyrk(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);
     }
 
-    static void xxsyrk(char * uplo, char * trans, SizeType * p, SizeType * n, fpType * alpha, fpType * a, SizeType * lda, fpType * beta, fpType * ata,
-                       SizeType * ldata)
+    static void xxsyrk(const char * uplo, const char * trans, SizeType * p, SizeType * n, fpType * alpha, fpType * a, SizeType * lda, fpType * beta, fpType * ata,
+                       const SizeType * ldata)
     {
         _impl<fpType, cpu>::xxsyrk(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);
     }

--- a/cpp/daal/src/externals/service_blas.h
+++ b/cpp/daal/src/externals/service_blas.h
@@ -109,8 +109,8 @@ struct Blas
         _impl<fpType, cpu>::xsyrk(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);
     }
 
-    static void xxsyrk(const char * uplo, const char * trans, SizeType * p, SizeType * n, fpType * alpha, fpType * a, SizeType * lda, fpType * beta,
-                       fpType * ata, const SizeType * ldata)
+    static void xxsyrk(const char * uplo, const char * trans, const SizeType * p, const SizeType * n, const fpType * alpha, const fpType * a,
+                       const SizeType * lda, const fpType * beta, fpType * ata, const SizeType * ldata)
     {
         _impl<fpType, cpu>::xxsyrk(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);
     }

--- a/cpp/daal/src/externals/service_blas_declar_ref.h
+++ b/cpp/daal/src/externals/service_blas_declar_ref.h
@@ -34,10 +34,10 @@ namespace ref
 {
 extern "C"
 {
-    extern void ssyrk_(const char *, const char *, const DAAL_INT *, const DAAL_INT *, const float *, float *, const DAAL_INT *, const float *,
+    extern void ssyrk_(const char *, const char *, const DAAL_INT *, const DAAL_INT *, const float *, const float *, const DAAL_INT *, const float *,
                        float *, const DAAL_INT *);
-    extern void dsyrk_(const char *, const char *, const DAAL_INT *, const DAAL_INT *, const double *, double *, const DAAL_INT *, const double *,
-                       double *, const DAAL_INT *);
+    extern void dsyrk_(const char *, const char *, const DAAL_INT *, const DAAL_INT *, const double *, const double *, const DAAL_INT *,
+                       const double *, double *, const DAAL_INT *);
 
     extern void ssyr_(const char *, const DAAL_INT *, const float *, const float *, const DAAL_INT *, float *, const DAAL_INT *);
     extern void dsyr_(const char *, const DAAL_INT *, const double *, const double *, const DAAL_INT *, double *, const DAAL_INT *);

--- a/cpp/daal/src/externals/service_blas_mkl.h
+++ b/cpp/daal/src/externals/service_blas_mkl.h
@@ -50,14 +50,14 @@ struct MklBlas<double, cpu>
 {
     typedef DAAL_INT SizeType;
 
-    static void xsyrk(char * uplo, char * trans, DAAL_INT * p, DAAL_INT * n, double * alpha, double * a, DAAL_INT * lda, double * beta, double * ata,
-                      DAAL_INT * ldata)
+    static void xsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const double * alpha, const double * a, const DAAL_INT * lda, const double * beta, double * ata,
+                      const DAAL_INT * ldata)
     {
         __DAAL_MKLFN_CALL_BLAS(dsyrk, (uplo, trans, (MKL_INT *)p, (MKL_INT *)n, alpha, a, (MKL_INT *)lda, beta, ata, (MKL_INT *)ldata));
     }
 
-    static void xxsyrk(char * uplo, char * trans, DAAL_INT * p, DAAL_INT * n, double * alpha, double * a, DAAL_INT * lda, double * beta, double * ata,
-                       DAAL_INT * ldata)
+    static void xxsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const double * alpha, const double * a, const DAAL_INT * lda, const double * beta, double * ata,
+                       const DAAL_INT * ldata)
     {
         int old_nthr = mkl_set_num_threads_local(1);
         __DAAL_MKLFN_CALL_BLAS(dsyrk, (uplo, trans, (MKL_INT *)p, (MKL_INT *)n, alpha, a, (MKL_INT *)lda, beta, ata, (MKL_INT *)ldata));
@@ -155,14 +155,14 @@ struct MklBlas<float, cpu>
 {
     typedef DAAL_INT SizeType;
 
-    static void xsyrk(char * uplo, char * trans, DAAL_INT * p, DAAL_INT * n, float * alpha, float * a, DAAL_INT * lda, float * beta, float * ata,
-                      DAAL_INT * ldata)
+    static void xsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const float * alpha, const float * a, const DAAL_INT * lda, const float * beta, float * ata,
+                      const DAAL_INT * ldata)
     {
         __DAAL_MKLFN_CALL_BLAS(ssyrk, (uplo, trans, (MKL_INT *)p, (MKL_INT *)n, alpha, a, (MKL_INT *)lda, beta, ata, (MKL_INT *)ldata));
     }
 
-    static void xxsyrk(char * uplo, char * trans, DAAL_INT * p, DAAL_INT * n, float * alpha, float * a, DAAL_INT * lda, float * beta, float * ata,
-                       DAAL_INT * ldata)
+    static void xxsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const float * alpha, const float * a, const DAAL_INT * lda, const float * beta, float * ata,
+                       const DAAL_INT * ldata)
     {
         int old_nthr = mkl_set_num_threads_local(1);
         __DAAL_MKLFN_CALL_BLAS(ssyrk, (uplo, trans, (MKL_INT *)p, (MKL_INT *)n, alpha, a, (MKL_INT *)lda, beta, ata, (MKL_INT *)ldata));

--- a/cpp/daal/src/externals/service_blas_mkl.h
+++ b/cpp/daal/src/externals/service_blas_mkl.h
@@ -50,14 +50,14 @@ struct MklBlas<double, cpu>
 {
     typedef DAAL_INT SizeType;
 
-    static void xsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const double * alpha, const double * a, const DAAL_INT * lda, const double * beta, double * ata,
-                      const DAAL_INT * ldata)
+    static void xsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const double * alpha, const double * a,
+                      const DAAL_INT * lda, const double * beta, double * ata, const DAAL_INT * ldata)
     {
         __DAAL_MKLFN_CALL_BLAS(dsyrk, (uplo, trans, (MKL_INT *)p, (MKL_INT *)n, alpha, a, (MKL_INT *)lda, beta, ata, (MKL_INT *)ldata));
     }
 
-    static void xxsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const double * alpha, const double * a, const DAAL_INT * lda, const double * beta, double * ata,
-                       const DAAL_INT * ldata)
+    static void xxsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const double * alpha, const double * a,
+                       const DAAL_INT * lda, const double * beta, double * ata, const DAAL_INT * ldata)
     {
         int old_nthr = mkl_set_num_threads_local(1);
         __DAAL_MKLFN_CALL_BLAS(dsyrk, (uplo, trans, (MKL_INT *)p, (MKL_INT *)n, alpha, a, (MKL_INT *)lda, beta, ata, (MKL_INT *)ldata));
@@ -155,14 +155,14 @@ struct MklBlas<float, cpu>
 {
     typedef DAAL_INT SizeType;
 
-    static void xsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const float * alpha, const float * a, const DAAL_INT * lda, const float * beta, float * ata,
-                      const DAAL_INT * ldata)
+    static void xsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const float * alpha, const float * a,
+                      const DAAL_INT * lda, const float * beta, float * ata, const DAAL_INT * ldata)
     {
         __DAAL_MKLFN_CALL_BLAS(ssyrk, (uplo, trans, (MKL_INT *)p, (MKL_INT *)n, alpha, a, (MKL_INT *)lda, beta, ata, (MKL_INT *)ldata));
     }
 
-    static void xxsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const float * alpha, const float * a, const DAAL_INT * lda, const float * beta, float * ata,
-                       const DAAL_INT * ldata)
+    static void xxsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const float * alpha, const float * a,
+                       const DAAL_INT * lda, const float * beta, float * ata, const DAAL_INT * ldata)
     {
         int old_nthr = mkl_set_num_threads_local(1);
         __DAAL_MKLFN_CALL_BLAS(ssyrk, (uplo, trans, (MKL_INT *)p, (MKL_INT *)n, alpha, a, (MKL_INT *)lda, beta, ata, (MKL_INT *)ldata));

--- a/cpp/daal/src/externals/service_blas_ref.h
+++ b/cpp/daal/src/externals/service_blas_ref.h
@@ -139,7 +139,7 @@ struct OpenBlas<float, cpu>
     typedef DAAL_INT SizeType;
 
     static void xsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const float * alpha, const float * a,
-                      const DAAL_INT * lda, const const float * beta, float * ata, const DAAL_INT * ldata)
+                      const DAAL_INT * lda, const float * beta, float * ata, const DAAL_INT * ldata)
     {
         ssyrk_(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);
     }

--- a/cpp/daal/src/externals/service_blas_ref.h
+++ b/cpp/daal/src/externals/service_blas_ref.h
@@ -46,14 +46,14 @@ struct OpenBlas<double, cpu>
 {
     typedef DAAL_INT SizeType;
 
-    static void xsyrk(char * uplo, char * trans, DAAL_INT * p, DAAL_INT * n, double * alpha, double * a, DAAL_INT * lda, double * beta, double * ata,
-                      DAAL_INT * ldata)
+    static void xsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const double * alpha, const double * a, const DAAL_INT * lda, const double * beta, double * ata,
+                      const DAAL_INT * ldata)
     {
         dsyrk_(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);
     }
 
-    static void xxsyrk(char * uplo, char * trans, DAAL_INT * p, DAAL_INT * n, double * alpha, double * a, DAAL_INT * lda, double * beta, double * ata,
-                       DAAL_INT * ldata)
+    static void xxsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const double * alpha, const double * a, const DAAL_INT * lda, const double * beta, double * ata,
+                       const DAAL_INT * ldata)
     {
         openblas_thread_setter ots(1);
         dsyrk_(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);
@@ -138,14 +138,14 @@ struct OpenBlas<float, cpu>
 {
     typedef DAAL_INT SizeType;
 
-    static void xsyrk(char * uplo, char * trans, DAAL_INT * p, DAAL_INT * n, float * alpha, float * a, DAAL_INT * lda, float * beta, float * ata,
-                      DAAL_INT * ldata)
+    static void xsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const float * alpha, const float * a, const DAAL_INT * lda, const fconst loat * beta, float * ata,
+                      const DAAL_INT * ldata)
     {
         ssyrk_(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);
     }
 
-    static void xxsyrk(char * uplo, char * trans, DAAL_INT * p, DAAL_INT * n, float * alpha, float * a, DAAL_INT * lda, float * beta, float * ata,
-                       DAAL_INT * ldata)
+    static void xxsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const float * alpha, const float * a, const DAAL_INT * lda, const float * beta, float * ata,
+                       const DAAL_INT * ldata)
     {
         openblas_thread_setter ots(1);
         ssyrk_(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);

--- a/cpp/daal/src/externals/service_blas_ref.h
+++ b/cpp/daal/src/externals/service_blas_ref.h
@@ -138,7 +138,7 @@ struct OpenBlas<float, cpu>
 {
     typedef DAAL_INT SizeType;
 
-    static void xsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const float * alpha, const float * a, const DAAL_INT * lda, const fconst loat * beta, float * ata,
+    static void xsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const float * alpha, const float * a, const DAAL_INT * lda, const const float * beta, float * ata,
                       const DAAL_INT * ldata)
     {
         ssyrk_(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);

--- a/cpp/daal/src/externals/service_blas_ref.h
+++ b/cpp/daal/src/externals/service_blas_ref.h
@@ -46,14 +46,14 @@ struct OpenBlas<double, cpu>
 {
     typedef DAAL_INT SizeType;
 
-    static void xsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const double * alpha, const double * a, const DAAL_INT * lda, const double * beta, double * ata,
-                      const DAAL_INT * ldata)
+    static void xsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const double * alpha, const double * a,
+                      const DAAL_INT * lda, const double * beta, double * ata, const DAAL_INT * ldata)
     {
         dsyrk_(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);
     }
 
-    static void xxsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const double * alpha, const double * a, const DAAL_INT * lda, const double * beta, double * ata,
-                       const DAAL_INT * ldata)
+    static void xxsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const double * alpha, const double * a,
+                       const DAAL_INT * lda, const double * beta, double * ata, const DAAL_INT * ldata)
     {
         openblas_thread_setter ots(1);
         dsyrk_(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);
@@ -138,14 +138,14 @@ struct OpenBlas<float, cpu>
 {
     typedef DAAL_INT SizeType;
 
-    static void xsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const float * alpha, const float * a, const DAAL_INT * lda, const const float * beta, float * ata,
-                      const DAAL_INT * ldata)
+    static void xsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const float * alpha, const float * a,
+                      const DAAL_INT * lda, const const float * beta, float * ata, const DAAL_INT * ldata)
     {
         ssyrk_(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);
     }
 
-    static void xxsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const float * alpha, const float * a, const DAAL_INT * lda, const float * beta, float * ata,
-                       const DAAL_INT * ldata)
+    static void xxsyrk(const char * uplo, const char * trans, const DAAL_INT * p, const DAAL_INT * n, const float * alpha, const float * a,
+                       const DAAL_INT * lda, const float * beta, float * ata, const DAAL_INT * ldata)
     {
         openblas_thread_setter ots(1);
         ssyrk_(uplo, trans, p, n, alpha, a, lda, beta, ata, ldata);

--- a/cpp/oneapi/dal/algo/linear_regression/backend/cpu/finalize_train_kernel_norm_eq.cpp
+++ b/cpp/oneapi/dal/algo/linear_regression/backend/cpu/finalize_train_kernel_norm_eq.cpp
@@ -55,9 +55,20 @@ static daal_lr_hyperparameters_t convert_parameters(const detail::train_paramete
     using daal_lr::internal::HyperparameterId;
 
     const std::int64_t block = params.get_cpu_macro_block();
+    const std::int64_t max_cols_batched = params.get_cpu_max_cols_batched();
+    const std::int64_t small_rows_threshold = params.get_cpu_small_rows_threshold();
+    const std::int64_t small_rows_max_cols_batched = params.get_cpu_small_rows_max_cols_batched();
 
     daal_lr_hyperparameters_t daal_hyperparameter;
     auto status = daal_hyperparameter.set(HyperparameterId::denseUpdateStepBlockSize, block);
+    interop::status_to_exception(status);
+    status = daal_hyperparameter.set(HyperparameterId::denseUpdateMaxColsBatched, max_cols_batched);
+    interop::status_to_exception(status);
+    status =
+        daal_hyperparameter.set(HyperparameterId::denseSmallRowsThreshold, small_rows_threshold);
+    interop::status_to_exception(status);
+    status = daal_hyperparameter.set(HyperparameterId::denseSmallRowsMaxColsBatched,
+                                     small_rows_max_cols_batched);
     interop::status_to_exception(status);
 
     return daal_hyperparameter;

--- a/cpp/oneapi/dal/algo/linear_regression/backend/cpu/finalize_train_kernel_norm_eq.cpp
+++ b/cpp/oneapi/dal/algo/linear_regression/backend/cpu/finalize_train_kernel_norm_eq.cpp
@@ -28,6 +28,7 @@
 #include "oneapi/dal/algo/linear_regression/train_types.hpp"
 #include "oneapi/dal/algo/linear_regression/backend/model_impl.hpp"
 #include "oneapi/dal/algo/linear_regression/backend/cpu/finalize_train_kernel.hpp"
+#include "oneapi/dal/algo/linear_regression/backend/cpu/train_kernel_common.hpp"
 
 namespace oneapi::dal::linear_regression::backend {
 
@@ -49,30 +50,6 @@ using online_lr_kernel_t = daal_lr::training::internal::OnlineKernel<Float, daal
 
 template <typename Float, daal::CpuType Cpu>
 using online_rr_kernel_t = daal_rr::training::internal::OnlineKernel<Float, daal_rr_method, Cpu>;
-
-template <typename Float, typename Task>
-static daal_lr_hyperparameters_t convert_parameters(const detail::train_parameters<Task>& params) {
-    using daal_lr::internal::HyperparameterId;
-
-    const std::int64_t block = params.get_cpu_macro_block();
-    const std::int64_t max_cols_batched = params.get_cpu_max_cols_batched();
-    const std::int64_t small_rows_threshold = params.get_cpu_small_rows_threshold();
-    const std::int64_t small_rows_max_cols_batched = params.get_cpu_small_rows_max_cols_batched();
-
-    daal_lr_hyperparameters_t daal_hyperparameter;
-    auto status = daal_hyperparameter.set(HyperparameterId::denseUpdateStepBlockSize, block);
-    interop::status_to_exception(status);
-    status = daal_hyperparameter.set(HyperparameterId::denseUpdateMaxColsBatched, max_cols_batched);
-    interop::status_to_exception(status);
-    status =
-        daal_hyperparameter.set(HyperparameterId::denseSmallRowsThreshold, small_rows_threshold);
-    interop::status_to_exception(status);
-    status = daal_hyperparameter.set(HyperparameterId::denseSmallRowsMaxColsBatched,
-                                     small_rows_max_cols_batched);
-    interop::status_to_exception(status);
-
-    return daal_hyperparameter;
-}
 
 template <typename Float, typename Task>
 static train_result<Task> call_daal_kernel_finalize(const context_cpu& ctx,

--- a/cpp/oneapi/dal/algo/linear_regression/backend/cpu/partial_train_kernel_norm_eq.cpp
+++ b/cpp/oneapi/dal/algo/linear_regression/backend/cpu/partial_train_kernel_norm_eq.cpp
@@ -47,9 +47,20 @@ static daal_hyperparameters_t convert_parameters(const detail::train_parameters<
     using daal_lr::internal::HyperparameterId;
 
     const std::int64_t block = params.get_cpu_macro_block();
+    const std::int64_t max_cols_batched = params.get_cpu_max_cols_batched();
+    const std::int64_t small_rows_threshold = params.get_cpu_small_rows_threshold();
+    const std::int64_t small_rows_max_cols_batched = params.get_cpu_small_rows_max_cols_batched();
 
     daal_hyperparameters_t daal_hyperparameter;
     auto status = daal_hyperparameter.set(HyperparameterId::denseUpdateStepBlockSize, block);
+    interop::status_to_exception(status);
+    status = daal_hyperparameter.set(HyperparameterId::denseUpdateMaxColsBatched, max_cols_batched);
+    interop::status_to_exception(status);
+    status =
+        daal_hyperparameter.set(HyperparameterId::denseSmallRowsThreshold, small_rows_threshold);
+    interop::status_to_exception(status);
+    status = daal_hyperparameter.set(HyperparameterId::denseSmallRowsMaxColsBatched,
+                                     small_rows_max_cols_batched);
     interop::status_to_exception(status);
 
     return daal_hyperparameter;

--- a/cpp/oneapi/dal/algo/linear_regression/backend/cpu/partial_train_kernel_norm_eq.cpp
+++ b/cpp/oneapi/dal/algo/linear_regression/backend/cpu/partial_train_kernel_norm_eq.cpp
@@ -25,6 +25,7 @@
 #include "oneapi/dal/algo/linear_regression/train_types.hpp"
 #include "oneapi/dal/algo/linear_regression/backend/model_impl.hpp"
 #include "oneapi/dal/algo/linear_regression/backend/cpu/partial_train_kernel.hpp"
+#include "oneapi/dal/algo/linear_regression/backend/cpu/train_kernel_common.hpp"
 
 namespace oneapi::dal::linear_regression::backend {
 
@@ -41,30 +42,6 @@ constexpr auto daal_method = daal_lr::training::normEqDense;
 
 template <typename Float, daal::CpuType Cpu>
 using online_kernel_t = daal_lr::training::internal::OnlineKernel<Float, daal_method, Cpu>;
-
-template <typename Float, typename Task>
-static daal_hyperparameters_t convert_parameters(const detail::train_parameters<Task>& params) {
-    using daal_lr::internal::HyperparameterId;
-
-    const std::int64_t block = params.get_cpu_macro_block();
-    const std::int64_t max_cols_batched = params.get_cpu_max_cols_batched();
-    const std::int64_t small_rows_threshold = params.get_cpu_small_rows_threshold();
-    const std::int64_t small_rows_max_cols_batched = params.get_cpu_small_rows_max_cols_batched();
-
-    daal_hyperparameters_t daal_hyperparameter;
-    auto status = daal_hyperparameter.set(HyperparameterId::denseUpdateStepBlockSize, block);
-    interop::status_to_exception(status);
-    status = daal_hyperparameter.set(HyperparameterId::denseUpdateMaxColsBatched, max_cols_batched);
-    interop::status_to_exception(status);
-    status =
-        daal_hyperparameter.set(HyperparameterId::denseSmallRowsThreshold, small_rows_threshold);
-    interop::status_to_exception(status);
-    status = daal_hyperparameter.set(HyperparameterId::denseSmallRowsMaxColsBatched,
-                                     small_rows_max_cols_batched);
-    interop::status_to_exception(status);
-
-    return daal_hyperparameter;
-}
 
 template <typename Float, typename Task>
 static partial_train_result<Task> call_daal_kernel(const context_cpu& ctx,

--- a/cpp/oneapi/dal/algo/linear_regression/backend/cpu/train_kernel_common.hpp
+++ b/cpp/oneapi/dal/algo/linear_regression/backend/cpu/train_kernel_common.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright contributors to the oneDAL project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "oneapi/dal/backend/interop/common.hpp"
 
 #include "oneapi/dal/algo/linear_regression/common.hpp"

--- a/cpp/oneapi/dal/algo/linear_regression/backend/cpu/train_kernel_common.hpp
+++ b/cpp/oneapi/dal/algo/linear_regression/backend/cpu/train_kernel_common.hpp
@@ -1,0 +1,36 @@
+#include "oneapi/dal/backend/interop/common.hpp"
+
+#include "oneapi/dal/algo/linear_regression/common.hpp"
+#include "oneapi/dal/algo/linear_regression/train_types.hpp"
+
+namespace oneapi::dal::linear_regression::backend {
+
+namespace daal_lr = daal::algorithms::linear_regression;
+using daal_lr_hyperparameters_t = daal_lr::internal::Hyperparameter;
+namespace interop = dal::backend::interop;
+
+template <typename Float, typename Task>
+static daal_lr_hyperparameters_t convert_parameters(const detail::train_parameters<Task>& params) {
+    using daal_lr::internal::HyperparameterId;
+
+    const std::int64_t block = params.get_cpu_macro_block();
+    const std::int64_t max_cols_batched = params.get_cpu_max_cols_batched();
+    const std::int64_t small_rows_threshold = params.get_cpu_small_rows_threshold();
+    const std::int64_t small_rows_max_cols_batched = params.get_cpu_small_rows_max_cols_batched();
+
+    daal_lr_hyperparameters_t daal_hyperparameter;
+    auto status = daal_hyperparameter.set(HyperparameterId::denseUpdateStepBlockSize, block);
+    interop::status_to_exception(status);
+    status = daal_hyperparameter.set(HyperparameterId::denseUpdateMaxColsBatched, max_cols_batched);
+    interop::status_to_exception(status);
+    status =
+        daal_hyperparameter.set(HyperparameterId::denseSmallRowsThreshold, small_rows_threshold);
+    interop::status_to_exception(status);
+    status = daal_hyperparameter.set(HyperparameterId::denseSmallRowsMaxColsBatched,
+                                     small_rows_max_cols_batched);
+    interop::status_to_exception(status);
+
+    return daal_hyperparameter;
+}
+
+} // namespace oneapi::dal::linear_regression::backend

--- a/cpp/oneapi/dal/algo/linear_regression/backend/cpu/train_kernel_norm_eq.cpp
+++ b/cpp/oneapi/dal/algo/linear_regression/backend/cpu/train_kernel_norm_eq.cpp
@@ -30,6 +30,7 @@
 #include "oneapi/dal/algo/linear_regression/train_types.hpp"
 #include "oneapi/dal/algo/linear_regression/backend/model_impl.hpp"
 #include "oneapi/dal/algo/linear_regression/backend/cpu/train_kernel.hpp"
+#include "oneapi/dal/algo/linear_regression/backend/cpu/train_kernel_common.hpp"
 
 namespace oneapi::dal::linear_regression::backend {
 
@@ -52,30 +53,6 @@ using batch_lr_kernel_t = daal_lr::training::internal::BatchKernel<Float, daal_l
 
 template <typename Float, daal::CpuType Cpu>
 using batch_rr_kernel_t = daal_rr::training::internal::BatchKernel<Float, daal_rr_method, Cpu>;
-
-template <typename Float, typename Task>
-static daal_lr_hyperparameters_t convert_parameters(const detail::train_parameters<Task>& params) {
-    using daal_lr::internal::HyperparameterId;
-
-    const std::int64_t block = params.get_cpu_macro_block();
-    const std::int64_t max_cols_batched = params.get_cpu_max_cols_batched();
-    const std::int64_t small_rows_threshold = params.get_cpu_small_rows_threshold();
-    const std::int64_t small_rows_max_cols_batched = params.get_cpu_small_rows_max_cols_batched();
-
-    daal_lr_hyperparameters_t daal_hyperparameter;
-    auto status = daal_hyperparameter.set(HyperparameterId::denseUpdateStepBlockSize, block);
-    interop::status_to_exception(status);
-    status = daal_hyperparameter.set(HyperparameterId::denseUpdateMaxColsBatched, max_cols_batched);
-    interop::status_to_exception(status);
-    status =
-        daal_hyperparameter.set(HyperparameterId::denseSmallRowsThreshold, small_rows_threshold);
-    interop::status_to_exception(status);
-    status = daal_hyperparameter.set(HyperparameterId::denseSmallRowsMaxColsBatched,
-                                     small_rows_max_cols_batched);
-    interop::status_to_exception(status);
-
-    return daal_hyperparameter;
-}
 
 template <typename Float, typename Task>
 static train_result<Task> call_daal_kernel(const context_cpu& ctx,

--- a/cpp/oneapi/dal/algo/linear_regression/backend/cpu/train_kernel_norm_eq.cpp
+++ b/cpp/oneapi/dal/algo/linear_regression/backend/cpu/train_kernel_norm_eq.cpp
@@ -58,9 +58,20 @@ static daal_lr_hyperparameters_t convert_parameters(const detail::train_paramete
     using daal_lr::internal::HyperparameterId;
 
     const std::int64_t block = params.get_cpu_macro_block();
+    const std::int64_t max_cols_batched = params.get_cpu_max_cols_batched();
+    const std::int64_t small_rows_threshold = params.get_cpu_small_rows_threshold();
+    const std::int64_t small_rows_max_cols_batched = params.get_cpu_small_rows_max_cols_batched();
 
     daal_lr_hyperparameters_t daal_hyperparameter;
     auto status = daal_hyperparameter.set(HyperparameterId::denseUpdateStepBlockSize, block);
+    interop::status_to_exception(status);
+    status = daal_hyperparameter.set(HyperparameterId::denseUpdateMaxColsBatched, max_cols_batched);
+    interop::status_to_exception(status);
+    status =
+        daal_hyperparameter.set(HyperparameterId::denseSmallRowsThreshold, small_rows_threshold);
+    interop::status_to_exception(status);
+    status = daal_hyperparameter.set(HyperparameterId::denseSmallRowsMaxColsBatched,
+                                     small_rows_max_cols_batched);
     interop::status_to_exception(status);
 
     return daal_hyperparameter;

--- a/cpp/oneapi/dal/algo/linear_regression/parameters/cpu/train_parameters.cpp
+++ b/cpp/oneapi/dal/algo/linear_regression/parameters/cpu/train_parameters.cpp
@@ -39,6 +39,21 @@ std::int64_t propose_block_size(const std::int64_t f, const std::int64_t r) {
 }
 
 template <typename Float, typename Task>
+std::int64_t propose_max_cols_batched(const std::int64_t f, const std::int64_t r) {
+    return detail::train_parameters<Task>{}.get_cpu_max_cols_batched();
+}
+
+template <typename Float, typename Task>
+std::int64_t propose_small_rows_threshold(const std::int64_t f, const std::int64_t r) {
+    return detail::train_parameters<Task>{}.get_cpu_small_rows_threshold();
+}
+
+template <typename Float, typename Task>
+std::int64_t propose_small_rows_max_cols_batched(const std::int64_t f, const std::int64_t r) {
+    return detail::train_parameters<Task>{}.get_cpu_small_rows_max_cols_batched();
+}
+
+template <typename Float, typename Task>
 struct train_parameters_cpu<Float, method::norm_eq, Task> {
     using params_t = detail::train_parameters<Task>;
     params_t operator()(const context_cpu& ctx,
@@ -50,9 +65,20 @@ struct train_parameters_cpu<Float, method::norm_eq, Task> {
         const auto f_count = x_train.get_column_count();
         const auto r_count = y_train.get_column_count();
 
-        const auto block = propose_block_size<Float>(f_count, r_count);
+        const std::int64_t block = propose_block_size<Float>(f_count, r_count);
+        const std::int64_t max_cols_batched =
+            propose_max_cols_batched<Float, Task>(f_count, r_count);
+        const std::int64_t small_rows_threshold =
+            propose_small_rows_threshold<Float, Task>(f_count, r_count);
+        const std::int64_t small_rows_max_cols_batched =
+            propose_small_rows_max_cols_batched<Float, Task>(f_count, r_count);
 
-        return params_t{}.set_cpu_macro_block(block);
+        params_t out{};
+        out.set_cpu_macro_block(block);
+        out.set_cpu_max_cols_batched(max_cols_batched);
+        out.set_cpu_small_rows_threshold(small_rows_threshold);
+        out.set_cpu_small_rows_max_cols_batched(small_rows_max_cols_batched);
+        return out;
     }
     params_t operator()(const context_cpu& ctx,
                         const detail::descriptor_base<Task>& desc,
@@ -63,9 +89,20 @@ struct train_parameters_cpu<Float, method::norm_eq, Task> {
         const auto f_count = x_train.get_column_count();
         const auto r_count = y_train.get_column_count();
 
-        const auto block = propose_block_size<Float>(f_count, r_count);
+        const std::int64_t block = propose_block_size<Float>(f_count, r_count);
+        const std::int64_t max_cols_batched =
+            propose_max_cols_batched<Float, Task>(f_count, r_count);
+        const std::int64_t small_rows_threshold =
+            propose_small_rows_threshold<Float, Task>(f_count, r_count);
+        const std::int64_t small_rows_max_cols_batched =
+            propose_small_rows_max_cols_batched<Float, Task>(f_count, r_count);
 
-        return params_t{}.set_cpu_macro_block(block);
+        params_t out{};
+        out.set_cpu_macro_block(block);
+        out.set_cpu_max_cols_batched(max_cols_batched);
+        out.set_cpu_small_rows_threshold(small_rows_threshold);
+        out.set_cpu_small_rows_max_cols_batched(small_rows_max_cols_batched);
+        return out;
     }
     params_t operator()(const context_cpu& ctx,
                         const detail::descriptor_base<Task>& desc,
@@ -76,9 +113,20 @@ struct train_parameters_cpu<Float, method::norm_eq, Task> {
         const auto f_count = xtx.get_column_count();
         const auto r_count = xty.get_column_count();
 
-        const auto block = propose_block_size<Float>(f_count, r_count);
+        const std::int64_t block = propose_block_size<Float>(f_count, r_count);
+        const std::int64_t max_cols_batched =
+            propose_max_cols_batched<Float, Task>(f_count, r_count);
+        const std::int64_t small_rows_threshold =
+            propose_small_rows_threshold<Float, Task>(f_count, r_count);
+        const std::int64_t small_rows_max_cols_batched =
+            propose_small_rows_max_cols_batched<Float, Task>(f_count, r_count);
 
-        return params_t{}.set_cpu_macro_block(block);
+        params_t out{};
+        out.set_cpu_macro_block(block);
+        out.set_cpu_max_cols_batched(max_cols_batched);
+        out.set_cpu_small_rows_threshold(small_rows_threshold);
+        out.set_cpu_small_rows_max_cols_batched(small_rows_max_cols_batched);
+        return out;
     }
 };
 template struct ONEDAL_EXPORT train_parameters_cpu<float, method::norm_eq, task::regression>;

--- a/cpp/oneapi/dal/algo/linear_regression/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/linear_regression/test/batch.cpp
@@ -39,6 +39,9 @@ public:
         this->f_count_ = GENERATE(2, 17);
         this->r_count_ = GENERATE(2, 15);
         this->intercept_ = GENERATE(0, 1);
+        if (this->get_policy().is_cpu()) {
+            this->use_non_batched_route = GENERATE(false, true);
+        }
     }
 };
 

--- a/cpp/oneapi/dal/algo/linear_regression/test/fixture.hpp
+++ b/cpp/oneapi/dal/algo/linear_regression/test/fixture.hpp
@@ -72,6 +72,20 @@ public:
         }
     }
 
+    template <typename... Args>
+    auto partial_train(Args&&... args) {
+        if (!this->use_non_batched_route || !this->get_policy().is_cpu())
+            return te::crtp_algo_fixture<TestType, Derived>::partial_train(
+                std::forward<Args>(args)...);
+        else {
+            detail::train_parameters parameters{};
+            parameters.set_cpu_max_cols_batched(1);
+            return te::crtp_algo_fixture<TestType, Derived>::partial_train_with_parameters(
+                parameters,
+                std::forward<Args>(args)...);
+        }
+    }
+
     te::table_id get_homogen_table_id() const {
         return te::table_id::homogen<float_t>();
     }

--- a/cpp/oneapi/dal/algo/linear_regression/test/fixture.hpp
+++ b/cpp/oneapi/dal/algo/linear_regression/test/fixture.hpp
@@ -57,6 +57,21 @@ public:
     using partial_input_t = partial_train_input<>;
     using partial_result_t = partial_train_result<>;
 
+    bool use_non_batched_route = false;
+
+    template <typename... Args>
+    auto train(Args&&... args) {
+        if (!this->use_non_batched_route || !this->get_policy().is_cpu())
+            return te::crtp_algo_fixture<TestType, Derived>::train(std::forward<Args>(args)...);
+        else {
+            detail::train_parameters parameters{};
+            parameters.set_cpu_max_cols_batched(1);
+            return te::crtp_algo_fixture<TestType, Derived>::train_with_parameters(
+                parameters,
+                std::forward<Args>(args)...);
+        }
+    }
+
     te::table_id get_homogen_table_id() const {
         return te::table_id::homogen<float_t>();
     }

--- a/cpp/oneapi/dal/algo/linear_regression/test/online.cpp
+++ b/cpp/oneapi/dal/algo/linear_regression/test/online.cpp
@@ -39,6 +39,9 @@ public:
         this->f_count_ = GENERATE(2, 17);
         this->r_count_ = GENERATE(2, 15);
         this->intercept_ = GENERATE(0, 1);
+        if (this->get_policy().is_cpu()) {
+            this->use_non_batched_route = GENERATE(false, true);
+        }
     }
 };
 

--- a/cpp/oneapi/dal/algo/linear_regression/train_types.cpp
+++ b/cpp/oneapi/dal/algo/linear_regression/train_types.cpp
@@ -25,7 +25,7 @@ namespace detail::v1 {
 template <typename Task>
 class train_input_impl : public base {
 public:
-    train_input_impl() : data(table()) {};
+    train_input_impl() : data(table()){};
     train_input_impl(const table& data, const table& responses = table{})
             : data(data),
               responses(responses) {}

--- a/cpp/oneapi/dal/algo/linear_regression/train_types.cpp
+++ b/cpp/oneapi/dal/algo/linear_regression/train_types.cpp
@@ -25,7 +25,7 @@ namespace detail::v1 {
 template <typename Task>
 class train_input_impl : public base {
 public:
-    train_input_impl() : data(table()){};
+    train_input_impl() : data(table()) {};
     train_input_impl(const table& data, const table& responses = table{})
             : data(data),
               responses(responses) {}
@@ -56,6 +56,9 @@ template <typename Task>
 struct train_parameters_impl : public base {
     std::int64_t cpu_macro_block = 8'192l;
     std::int64_t gpu_macro_block = 16'384l;
+    std::int64_t cpu_max_cols_batched = 4'096l;
+    std::int64_t cpu_small_rows_threshold = 10'000l;
+    std::int64_t cpu_small_rows_max_cols_batched = 1'024l;
 };
 
 template <typename Task>
@@ -79,6 +82,36 @@ std::int64_t train_parameters<Task>::get_gpu_macro_block() const {
 template <typename Task>
 void train_parameters<Task>::set_gpu_macro_block_impl(std::int64_t val) {
     impl_->gpu_macro_block = val;
+}
+
+template <typename Task>
+std::int64_t train_parameters<Task>::get_cpu_max_cols_batched() const {
+    return impl_->cpu_max_cols_batched;
+}
+
+template <typename Task>
+void train_parameters<Task>::set_cpu_max_cols_batched_impl(std::int64_t val) {
+    impl_->cpu_max_cols_batched = val;
+}
+
+template <typename Task>
+std::int64_t train_parameters<Task>::get_cpu_small_rows_threshold() const {
+    return impl_->cpu_small_rows_threshold;
+}
+
+template <typename Task>
+void train_parameters<Task>::set_cpu_small_rows_threshold_impl(std::int64_t val) {
+    impl_->cpu_small_rows_threshold = val;
+}
+
+template <typename Task>
+std::int64_t train_parameters<Task>::get_cpu_small_rows_max_cols_batched() const {
+    return impl_->cpu_small_rows_max_cols_batched;
+}
+
+template <typename Task>
+void train_parameters<Task>::set_cpu_small_rows_max_cols_batched_impl(std::int64_t val) {
+    impl_->cpu_small_rows_max_cols_batched = val;
 }
 
 template class ONEDAL_EXPORT train_parameters<task::regression>;

--- a/cpp/oneapi/dal/algo/linear_regression/train_types.hpp
+++ b/cpp/oneapi/dal/algo/linear_regression/train_types.hpp
@@ -54,9 +54,30 @@ public:
         return *this;
     }
 
+    std::int64_t get_cpu_max_cols_batched() const;
+    auto& set_cpu_max_cols_batched(std::int64_t val) {
+        set_cpu_max_cols_batched_impl(val);
+        return *this;
+    }
+
+    std::int64_t get_cpu_small_rows_threshold() const;
+    auto& set_cpu_small_rows_threshold(std::int64_t val) {
+        set_cpu_small_rows_threshold_impl(val);
+        return *this;
+    }
+
+    std::int64_t get_cpu_small_rows_max_cols_batched() const;
+    auto& set_cpu_small_rows_max_cols_batched(std::int64_t val) {
+        set_cpu_small_rows_max_cols_batched_impl(val);
+        return *this;
+    }
+
 private:
     void set_cpu_macro_block_impl(std::int64_t val);
     void set_gpu_macro_block_impl(std::int64_t val);
+    void set_cpu_max_cols_batched_impl(std::int64_t val);
+    void set_cpu_small_rows_threshold_impl(std::int64_t val);
+    void set_cpu_small_rows_max_cols_batched_impl(std::int64_t val);
     dal::detail::pimpl<train_parameters_impl<Task>> impl_;
 };
 

--- a/cpp/oneapi/dal/test/engine/fixtures.hpp
+++ b/cpp/oneapi/dal/test/engine/fixtures.hpp
@@ -46,6 +46,14 @@ public:
         return oneapi::dal::test::engine::train(get_policy(), std::forward<Args>(args)...);
     }
 
+    template <class Descriptor, class Parameters, typename... Args>
+    auto train_with_parameters(Parameters params, Descriptor descriptor, Args&&... args) {
+        return oneapi::dal::test::engine::train(get_policy(),
+                                                descriptor,
+                                                params,
+                                                std::forward<Args>(args)...);
+    }
+
     template <typename... Args>
     auto infer(Args&&... args) {
         return oneapi::dal::test::engine::infer(get_policy(), std::forward<Args>(args)...);

--- a/cpp/oneapi/dal/test/engine/fixtures.hpp
+++ b/cpp/oneapi/dal/test/engine/fixtures.hpp
@@ -81,6 +81,14 @@ public:
         return oneapi::dal::test::engine::partial_train(get_policy(), std::forward<Args>(args)...);
     }
 
+    template <class Descriptor, class Parameters, typename... Args>
+    auto partial_train_with_parameters(Parameters params, Descriptor descriptor, Args&&... args) {
+        return oneapi::dal::test::engine::partial_train(get_policy(),
+                                                        descriptor,
+                                                        params,
+                                                        std::forward<Args>(args)...);
+    }
+
     template <typename... Args>
     auto finalize_train(Args&&... args) {
         return oneapi::dal::test::engine::finalize_train(get_policy(), std::forward<Args>(args)...);


### PR DESCRIPTION
<!--
  ~ Copyright 2019 Intel Corporation
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
  ~
  ~     http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-->

## Description

This PR adds a preliminary version of a non-batched version of the linear regression normal regression algorithm for high-dimensional problems, which calculates the aggregates $\mathbf{X}^T \mathbf{X}$ and $\mathbf{X}^T \mathbf{y}$ separately through corresponding calls to BLAS functions.

The code route here is only meant for high-dimensional problems where the current approach does not lead to better performance. The idea is to make these thresholds configurable through the same parameters system used for e.g. the batch size in the regular route, but adding new configurable parameters appears to be a much trickier job so I'm starting with this PR with hard-coded thresholds in the meantime.

A few notes:
* ~The function that computes the aggregates takes a flag `initializeResult`, but if this flag is `false` and the results are not zeroed-out beforehand, it will lead to failing some bazel tests when the code route here is used.~ This was due to a bug in the PR code, has been fixed by now.
* There are methods to calculate statistics such as column sums from the `NumericTable` class in which the data is passed, but the inputs have `const` qualifiers and those methods that add the statistics to them modify the inputs, so cannot be used with `const` data.
    * Hence, I am calculating those by vector-matrix products with an array of all-ones. ~I wasn't sure if there's dedicated procedures to allocate aligned arrays, so I'm just using a regular unique pointer for them.~ Changed to use the dedicated `TArray` class.
* ~While the new code route being introduced here is meant for high-dimensional data only, for testing purposes, I'm enabling it for all input sizes. It works only for row-major data as it requires contiguous arrays though.~ Modified the tests to test both the regular route and this route for all linear regression cases on CPU.

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

Tests will be left for a future PR once the thresholds for triggering this mode are made configurable.

**Performance**

Performance comparisons were shared internally, without sklearn_bench as the situations to trigger it are rather specific.
