### PR TITLE
Fix sparse K-means failure on PVC when the number of rows in large

### DIFF
--- a/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_csr_impl.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_csr_impl.hpp
@@ -151,7 +151,7 @@ sycl::event assign_clusters(sycl::queue& q,
 
     sycl::event transpose_event = transpose(q, centroids, centroids_transposed, deps);
 
-    // Workaround to sparse K-means crash on PVC.
+    // Workaround to sparse K-means abort on PVC.
     transpose_event.wait();
 
     // Compute dot products of each data point and each cluster centroid:
@@ -165,7 +165,7 @@ sycl::event assign_clusters(sycl::queue& q,
                                Float(0),
                                { transpose_event });
 
-    // Workaround to sparse K-means crash on PVC.
+    // Workaround to sparse K-means abort on PVC.
     dist_event.wait();
 
     // Select min_j (D_ij) and idxmin_j (D_ij),

--- a/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_csr_impl.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_csr_impl.hpp
@@ -151,6 +151,9 @@ sycl::event assign_clusters(sycl::queue& q,
 
     sycl::event transpose_event = transpose(q, centroids, centroids_transposed, deps);
 
+    // Workaround to sparse K-means crash on PVC.
+    transpose_event.wait();
+
     // Compute dot products of each data point and each cluster centroid:
     // -2 * (x_i, c_j) term in the distances calculation
     auto dist_event = pr::gemm(q,
@@ -161,6 +164,9 @@ sycl::event assign_clusters(sycl::queue& q,
                                Float(-2.0),
                                Float(0),
                                { transpose_event });
+
+    // Workaround to sparse K-means crash on PVC.
+    dist_event.wait();
 
     // Select min_j (D_ij) and idxmin_j (D_ij),
     // where min_j (D_ij) == min_j (|| c_j ||^2 - 2 * (x_i, c_j)$),

--- a/cpp/oneapi/dal/algo/kmeans/backend/gpu/train_kernel_lloyd_csr_dpc.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/backend/gpu/train_kernel_lloyd_csr_dpc.cpp
@@ -177,6 +177,8 @@ struct train_kernel_gpu<Float, method::lloyd_csr, task::clustering> {
             const std::int64_t empty_cluster_count =
                 count_empty_clusters(queue, cluster_count, cluster_counts, { count_event });
 
+            last_event = update_event;
+
             Float correction(0);
             sycl::event empty_cluster_event;
             if (empty_cluster_count > 0) {
@@ -191,11 +193,10 @@ struct train_kernel_gpu<Float, method::lloyd_csr, task::clustering> {
                                           cluster_counts,
                                           arr_closest_distances,
                                           { update_event });
+                last_event = empty_cluster_event;
             }
 
             objective_function += correction;
-
-            last_event = empty_cluster_event;
 
             if (accuracy_threshold > 0 &&
                 objective_function + accuracy_threshold > prev_objective_function) {

--- a/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
@@ -318,4 +318,23 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
     }
 }
 
+
+TEMPLATE_LIST_TEST_M(kmeans_batch_test,
+    "KMmeans sparse cases on large number of rows",
+    "[kmeans][batch]",
+    kmeans_types) {
+    SKIP_IF(!this->is_sparse_method());
+    SKIP_IF(this->not_float64_friendly());
+    using Float = std::tuple_element_t<0, TestType>;
+
+    // Check that algorithm does not crash on big number of rows
+    constexpr std::int64_t cluster_count = 5;
+    auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(cluster_count, 100000000, 20);
+
+    auto desc = this->get_descriptor(cluster_count, 10, 0.01);
+    const table initial_centroids = input.get_initial_centroids();
+    const table data = input.get_data(this->get_policy());
+    const auto train_result = this->train(desc, data, initial_centroids);
+}
+
 } // namespace oneapi::dal::kmeans::test

--- a/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
@@ -318,11 +318,10 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
     }
 }
 
-
 TEMPLATE_LIST_TEST_M(kmeans_batch_test,
-    "KMmeans sparse cases on large number of rows",
-    "[kmeans][batch]",
-    kmeans_types) {
+                     "KMmeans sparse cases on large number of rows",
+                     "[kmeans][batch]",
+                     kmeans_types) {
     SKIP_IF(!this->is_sparse_method());
     SKIP_IF(this->not_float64_friendly());
     using Float = std::tuple_element_t<0, TestType>;


### PR DESCRIPTION
## Description

SYCL dependencies flow was fixed in sparse K-means;
Additional .wait() statements were added in `assign_clusters` kernel to workaround the issue.

Testcase that reproduces the failure on PVC was added.
The output of the test before the fix in source files:

```
Abort was called at 80 line in file:
./shared/source/command_stream/linear_stream.h
-------------------------------------------------------------------------------
KMmeans sparse cases on large number of rows - kmeans_types - 1
-------------------------------------------------------------------------------
cpp/oneapi/dal/algo/kmeans/test/batch.cpp:325
...............................................................................

cpp/oneapi/dal/algo/kmeans/test/batch.cpp:325: FAILED:
due to a fatal error condition:
  SIGABRT - Abort (abnormal termination) signal
```

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

The change might have some performance impact, but without the change the algorithm aborts on PVC.
