### PR TITLE
Fix outlier detection assignment operators (rule of three violation, Coverity)

### DIFF
--- a/cpp/daal/include/algorithms/outlier_detection/outlier_detection_bacon_types.h
+++ b/cpp/daal/include/algorithms/outlier_detection/outlier_detection_bacon_types.h
@@ -114,6 +114,7 @@ class DAAL_EXPORT Input : public daal::algorithms::Input
 public:
     Input();
     Input(const Input & other);
+    Input & operator=(const Input & other);
 
     virtual ~Input() {}
 

--- a/cpp/daal/include/algorithms/outlier_detection/outlier_detection_multivariate_types.h
+++ b/cpp/daal/include/algorithms/outlier_detection/outlier_detection_multivariate_types.h
@@ -185,6 +185,7 @@ class DAAL_EXPORT Input : public daal::algorithms::Input
 public:
     Input();
     Input(const Input & other);
+    Input & operator=(const Input & other);
 
     virtual ~Input() {}
 

--- a/cpp/daal/include/algorithms/outlier_detection/outlier_detection_univariate_types.h
+++ b/cpp/daal/include/algorithms/outlier_detection/outlier_detection_univariate_types.h
@@ -145,6 +145,7 @@ class DAAL_EXPORT Input : public daal::algorithms::Input
 public:
     Input();
     Input(const Input & other);
+    Input & operator=(const Input & other);
 
     virtual ~Input() {}
 

--- a/cpp/daal/src/algorithms/outlierdetection_bacon/outlierdetection_bacon.cpp
+++ b/cpp/daal/src/algorithms/outlierdetection_bacon/outlierdetection_bacon.cpp
@@ -57,6 +57,7 @@ services::Status Parameter::check() const
 
 Input::Input() : daal::algorithms::Input(1) {}
 Input::Input(const Input & other) : daal::algorithms::Input(other) {}
+Input & Input::operator=(const Input & other) = default;
 
 /**
  * Returns input object for the multivariate outlier detection algorithm

--- a/cpp/daal/src/algorithms/outlierdetection_multivariate/outlierdetection_multivariate.cpp
+++ b/cpp/daal/src/algorithms/outlierdetection_multivariate/outlierdetection_multivariate.cpp
@@ -40,6 +40,7 @@ __DAAL_REGISTER_SERIALIZATION_CLASS(Result, SERIALIZATION_OUTLIER_DETECTION_MULT
 
 Input::Input() : daal::algorithms::Input(4) {}
 Input::Input(const Input & other) : daal::algorithms::Input(other) {}
+Input & Input::operator=(const Input & other);
 
 /**
  * Returns input object for the multivariate outlier detection algorithm

--- a/cpp/daal/src/algorithms/outlierdetection_multivariate/outlierdetection_multivariate.cpp
+++ b/cpp/daal/src/algorithms/outlierdetection_multivariate/outlierdetection_multivariate.cpp
@@ -40,7 +40,7 @@ __DAAL_REGISTER_SERIALIZATION_CLASS(Result, SERIALIZATION_OUTLIER_DETECTION_MULT
 
 Input::Input() : daal::algorithms::Input(4) {}
 Input::Input(const Input & other) : daal::algorithms::Input(other) {}
-Input & Input::operator=(const Input & other);
+Input & Input::operator=(const Input & other) = default;
 
 /**
  * Returns input object for the multivariate outlier detection algorithm

--- a/cpp/daal/src/algorithms/outlierdetection_univariate/outlier_detection_univariate.cpp
+++ b/cpp/daal/src/algorithms/outlierdetection_univariate/outlier_detection_univariate.cpp
@@ -40,7 +40,7 @@ __DAAL_REGISTER_SERIALIZATION_CLASS(Result, SERIALIZATION_OUTLIER_DETECTION_UNIV
 
 Input::Input() : daal::algorithms::Input(lastInputId + 1) {}
 Input::Input(const Input & other) : daal::algorithms::Input(other) {}
-Input & Input::operator=(const Input & other);
+Input & Input::operator=(const Input & other) = default;
 
 /**
  * Returns an input object for the univariate outlier detection algorithm

--- a/cpp/daal/src/algorithms/outlierdetection_univariate/outlier_detection_univariate.cpp
+++ b/cpp/daal/src/algorithms/outlierdetection_univariate/outlier_detection_univariate.cpp
@@ -40,6 +40,7 @@ __DAAL_REGISTER_SERIALIZATION_CLASS(Result, SERIALIZATION_OUTLIER_DETECTION_UNIV
 
 Input::Input() : daal::algorithms::Input(lastInputId + 1) {}
 Input::Input(const Input & other) : daal::algorithms::Input(other) {}
+Input & Input::operator=(const Input & other);
 
 /**
  * Returns an input object for the univariate outlier detection algorithm


### PR DESCRIPTION
## Description

This solves a rule-of-three violation in the DAAL outlier detection algorithms, which do not have assignment operators. This adds them to Bacon, univariate and multivariate outlier detectors.

Benchmarking unnecessary.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
