### PR TITLE
Remove redundant gradient computation in backtracking algorithm

### DIFF
--- a/cpp/oneapi/dal/backend/primitives/objective_function/logloss_functors.hpp
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/logloss_functors.hpp
@@ -94,6 +94,7 @@ public:
     base_matrix_operator<Float>& get_hessian_product() final;
 
     event_vector update_x(const ndview<Float, 1>& x,
+                          bool need_grad = true,
                           bool need_hessp = false,
                           const event_vector& deps = {}) final;
 

--- a/cpp/oneapi/dal/backend/primitives/objective_function/logloss_functors_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/logloss_functors_dpc.cpp
@@ -378,6 +378,7 @@ logloss_function<Float>::logloss_function(sycl::queue& q,
 
 template <typename Float>
 event_vector logloss_function<Float>::update_x(const ndview<Float, 1>& x,
+                                               bool need_grad,
                                                bool need_hessp,
                                                const event_vector& deps) {
     ONEDAL_PROFILER_TASK(logloss_function_update_weights, q_);
@@ -400,14 +401,25 @@ event_vector logloss_function<Float>::update_x(const ndview<Float, 1>& x,
 
         auto fill_loss_e = fill(q_, loss_batch, zero, deps);
 
-        sycl::event compute_e = compute_logloss_with_der_sparse(q_,
-                                                                *sp_handle_,
-                                                                labels_,
-                                                                probabilities_,
-                                                                loss_batch,
-                                                                grad_ndview,
-                                                                fit_intercept_,
-                                                                { fill_loss_e, prob_e });
+        sycl::event compute_e;
+        if (need_grad) {
+            compute_e = compute_logloss_with_der_sparse(q_,
+                                                        *sp_handle_,
+                                                        labels_,
+                                                        probabilities_,
+                                                        loss_batch,
+                                                        grad_ndview,
+                                                        fit_intercept_,
+                                                        { fill_loss_e, prob_e });
+        }
+        else {
+            compute_e = compute_logloss(q_,
+                                        labels_,
+                                        probabilities_,
+                                        loss_batch,
+                                        fit_intercept_,
+                                        { fill_loss_e, prob_e });
+        }
 
         value_ = loss_batch.at_device(q_, 0, { compute_e });
 
@@ -439,26 +451,36 @@ event_vector logloss_function<Float>::update_x(const ndview<Float, 1>& x,
 
             auto fill_buffer_e = fill(q_, buffer_, zero, last_iter_e);
 
-            sycl::event compute_e = compute_logloss_with_der(q_,
-                                                             data_batch,
-                                                             labels_batch,
-                                                             prob_batch,
-                                                             loss_batch,
-                                                             grad_batch,
-                                                             fit_intercept_,
-                                                             { fill_buffer_e, prob_e });
-
-            sycl::event update_grad_e = element_wise(q_,
-                                                     sycl::plus<>(),
-                                                     grad_ndview,
+            sycl::event compute_e;
+            if (need_grad) {
+                compute_e = compute_logloss_with_der(q_,
+                                                     data_batch,
+                                                     labels_batch,
+                                                     prob_batch,
+                                                     loss_batch,
                                                      grad_batch,
-                                                     grad_ndview,
-                                                     { compute_e });
+                                                     fit_intercept_,
+                                                     { fill_buffer_e, prob_e });
+
+                sycl::event update_grad_e = element_wise(q_,
+                                                         sycl::plus<>(),
+                                                         grad_ndview,
+                                                         grad_batch,
+                                                         grad_ndview,
+                                                         { compute_e });
+                last_iter_e = { update_grad_e };
+            }
+            else {
+                compute_e = compute_logloss(q_,
+                                            labels_,
+                                            prob_batch,
+                                            loss_batch,
+                                            fit_intercept_,
+                                            { fill_buffer_e, prob_e });
+                last_iter_e = { compute_e };
+            }
 
             value_ += loss_batch.at_device(q_, 0, { compute_e });
-
-            last_iter_e = { update_grad_e };
-
             if (need_hessp) {
                 auto raw_hessian_batch = raw_hessian.get_slice(first, first + cursize);
                 auto hess_e = compute_raw_hessian(q_, prob_batch, raw_hessian_batch, { prob_e });
@@ -471,7 +493,7 @@ event_vector logloss_function<Float>::update_x(const ndview<Float, 1>& x,
         }
     }
     if (comm_.get_rank_count() > 1) {
-        {
+        if (need_grad) {
             ONEDAL_PROFILER_TASK(gradient_allreduce);
             auto gradient_arr = dal::array<Float>::wrap(q_,
                                                         gradient_.get_mutable_data(),
@@ -499,7 +521,9 @@ event_vector logloss_function<Float>::update_x(const ndview<Float, 1>& x,
             auto sum_reduction = sycl::reduction(loss_ptr, sycl::plus<>());
             cgh.parallel_for(range, sum_reduction, [=](sycl::id<1> idx, auto& sum_v0) {
                 const Float param = w_ptr[st_id + idx];
-                grad_ptr[st_id + idx] += regularization_factor * param;
+                if (need_grad) {
+                    grad_ptr[st_id + idx] += regularization_factor * param;
+                }
                 sum_v0 += regularization_factor * param * param / 2;
             });
         });

--- a/cpp/oneapi/dal/backend/primitives/objective_function/test/fixture.hpp
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/test/fixture.hpp
@@ -622,7 +622,7 @@ public:
                                                  L2 * 2,
                                                  fit_intercept,
                                                  bsz);
-        auto set_point_event = functor.update_x(params_gpu, true, {});
+        auto set_point_event = functor.update_x(params_gpu, true, true, {});
         wait_or_pass(set_point_event).wait_and_throw();
 
         IS_CLOSE(float_t, gth_logloss, functor.get_value(), rtol, atol);

--- a/cpp/oneapi/dal/backend/primitives/objective_function/test/spmd_fixture.hpp
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/test/spmd_fixture.hpp
@@ -110,7 +110,7 @@ public:
         }
 
         const auto results = comm.map([&](std::int64_t rank) {
-            sycl::event::wait_and_throw(funcs[rank].update_x(params_gpu, true, {}));
+            sycl::event::wait_and_throw(funcs[rank].update_x(params_gpu, true, true, {}));
             base_matrix_operator<float_t>& hessp = funcs[rank].get_hessian_product();
             std::vector<ndarray<float_t, 1>> out_vecs(num_checks);
             for (std::int64_t ij = 0; ij < num_checks; ++ij) {

--- a/cpp/oneapi/dal/backend/primitives/optimizers/common.hpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/common.hpp
@@ -72,6 +72,7 @@ public:
     virtual ndview<Float, 1>& get_gradient() = 0;
     virtual base_matrix_operator<Float>& get_hessian_product() = 0;
     virtual event_vector update_x(const ndview<Float, 1>& x,
+                                  bool need_grad = true,
                                   bool need_hessp = false,
                                   const event_vector& deps = {}) = 0;
 };

--- a/cpp/oneapi/dal/backend/primitives/optimizers/line_search_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/line_search_dpc.cpp
@@ -35,7 +35,7 @@ Float backtracking(sycl::queue queue,
     using dal::backend::operator+;
     event_vector precompute = {};
     if (!x0_initialized) {
-        precompute = f.update_x(x, false, deps);
+        precompute = f.update_x(x, true, false, deps);
     }
     Float f0 = f.get_value();
     auto grad_f0 = f.get_gradient();
@@ -58,7 +58,7 @@ Float backtracking(sycl::queue queue,
         };
 
         auto update_x_event = element_wise(queue, update_x_kernel, x, direction, result, {});
-        auto func_event_vec = f.update_x(result, false, { update_x_event });
+        auto func_event_vec = f.update_x(result, false, false, { update_x_event });
         wait_or_pass(func_event_vec).wait_and_throw();
         cur_val = f.get_value();
     }

--- a/cpp/oneapi/dal/backend/primitives/optimizers/newton_cg_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/newton_cg_dpc.cpp
@@ -58,7 +58,7 @@ std::tuple<sycl::event, std::int64_t, std::int64_t> newton_cg(sycl::queue& queue
     std::int64_t inner_iter_sum = 0;
     while (cur_iter_id < maxiter) {
         cur_iter_id++;
-        auto update_event_vec = f.update_x(x, true, last_iter_deps);
+        auto update_event_vec = f.update_x(x, true, true, last_iter_deps);
         auto gradient = f.get_gradient();
 
         Float grad_norm = 0, grad_max_abs = 0;

--- a/cpp/oneapi/dal/backend/primitives/optimizers/test/newton_cg_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/test/newton_cg_dpc.cpp
@@ -165,7 +165,7 @@ public:
         for (std::int32_t test_num = 0; test_num < 5; ++test_num) {
             uniform<float_t>(n_, x_host.get_mutable_data(), eng, -1.0, 1.0);
             auto x_gpu = x_host.to_device(this->get_queue());
-            auto compute_event_vec = func_->update_x(x_gpu, true, {});
+            auto compute_event_vec = func_->update_x(x_gpu, true, true, {});
             wait_or_pass(compute_event_vec).wait_and_throw();
 
             float_t val = func_->get_value();


### PR DESCRIPTION
## Description

DPC++ newton-cg solver relies on backtracking algorithm to find an optimal step length. In backtracking algorithm we only need to check if Armijo is satisfied at a given point. To do that we only need to know function value, the gradient is not need though in current implementation it is computed. 

In this PR we introduce new parameter need_grad for update_x method to avoid gradient computations when it's not needed. Also update_x function was modified for logloss function.

---

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
