### PR TITLE
[backport: rls/2025.4.0-rls] chore(dev): allow bazel to use different versions of OpenCL lib (#3089)

### DIFF
--- a/dev/bazel/deps/opencl.tpl.BUILD
+++ b/dev/bazel/deps/opencl.tpl.BUILD
@@ -2,7 +2,8 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "opencl_binary",
-    srcs = [
+    srcs = glob([
         "libOpenCL.so.1.2",
-    ],
+        "libOpenCL.so.1.0",
+    ]),
 )


### PR DESCRIPTION
## Description

This pull request updates the Bazel build file for OpenCL dependency to allow the use of different versions of the library.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

