### PR TITLE
fix: add isValid() method for dtrees ModelImpl

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/dtrees_model.cpp
+++ b/cpp/daal/src/algorithms/dtrees/dtrees_model.cpp
@@ -97,16 +97,14 @@ bool ModelImpl::reserve(const size_t nTrees)
     if (_serializationData.get()) return false;
     _nTree.set(0);
     _serializationData.reset(new DataCollection());
-    _serializationData->resize(nTrees);
-
     _impurityTables.reset(new DataCollection());
-    _impurityTables->resize(nTrees);
-
     _nNodeSampleTables.reset(new DataCollection());
-    _nNodeSampleTables->resize(nTrees);
-
     _probTbl.reset(new DataCollection());
-    _probTbl->resize(nTrees);
+
+    if (!(_serializationData->resize(nTrees) && _impurityTables->resize(nTrees) && _nNodeSampleTables->resize(nTrees) && _probTbl->resize(nTrees)))
+    {
+        return false;
+    }
 
     return isValid();
 }

--- a/cpp/daal/src/algorithms/dtrees/dtrees_model.cpp
+++ b/cpp/daal/src/algorithms/dtrees/dtrees_model.cpp
@@ -43,12 +43,16 @@ ModelImpl::ModelImpl(const ModelImpl & other)
     const size_t nTree = other._nTree.get();
     resize(nTree); // sets _nTree = 0
     _nTree.set(nTree);
-    for (size_t i = 0; i < nTree; ++i)
+    // copy data if source and target pointers are valid
+    if (isValid() && other.isValid())
     {
-        (*_serializationData)[i] = (*other._serializationData)[i];
-        (*_impurityTables)[i]    = (*other._impurityTables)[i];
-        (*_nNodeSampleTables)[i] = (*other._nNodeSampleTables)[i];
-        (*_probTbl)[i]           = (*other._probTbl)[i];
+        for (size_t i = 0; i < nTree; ++i)
+        {
+            (*_serializationData)[i] = (*other._serializationData)[i];
+            (*_impurityTables)[i]    = (*other._impurityTables)[i];
+            (*_nNodeSampleTables)[i] = (*other._nNodeSampleTables)[i];
+            (*_probTbl)[i]           = (*other._probTbl)[i];
+        }
     }
 }
 
@@ -60,12 +64,16 @@ ModelImpl & ModelImpl::operator=(const ModelImpl & other)
         const size_t nTree = other._nTree.get();
         resize(nTree); // sets _nTree = 0
         _nTree.set(nTree);
-        for (size_t i = 0; i < nTree; ++i)
+        // copy data if source and target pointers are valid
+        if (isValid() && other.isValid())
         {
-            (*_serializationData)[i] = (*other._serializationData)[i];
-            (*_impurityTables)[i]    = (*other._impurityTables)[i];
-            (*_nNodeSampleTables)[i] = (*other._nNodeSampleTables)[i];
-            (*_probTbl)[i]           = (*other._probTbl)[i];
+            for (size_t i = 0; i < nTree; ++i)
+            {
+                (*_serializationData)[i] = (*other._serializationData)[i];
+                (*_impurityTables)[i]    = (*other._impurityTables)[i];
+                (*_nNodeSampleTables)[i] = (*other._nNodeSampleTables)[i];
+                (*_probTbl)[i]           = (*other._probTbl)[i];
+            }
         }
     }
     return *this;
@@ -100,7 +108,7 @@ bool ModelImpl::reserve(const size_t nTrees)
     _probTbl.reset(new DataCollection());
     _probTbl->resize(nTrees);
 
-    return _serializationData.get();
+    return isValid();
 }
 
 bool ModelImpl::resize(const size_t nTrees)
@@ -111,7 +119,12 @@ bool ModelImpl::resize(const size_t nTrees)
     _impurityTables.reset(new DataCollection(nTrees));
     _nNodeSampleTables.reset(new DataCollection(nTrees));
     _probTbl.reset(new DataCollection(nTrees));
-    return _serializationData.get();
+    return isValid();
+}
+
+bool ModelImpl::isValid() const
+{
+    return _serializationData.get() && _impurityTables.get() && _nNodeSampleTables.get() && _probTbl.get();
 }
 
 void ModelImpl::clear()

--- a/cpp/daal/src/algorithms/dtrees/dtrees_model.cpp
+++ b/cpp/daal/src/algorithms/dtrees/dtrees_model.cpp
@@ -101,12 +101,13 @@ bool ModelImpl::reserve(const size_t nTrees)
     _nNodeSampleTables.reset(new DataCollection());
     _probTbl.reset(new DataCollection());
 
-    if (!(_serializationData->resize(nTrees) && _impurityTables->resize(nTrees) && _nNodeSampleTables->resize(nTrees) && _probTbl->resize(nTrees)))
+    // check for all pointers being non-null and successful resizing
+    if (!(isValid() && _serializationData->resize(nTrees) && _impurityTables->resize(nTrees) && _nNodeSampleTables->resize(nTrees)
+          && _probTbl->resize(nTrees)))
     {
         return false;
     }
-
-    return isValid();
+    return true;
 }
 
 bool ModelImpl::resize(const size_t nTrees)

--- a/cpp/daal/src/algorithms/dtrees/dtrees_model_impl.h
+++ b/cpp/daal/src/algorithms/dtrees/dtrees_model_impl.h
@@ -490,6 +490,8 @@ public:
     bool reserve(const size_t nTrees);
     bool resize(const size_t nTrees);
     void clear();
+    // check if all allocated memory is valid
+    bool isValid() const;
 
     const data_management::DataCollection * serializationData() const { return _serializationData.get(); }
 


### PR DESCRIPTION
## Description

Adds a check for valid buffer allocations in the copy and copy assignment constructors to address null pointer dereference coverity hits.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
