### PR TITLE
ci: pin some dependencies by hash

### DIFF
--- a/.ci/env/apt.sh
+++ b/.ci/env/apt.sh
@@ -100,8 +100,23 @@ function build_sysroot {
 }
 
 function install_miniforge {
-    wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
-    sudo bash Miniforge3.sh -b -p /usr/share/miniconda
+    local platform
+    local version
+    local installer
+
+    platform="$(uname)-$(uname -m)"
+    version=$(curl -s https://api.github.com/repos/conda-forge/miniforge/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
+    installer=Miniforge3-${version}-${platform}.sh
+
+    curl -LO "https://github.com/conda-forge/miniforge/releases/download/${version}/${installer}"
+    curl -LO "https://github.com/conda-forge/miniforge/releases/download/${version}/${installer}.sha256"
+
+    if ! sha256sum -c "${installer}.sha256"; then
+        echo "Error: SHA256 checksum verification failed."
+        exit 1
+    fi
+
+    sudo bash "${installer}" -b -p /usr/share/miniconda
     source /usr/share/miniconda/etc/profile.d/conda.sh
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install MKL
         run: .ci/env/apt.sh mkl
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: 3.9
       # Miniforge is necessary in order to get Intel MPI from conda-forge for MPI examples
@@ -85,7 +85,7 @@ jobs:
       - name: oneapi/dpc examples
         run: |
             source /opt/intel/oneapi/setvars.sh
-            .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/dpc --build-system cmake            
+            .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/dpc --build-system cmake
       - name: daal/cpp/mpi examples
         run: |
             source /opt/intel/oneapi/setvars.sh


### PR DESCRIPTION
## Description


1. **Update Miniforge Installation Script**:
  - Enhanced the `install_miniforge` function in `.ci/env/apt.sh` to dynamically fetch the latest Miniforge version and verify the SHA256 checksum before installation. This ensures that the latest and verified version of Miniforge is installed.

2. **Update GitHub Actions Workflow**:
  - Modified the `ci.yml` workflow to use a specific commit hash for the `actions/setup-python` action instead of the latest version. This change ensures consistency and reproducibility in the CI pipeline.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

