### PR TITLE
Resolve Symbol Conflicts Between oneMKL and oneDAL

### DIFF
--- a/dev/make/common.mk
+++ b/dev/make/common.mk
@@ -116,7 +116,7 @@ link.static.mac = libtool -V -static -o $@ $(1:%_link.txt=-filelist %_link.txt)
 LINK.DYNAMIC = $(mkdir)$(call rm,$@)$(link.dynamic.cmd)
 link.dynamic.cmd = $(call link.dynamic.$(_OS),$(secure.opts.link.$(_OS)) $(or $1,$(^.no-mkdeps)) $(LOPT))
 link.dynamic.lnx = $(if $(link.dynamic.lnx.$(COMPILER)),$(link.dynamic.lnx.$(COMPILER)),$(error link.dynamic.lnx.$(COMPILER) must be defined)) \
-                   -Wl,-soname,$(@F).$(MAJORBINARY) -shared $(-sGRP) $(patsubst %_link.txt,@%_link.txt,$(patsubst %_link.def,@%_link.def,$1)) $(-eGRP) -o $@
+                    -Wl$(comma)--exclude-libs=libmkl_intel_ilp64.a -Wl$(comma)--exclude-libs=libmkl_core.a -Wl$(comma)--exclude-libs=libmkl_sycl.a -Wl$(comma)--exclude-libs=libmkl_tbb_thread.a -Wl,-soname,$(@F).$(MAJORBINARY) -shared $(-sGRP) $(patsubst %_link.txt,@%_link.txt,$(patsubst %_link.def,@%_link.def,$1)) $(-eGRP) -o $@
 link.dynamic.win = link $(link.dynamic.win.$(COMPILER)) -WX -nologo -map -dll $(-DEBL) \
                    $(patsubst %_link.txt,@%_link.txt,$(patsubst %.def,-DEF:%.def,$1)) -out:$@
 link.dynamic.mac = $(if $(link.dynamic.mac.$(COMPILER)),$(link.dynamic.mac.$(COMPILER)),$(error link.dynamic.mac.$(COMPILER) must be defined)) \
@@ -128,7 +128,7 @@ link.dynamic.mac = $(if $(link.dynamic.mac.$(COMPILER)),$(link.dynamic.mac.$(COM
 # Link dynamic DPC++ lib
 DPC.LINK.DYNAMIC = $(mkdir)$(call rm,$@)$(dpc.link.dynamic.cmd)
 dpc.link.dynamic.cmd = $(call dpc.link.dynamic.$(_OS),$(or $1,$(^.no-mkdeps)) $(LOPT))
-dpc.link.dynamic.lnx = $(if $(link.dynamic.lnx.dpcpp),$(link.dynamic.lnx.dpcpp),$(error link.dynamic.lnx.dpcpp must be defined)) -Wl,-soname,$(@F).$(MAJORBINARY) \
+dpc.link.dynamic.lnx = $(if $(link.dynamic.lnx.dpcpp),$(link.dynamic.lnx.dpcpp),$(error link.dynamic.lnx.dpcpp must be defined)) -Wl$(comma)--exclude-libs=libmkl_intel_ilp64.a -Wl$(comma)--exclude-libs=libmkl_core.a -Wl$(comma)--exclude-libs=libmkl_sycl.a -Wl$(comma)--exclude-libs=libmkl_tbb_thread.a -Wl,-soname,$(@F).$(MAJORBINARY) \
                        $(secure.opts.link.lnx) -shared $(-sGRP) $(patsubst %_link.txt,@%_link.txt,$(patsubst %_link.def,@%_link.def,$1)) $(-eGRP) -o $@
 dpc.link.dynamic.win = $(if $(link.dynamic.win.dpcpp),$(link.dynamic.win.dpcpp),$(error link.dynamic.win.dpcpp must be defined)) \
                        -LD $(patsubst %_link.txt,@%_link.txt,$(filter %_link.txt,$1)) $(filter-out -IMPLIB:%,$(filter %.lib,$1)) -o$@ \

--- a/dev/make/common.mk
+++ b/dev/make/common.mk
@@ -100,8 +100,6 @@ write.prereqs.args = $(or $1,$(^.no-mkdeps))
 write.prereqs.impl = $(call xargs,write.prereqs.dump,$1,$2)
 write.prereqs.dump = $(call exec,printf -- "$(subst $(space),$2,$1)$(if $6,$2)" >> $@)
 
-EXCLUDE_MATH_SYMBOLS = $(foreach lib,$(MATH_LIBS_TO_EXCLUDE),-Wl$(comma)--exclude-libs=$(lib))
-
 # Link static lib
 LINK.STATIC = $(mkdir)$(call rm,$@)$(link.static.cmd)
 link.static.cmd = $(call link.static.$(_OS),$(LOPT) $(or $1,$(^.no-mkdeps)))
@@ -118,7 +116,7 @@ link.static.mac = libtool -V -static -o $@ $(1:%_link.txt=-filelist %_link.txt)
 LINK.DYNAMIC = $(mkdir)$(call rm,$@)$(link.dynamic.cmd)
 link.dynamic.cmd = $(call link.dynamic.$(_OS),$(secure.opts.link.$(_OS)) $(or $1,$(^.no-mkdeps)) $(LOPT))
 link.dynamic.lnx = $(if $(link.dynamic.lnx.$(COMPILER)),$(link.dynamic.lnx.$(COMPILER)),$(error link.dynamic.lnx.$(COMPILER) must be defined)) \
-                   $(EXCLUDE_MATH_SYMBOLS) -Wl,-soname,$(@F).$(MAJORBINARY) -shared $(-sGRP) $(patsubst %_link.txt,@%_link.txt,$(patsubst %_link.def,@%_link.def,$1)) $(-eGRP) -o $@
+                   -Wl$(comma)--exclude-libs=ALL -Wl,-soname,$(@F).$(MAJORBINARY) -shared $(-sGRP) $(patsubst %_link.txt,@%_link.txt,$(patsubst %_link.def,@%_link.def,$1)) $(-eGRP) -o $@
 link.dynamic.win = link $(link.dynamic.win.$(COMPILER)) -WX -nologo -map -dll $(-DEBL) \
                    $(patsubst %_link.txt,@%_link.txt,$(patsubst %.def,-DEF:%.def,$1)) -out:$@
 link.dynamic.mac = $(if $(link.dynamic.mac.$(COMPILER)),$(link.dynamic.mac.$(COMPILER)),$(error link.dynamic.mac.$(COMPILER) must be defined)) \
@@ -130,7 +128,7 @@ link.dynamic.mac = $(if $(link.dynamic.mac.$(COMPILER)),$(link.dynamic.mac.$(COM
 # Link dynamic DPC++ lib
 DPC.LINK.DYNAMIC = $(mkdir)$(call rm,$@)$(dpc.link.dynamic.cmd)
 dpc.link.dynamic.cmd = $(call dpc.link.dynamic.$(_OS),$(or $1,$(^.no-mkdeps)) $(LOPT))
-dpc.link.dynamic.lnx = $(if $(link.dynamic.lnx.dpcpp),$(link.dynamic.lnx.dpcpp),$(error link.dynamic.lnx.dpcpp must be defined)) $(EXCLUDE_MATH_SYMBOLS) -Wl,-soname,$(@F).$(MAJORBINARY) \
+dpc.link.dynamic.lnx = $(if $(link.dynamic.lnx.dpcpp),$(link.dynamic.lnx.dpcpp),$(error link.dynamic.lnx.dpcpp must be defined)) -Wl$(comma)--exclude-libs=ALL -Wl,-soname,$(@F).$(MAJORBINARY) \
                        $(secure.opts.link.lnx) -shared $(-sGRP) $(patsubst %_link.txt,@%_link.txt,$(patsubst %_link.def,@%_link.def,$1)) $(-eGRP) -o $@
 dpc.link.dynamic.win = $(if $(link.dynamic.win.dpcpp),$(link.dynamic.win.dpcpp),$(error link.dynamic.win.dpcpp must be defined)) \
                        -LD $(patsubst %_link.txt,@%_link.txt,$(filter %_link.txt,$1)) $(filter-out -IMPLIB:%,$(filter %.lib,$1)) -o$@ \

--- a/dev/make/common.mk
+++ b/dev/make/common.mk
@@ -100,7 +100,9 @@ write.prereqs.args = $(or $1,$(^.no-mkdeps))
 write.prereqs.impl = $(call xargs,write.prereqs.dump,$1,$2)
 write.prereqs.dump = $(call exec,printf -- "$(subst $(space),$2,$1)$(if $6,$2)" >> $@)
 
-EXCLUDE_MATH_SYMBOLS = $(foreach lib,$(MATH_LIBS_TO_EXCLUDE),-Wl$(comma)--exclude-libs=$(lib))
+# Dynamically generate EXCLUDE_LIBS from MATH_LIBS_TO_EXCLUDE
+# Each library in MATH_LIBS_TO_EXCLUDE is prefixed with `-Wl,--exclude-libs=`
+EXCLUDE_LIBS = $(foreach lib,$(MATH_LIBS_TO_EXCLUDE),-Wl$(comma)--exclude-libs=$(lib))
 
 # Link static lib
 LINK.STATIC = $(mkdir)$(call rm,$@)$(link.static.cmd)
@@ -118,7 +120,7 @@ link.static.mac = libtool -V -static -o $@ $(1:%_link.txt=-filelist %_link.txt)
 LINK.DYNAMIC = $(mkdir)$(call rm,$@)$(link.dynamic.cmd)
 link.dynamic.cmd = $(call link.dynamic.$(_OS),$(secure.opts.link.$(_OS)) $(or $1,$(^.no-mkdeps)) $(LOPT))
 link.dynamic.lnx = $(if $(link.dynamic.lnx.$(COMPILER)),$(link.dynamic.lnx.$(COMPILER)),$(error link.dynamic.lnx.$(COMPILER) must be defined)) \
-                   $(EXCLUDE_MATH_SYMBOLS) -Wl,-soname,$(@F).$(MAJORBINARY) -shared $(-sGRP) $(patsubst %_link.txt,@%_link.txt,$(patsubst %_link.def,@%_link.def,$1)) $(-eGRP) -o $@
+                   $(EXCLUDE_LIBS) -Wl,-soname,$(@F).$(MAJORBINARY) -shared $(-sGRP) $(patsubst %_link.txt,@%_link.txt,$(patsubst %_link.def,@%_link.def,$1)) $(-eGRP) -o $@
 link.dynamic.win = link $(link.dynamic.win.$(COMPILER)) -WX -nologo -map -dll $(-DEBL) \
                    $(patsubst %_link.txt,@%_link.txt,$(patsubst %.def,-DEF:%.def,$1)) -out:$@
 link.dynamic.mac = $(if $(link.dynamic.mac.$(COMPILER)),$(link.dynamic.mac.$(COMPILER)),$(error link.dynamic.mac.$(COMPILER) must be defined)) \
@@ -130,7 +132,7 @@ link.dynamic.mac = $(if $(link.dynamic.mac.$(COMPILER)),$(link.dynamic.mac.$(COM
 # Link dynamic DPC++ lib
 DPC.LINK.DYNAMIC = $(mkdir)$(call rm,$@)$(dpc.link.dynamic.cmd)
 dpc.link.dynamic.cmd = $(call dpc.link.dynamic.$(_OS),$(or $1,$(^.no-mkdeps)) $(LOPT))
-dpc.link.dynamic.lnx = $(if $(link.dynamic.lnx.dpcpp),$(link.dynamic.lnx.dpcpp),$(error link.dynamic.lnx.dpcpp must be defined)) $(EXCLUDE_MATH_SYMBOLS) -Wl,-soname,$(@F).$(MAJORBINARY) \
+dpc.link.dynamic.lnx = $(if $(link.dynamic.lnx.dpcpp),$(link.dynamic.lnx.dpcpp),$(error link.dynamic.lnx.dpcpp must be defined)) $(EXCLUDE_LIBS) -Wl,-soname,$(@F).$(MAJORBINARY) \
                        $(secure.opts.link.lnx) -shared $(-sGRP) $(patsubst %_link.txt,@%_link.txt,$(patsubst %_link.def,@%_link.def,$1)) $(-eGRP) -o $@
 dpc.link.dynamic.win = $(if $(link.dynamic.win.dpcpp),$(link.dynamic.win.dpcpp),$(error link.dynamic.win.dpcpp must be defined)) \
                        -LD $(patsubst %_link.txt,@%_link.txt,$(filter %_link.txt,$1)) $(filter-out -IMPLIB:%,$(filter %.lib,$1)) -o$@ \

--- a/dev/make/common.mk
+++ b/dev/make/common.mk
@@ -100,6 +100,8 @@ write.prereqs.args = $(or $1,$(^.no-mkdeps))
 write.prereqs.impl = $(call xargs,write.prereqs.dump,$1,$2)
 write.prereqs.dump = $(call exec,printf -- "$(subst $(space),$2,$1)$(if $6,$2)" >> $@)
 
+EXCLUDE_MATH_SYMBOLS = $(foreach lib,$(MATH_LIBS_TO_EXCLUDE),-Wl$(comma)--exclude-libs=$(lib))
+
 # Link static lib
 LINK.STATIC = $(mkdir)$(call rm,$@)$(link.static.cmd)
 link.static.cmd = $(call link.static.$(_OS),$(LOPT) $(or $1,$(^.no-mkdeps)))
@@ -116,7 +118,7 @@ link.static.mac = libtool -V -static -o $@ $(1:%_link.txt=-filelist %_link.txt)
 LINK.DYNAMIC = $(mkdir)$(call rm,$@)$(link.dynamic.cmd)
 link.dynamic.cmd = $(call link.dynamic.$(_OS),$(secure.opts.link.$(_OS)) $(or $1,$(^.no-mkdeps)) $(LOPT))
 link.dynamic.lnx = $(if $(link.dynamic.lnx.$(COMPILER)),$(link.dynamic.lnx.$(COMPILER)),$(error link.dynamic.lnx.$(COMPILER) must be defined)) \
-                   -Wl$(comma)--exclude-libs=ALL -Wl,-soname,$(@F).$(MAJORBINARY) -shared $(-sGRP) $(patsubst %_link.txt,@%_link.txt,$(patsubst %_link.def,@%_link.def,$1)) $(-eGRP) -o $@
+                   $(EXCLUDE_MATH_SYMBOLS) -Wl,-soname,$(@F).$(MAJORBINARY) -shared $(-sGRP) $(patsubst %_link.txt,@%_link.txt,$(patsubst %_link.def,@%_link.def,$1)) $(-eGRP) -o $@
 link.dynamic.win = link $(link.dynamic.win.$(COMPILER)) -WX -nologo -map -dll $(-DEBL) \
                    $(patsubst %_link.txt,@%_link.txt,$(patsubst %.def,-DEF:%.def,$1)) -out:$@
 link.dynamic.mac = $(if $(link.dynamic.mac.$(COMPILER)),$(link.dynamic.mac.$(COMPILER)),$(error link.dynamic.mac.$(COMPILER) must be defined)) \
@@ -128,7 +130,7 @@ link.dynamic.mac = $(if $(link.dynamic.mac.$(COMPILER)),$(link.dynamic.mac.$(COM
 # Link dynamic DPC++ lib
 DPC.LINK.DYNAMIC = $(mkdir)$(call rm,$@)$(dpc.link.dynamic.cmd)
 dpc.link.dynamic.cmd = $(call dpc.link.dynamic.$(_OS),$(or $1,$(^.no-mkdeps)) $(LOPT))
-dpc.link.dynamic.lnx = $(if $(link.dynamic.lnx.dpcpp),$(link.dynamic.lnx.dpcpp),$(error link.dynamic.lnx.dpcpp must be defined)) -Wl$(comma)--exclude-libs=ALL -Wl,-soname,$(@F).$(MAJORBINARY) \
+dpc.link.dynamic.lnx = $(if $(link.dynamic.lnx.dpcpp),$(link.dynamic.lnx.dpcpp),$(error link.dynamic.lnx.dpcpp must be defined)) $(EXCLUDE_MATH_SYMBOLS) -Wl,-soname,$(@F).$(MAJORBINARY) \
                        $(secure.opts.link.lnx) -shared $(-sGRP) $(patsubst %_link.txt,@%_link.txt,$(patsubst %_link.def,@%_link.def,$1)) $(-eGRP) -o $@
 dpc.link.dynamic.win = $(if $(link.dynamic.win.dpcpp),$(link.dynamic.win.dpcpp),$(error link.dynamic.win.dpcpp must be defined)) \
                        -LD $(patsubst %_link.txt,@%_link.txt,$(filter %_link.txt,$1)) $(filter-out -IMPLIB:%,$(filter %.lib,$1)) -o$@ \

--- a/dev/make/deps.mkl.mk
+++ b/dev/make/deps.mkl.mk
@@ -38,6 +38,8 @@ daaldep.lnx32e.mkl.core := $(MKLDIR.libia)/$(plib)mkl_core.$a
 daaldep.lnx32e.mkl.interfaces := $(MKLDIR.libia)/$(plib)mkl_intel_ilp64.$a
 daaldep.lnx32e.mkl.sycl := $(MKLGPUDIR.lib)/$(plib)mkl_sycl.$a
 
+MATH_LIBS_TO_EXCLUDE := $(plib)mkl_tbb_thread.$a $(plib)mkl_core.$a $(plib)mkl_intel_ilp64.$a $(plib)mkl_sycl.$a
+
 daaldep.win32e.mkl.thr := $(MKLDIR.libia)/mkl_tbb_thread$d.$a
 daaldep.win32e.mkl.seq := $(MKLDIR.libia)/mkl_sequential.$a
 daaldep.win32e.mkl.interfaces := $(MKLDIR.libia)/mkl_intel_ilp64.$a

--- a/dev/make/deps.mkl.mk
+++ b/dev/make/deps.mkl.mk
@@ -38,6 +38,9 @@ daaldep.lnx32e.mkl.core := $(MKLDIR.libia)/$(plib)mkl_core.$a
 daaldep.lnx32e.mkl.interfaces := $(MKLDIR.libia)/$(plib)mkl_intel_ilp64.$a
 daaldep.lnx32e.mkl.sycl := $(MKLGPUDIR.lib)/$(plib)mkl_sycl.$a
 
+# List of oneMKL libraries to exclude from linking.
+# This list is used to generate the `--exclude-libs` linker options.
+# If you need to exclude additional libraries, extend this list by appending the library names.
 MATH_LIBS_TO_EXCLUDE := $(plib)mkl_tbb_thread.$a $(plib)mkl_core.$a $(plib)mkl_intel_ilp64.$a $(plib)mkl_sycl.$a
 
 daaldep.win32e.mkl.thr := $(MKLDIR.libia)/mkl_tbb_thread$d.$a

--- a/dev/make/deps.mkl.mk
+++ b/dev/make/deps.mkl.mk
@@ -38,8 +38,6 @@ daaldep.lnx32e.mkl.core := $(MKLDIR.libia)/$(plib)mkl_core.$a
 daaldep.lnx32e.mkl.interfaces := $(MKLDIR.libia)/$(plib)mkl_intel_ilp64.$a
 daaldep.lnx32e.mkl.sycl := $(MKLGPUDIR.lib)/$(plib)mkl_sycl.$a
 
-MATH_LIBS_TO_EXCLUDE := $(plib)mkl_tbb_thread.$a $(plib)mkl_core.$a $(plib)mkl_intel_ilp64.$a $(plib)mkl_sycl.$a
-
 daaldep.win32e.mkl.thr := $(MKLDIR.libia)/mkl_tbb_thread$d.$a
 daaldep.win32e.mkl.seq := $(MKLDIR.libia)/mkl_sequential.$a
 daaldep.win32e.mkl.interfaces := $(MKLDIR.libia)/mkl_intel_ilp64.$a

--- a/dev/make/deps.ref.mk
+++ b/dev/make/deps.ref.mk
@@ -31,6 +31,9 @@ daaldep.math_backend.seq := $(OPENBLASDIR.libia)/libopenblas.$a
 daaldep.math_backend.incdir := $(OPENBLASDIR.include)
 daaldep.math_backend_oneapi.incdir := $(OPENBLASDIR.include)
 
+# List of OpenBLAS libraries to exclude from linking.
+# This list is used to generate the `--exclude-libs` linker options.
+# If you need to exclude additional libraries, extend this list by appending the library names.
 MATH_LIBS_TO_EXCLUDE := libopenblas.$a 
 
 ifeq ($(RNG_OPENRNG), yes)
@@ -43,11 +46,11 @@ ifeq ($(RNG_OPENRNG), yes)
 	daaldep.rng_backend.incdir := $(OPENRNGDIR.include)
 	daaldep.rng_backend.lib := $(OPENRNGDIR.libia)/libopenrng.$a
 
+# Add libopenrng.$a to the exclusion list because RNG_OPENRNG is enabled
 	MATH_LIBS_TO_EXCLUDE += libopenrng.$a
 
 	daaldep.math_backend.incdir += $(daaldep.rng_backend.incdir)
 endif
-
 
 daaldep.math_backend.ext := $(daaldep.math_backend.thr)
 daaldep.math_backend.sycl := $(daaldep.math_backend.thr)

--- a/dev/make/deps.ref.mk
+++ b/dev/make/deps.ref.mk
@@ -31,6 +31,8 @@ daaldep.math_backend.seq := $(OPENBLASDIR.libia)/libopenblas.$a
 daaldep.math_backend.incdir := $(OPENBLASDIR.include)
 daaldep.math_backend_oneapi.incdir := $(OPENBLASDIR.include)
 
+MATH_LIBS_TO_EXCLUDE := libopenblas.$a 
+
 ifeq ($(RNG_OPENRNG), yes)
 	OPENRNGDIR:= $(if $(wildcard $(DIR)/__deps/openrng/*),$(DIR)/__deps/openrng,                            \
 					$(if $(wildcard $(OPENRNGROOT)/include/*),$(subst \,/,$(OPENRNGROOT)),                              \
@@ -41,8 +43,11 @@ ifeq ($(RNG_OPENRNG), yes)
 	daaldep.rng_backend.incdir := $(OPENRNGDIR.include)
 	daaldep.rng_backend.lib := $(OPENRNGDIR.libia)/libopenrng.$a
 
+	MATH_LIBS_TO_EXCLUDE += libopenrng.$a
+
 	daaldep.math_backend.incdir += $(daaldep.rng_backend.incdir)
 endif
+
 
 daaldep.math_backend.ext := $(daaldep.math_backend.thr)
 daaldep.math_backend.sycl := $(daaldep.math_backend.thr)

--- a/dev/make/deps.ref.mk
+++ b/dev/make/deps.ref.mk
@@ -44,6 +44,8 @@ ifeq ($(RNG_OPENRNG), yes)
 	daaldep.math_backend.incdir += $(daaldep.rng_backend.incdir)
 endif
 
+MATH_LIBS_TO_EXCLUDE :=
+
 daaldep.math_backend.ext := $(daaldep.math_backend.thr)
 daaldep.math_backend.sycl := $(daaldep.math_backend.thr)
 daaldep.math_backend.oneapi := $(daaldep.math_backend.thr)

--- a/dev/make/deps.ref.mk
+++ b/dev/make/deps.ref.mk
@@ -44,8 +44,6 @@ ifeq ($(RNG_OPENRNG), yes)
 	daaldep.math_backend.incdir += $(daaldep.rng_backend.incdir)
 endif
 
-MATH_LIBS_TO_EXCLUDE :=
-
 daaldep.math_backend.ext := $(daaldep.math_backend.thr)
 daaldep.math_backend.sycl := $(daaldep.math_backend.thr)
 daaldep.math_backend.oneapi := $(daaldep.math_backend.thr)


### PR DESCRIPTION
### PR: Resolve Symbol Conflicts Between oneMKL and oneDAL  

#### Overview  
This PR addresses symbol conflicts between oneMKL and oneDAL that emerged after the oneMKL migration. These conflicts occur when both libraries define identical symbols, leading to linker errors or runtime issues.  

#### Solution  
To resolve this, we introduced the `--exclude-libs` linker flag to explicitly exclude specific oneMKL libraries from linking, ensuring no overlap with oneDAL symbols.  

#### Key Changes  

### 🛠 Symbol Conflict Resolution  
- Added `--exclude-libs` to exclude the following oneMKL libraries:  
  - `libmkl_intel_ilp64.a`  
  - `libmkl_core.a`  
  - `libmkl_sycl.a`  
  - `libmkl_tbb_thread.a`  

  This ensures that oneMKL symbols do not conflict with oneDAL symbols during linking.  
 
- Added `--exclude-libs` list for OpenBLAS libraries

### 🚀 Dynamic and Maintainable Build System  
- Used `foreach` to dynamically generate the `EXCLUDE_LIBS` variable, making it easy to extend the exclusion list in the future.  
- Added comments and notifications to document the purpose of the exclusion list and remind developers to update it if needed.  


**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

