### PR TITLE
Reduce memory requirements of sparse K-means test

### DIFF
--- a/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
@@ -318,8 +318,6 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
     }
 }
 
-#ifdef ONEDAL_DATA_PARALLEL
-
 TEMPLATE_LIST_TEST_M(kmeans_batch_test,
                      "KMmeans sparse cases on large number of rows",
                      "[kmeans][batch]",
@@ -344,7 +342,5 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
     const table data = input.get_data(this->get_policy());
     const auto train_result = this->train(desc, data, initial_centroids);
 }
-
-#endif
 
 } // namespace oneapi::dal::kmeans::test

--- a/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
@@ -318,6 +318,8 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
     }
 }
 
+#ifdef ONEDAL_DATA_PARALLEL
+
 TEMPLATE_LIST_TEST_M(kmeans_batch_test,
                      "KMmeans sparse cases on large number of rows",
                      "[kmeans][batch]",
@@ -342,5 +344,7 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
     const table data = input.get_data(this->get_policy());
     const auto train_result = this->train(desc, data, initial_centroids);
 }
+
+#endif
 
 } // namespace oneapi::dal::kmeans::test


### PR DESCRIPTION
The test that tests SYCL implementation of sparse K-means on the large number of rows was modified:
* It was switched off on CPUs;
* On all GPUs except Intel(R) Data Center GPU Max series, the number of rows in the testing data set was reduced 100 times to prevent out of memory crashes.

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.
