### PR TITLE
FIX: addressing Coverity hits on Ridge

### DIFF
--- a/cpp/daal/include/algorithms/ridge_regression/ridge_regression_predict_types.h
+++ b/cpp/daal/include/algorithms/ridge_regression/ridge_regression_predict_types.h
@@ -106,6 +106,9 @@ public:
     /** Copy constructor */
     Input(const Input & other);
 
+    /** Assign operator */
+    Input & operator=(const Input & other);
+
     /**
      * Returns an input object for making ridge regression model-based prediction
      * \param[in] id    Identifier of the input object

--- a/cpp/daal/include/algorithms/ridge_regression/ridge_regression_training_types.h
+++ b/cpp/daal/include/algorithms/ridge_regression/ridge_regression_training_types.h
@@ -136,7 +136,12 @@ class DAAL_EXPORT Input : public linear_model::training::Input, public InputIfac
 public:
     /** Default constructor */
     Input();
+
+    /** Copy constructor */
     Input(const Input & other);
+
+    /** Assignment operator */
+    Input & operator=(const Input & other);
 
     virtual ~Input() {}
 
@@ -283,6 +288,7 @@ class DAAL_EXPORT DistributedInput<step2Master> : public daal::algorithms::Input
 public:
     DistributedInput();
     DistributedInput(const DistributedInput & other);
+    DistributedInput operator=(const DistributedInput & other);
 
     /**
      * Gets an input object for ridge regression model-based training in the second step of the distributed processing mode

--- a/cpp/daal/src/algorithms/ridge_regression/ridge_regression_prediction_batch.cpp
+++ b/cpp/daal/src/algorithms/ridge_regression/ridge_regression_prediction_batch.cpp
@@ -42,7 +42,6 @@ __DAAL_REGISTER_SERIALIZATION_CLASS(Result, SERIALIZATION_RIDGE_REGRESSION_PREDI
 /** Default constructor */
 Input::Input() : linear_model::prediction::Input(lastModelInputId + 1) {}
 Input::Input(const Input & other) : linear_model::prediction::Input(other) {}
-
 Input & Input::operator=(const Input & other) = default;
 
 /**

--- a/cpp/daal/src/algorithms/ridge_regression/ridge_regression_prediction_batch.cpp
+++ b/cpp/daal/src/algorithms/ridge_regression/ridge_regression_prediction_batch.cpp
@@ -43,6 +43,8 @@ __DAAL_REGISTER_SERIALIZATION_CLASS(Result, SERIALIZATION_RIDGE_REGRESSION_PREDI
 Input::Input() : linear_model::prediction::Input(lastModelInputId + 1) {}
 Input::Input(const Input & other) : linear_model::prediction::Input(other) {}
 
+Input & Input::operator=(const Input & other) = default;
+
 /**
  * Returns an input object for making ridge regression model-based prediction
  * \param[in] id    Identifier of the input object

--- a/cpp/daal/src/algorithms/ridge_regression/ridge_regression_training_input.cpp
+++ b/cpp/daal/src/algorithms/ridge_regression/ridge_regression_training_input.cpp
@@ -38,7 +38,6 @@ namespace interface1
 {
 Input::Input() : linear_model::training::Input(lastInputId + 1) {}
 Input::Input(const Input & other) : linear_model::training::Input(other) {}
-
 Input & Input::operator=(const Input & other) = default;
 
 /**

--- a/cpp/daal/src/algorithms/ridge_regression/ridge_regression_training_input.cpp
+++ b/cpp/daal/src/algorithms/ridge_regression/ridge_regression_training_input.cpp
@@ -39,6 +39,8 @@ namespace interface1
 Input::Input() : linear_model::training::Input(lastInputId + 1) {}
 Input::Input(const Input & other) : linear_model::training::Input(other) {}
 
+Input & Input::operator=(const Input & other) = default;
+
 /**
  * Returns an input object for ridge regression model-based training
  * \param[in] id    Identifier of the input object


### PR DESCRIPTION
<!--
  ~ Copyright 2019 Intel Corporation
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
  ~
  ~     http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-->

## Description

This PR addresses Coverity hits on Ridge such as `rule of 3` and `copy without assign`.

---



**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
