### PR TITLE
Changed stream handling in RNG clone

### DIFF
--- a/cpp/daal/src/externals/service_rng_mkl.h
+++ b/cpp/daal/src/externals/service_rng_mkl.h
@@ -283,18 +283,7 @@ public:
 
     BaseRNG(const BaseRNG<cpu> & other) : _stream(0), _seed(nullptr), _seedSize(other._seedSize), _brngId(other._brngId)
     {
-        services::Status s = allocSeeds(_seedSize);
-        if (s)
-        {
-            for (size_t i = 0; i < _seedSize; i++)
-            {
-                _seed[i] = other._seed[i];
-            }
-            int errcode = 0;
-            __DAAL_VSLFN_CALL_NR(vslCopyStream, (&_stream, other._stream), errcode);
-            //__DAAL_VSLFN_CALL_NR(vslNewStreamEx, (&_stream, (const MKL_INT)_brngId, (const MKL_INT)_seedSize, _seed), errcode);
-            //if (!errcode) __DAAL_VSLFN_CALL_NR(vslCopyStreamState, (_stream, other._stream), errcode);
-        }
+        __DAAL_VSLFN_CALL_NR(vslCopyStream, (&_stream, other._stream), errcode);
     }
 
     ~BaseRNG()

--- a/cpp/daal/src/externals/service_rng_mkl.h
+++ b/cpp/daal/src/externals/service_rng_mkl.h
@@ -291,8 +291,9 @@ public:
                 _seed[i] = other._seed[i];
             }
             int errcode = 0;
-            __DAAL_VSLFN_CALL_NR(vslNewStreamEx, (&_stream, (const MKL_INT)_brngId, (const MKL_INT)_seedSize, _seed), errcode);
-            if (!errcode) __DAAL_VSLFN_CALL_NR(vslCopyStreamState, (_stream, other._stream), errcode);
+            __DAAL_VSLFN_CALL_NR(vslCopyStream, (&_stream, other._stream), errcode);
+            //__DAAL_VSLFN_CALL_NR(vslNewStreamEx, (&_stream, (const MKL_INT)_brngId, (const MKL_INT)_seedSize, _seed), errcode);
+            //if (!errcode) __DAAL_VSLFN_CALL_NR(vslCopyStreamState, (_stream, other._stream), errcode);
         }
     }
 


### PR DESCRIPTION
## Changed stream handling in RNG clone

Changed RNG clone to use vslCopyStream instead of vslNewStreamEx and then vslCopyStreamState

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [X] I have reviewed my changes thoroughly before submitting this pull request.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [X] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [X] I have added a respective label(s) to PR if I have a permission for that.
- [X] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [X] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [X] I have provided justification why performance has changed or why changes are not expected.
- [X] I have provided justification why quality metrics have changed or why changes are not expected.
- [X] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
