### PR TITLE
DOC: Remove broken instructions for building with conda environments on windows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -212,7 +212,7 @@ For example, in a Linux platform, assuming one wishes to execute the `adaboost_d
 
 ## Conda Development Environment Setup
 
-The previous instructions assumed system-wide installs of the necessary dependencies. These can also be installed at a user-level through the `conda` or [mamba](https://github.com/conda-forge/miniforge) ecosystems.
+The previous instructions assumed system-wide installs of the necessary dependencies. On Linux*, these can also be installed at a user-level through the `conda` or [mamba](https://github.com/conda-forge/miniforge) ecosystems.
 
 First, create a conda environment for building oneDAL, after `conda` has been installed:
 
@@ -222,8 +222,6 @@ conda activate onedal_env
 ```
 
 Then, install the necessary dependencies from the appropriate channels with `conda`:
-
-* **Linux\***:
 
 ```shell
 conda install -y \
@@ -236,22 +234,7 @@ conda install -y \
     cmake `# required to build the examples only`
 ```
 
-* **Windows\***:
-
-```bat
-conda install -y^
-    -c https://software.repos.intel.com/python/conda/^
-    -c conda-forge^
-    make "python>=3.9"^
-    dpcpp-cpp-rt dpcpp_win-64 intel-sycl-rt^
-    tbb tbb-devel^
-    mkl mkl-devel mkl-static mkl-dpcpp mkl-devel-dpcpp^
-    cmake
-```
-
 Then modify the relevant environment variables to point to the conda-installed libraries:
-
-* **Linux\***:
 
 ```shell
 export MKLROOT=${CONDA_PREFIX}
@@ -262,19 +245,6 @@ export CPATH="${CONDA_PREFIX}/include:${CPATH}"
 export PATH="${CONDA_PREFIX}/bin:${PATH}"
 export PKG_CONFIG_PATH="${CONDA_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 export CMAKE_PREFIX_PATH="${CONDA_PREFIX}/lib/cmake:${CMAKE_PREFIX_PATH}"
-```
-
-* **Windows\***:
-
-```bat
-set MKLROOT=%CONDA_PREFIX%\Library
-set TBBROOT=%CONDA_PREFIX%\Library
-set "LD_LIBRARY_PATH=%CONDA_PREFIX%\Library\lib;%LD_LIBRARY_PATH%"
-set "LIBRARY_PATH=%CONDA_PREFIX%\Library\lib;%LIBRARY_PATH%"
-set "CPATH=%CONDA_PREFIX%\Library\include;%CPATH%"
-set "PATH=%CONDA_PREFIX%\Library\bin;%PATH%"
-set "PKG_CONFIG_PATH=%CONDA_PREFIX%\Library\lib\pkgconfig;%PKG_CONFIG_PATH%"
-set "CMAKE_PREFIX_PATH=%CONDA_PREFIX%\Library\lib\cmake;%CMAKE_PREFIX_PATH%"
 ```
 
 After that, it should be possible to build oneDAL and run the examples using the ICX compiler and the oneMKL libraries as per the instructions.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -242,7 +242,7 @@ conda install -y \
 conda install -y^
     -c https://software.repos.intel.com/python/conda/^
     -c conda-forge^
-    make dos2unix "python>=3.9"^
+    make "python>=3.9"^
     dpcpp-cpp-rt dpcpp_win-64 intel-sycl-rt^
     tbb tbb-devel^
     mkl mkl-devel mkl-static mkl-dpcpp mkl-devel-dpcpp^


### PR DESCRIPTION
## Description

~This PR removes the suggestion to install `dos2unix` from conda on windows, since it's not available in that platform:~
https://anaconda.org/conda-forge/dos2unix

This PR removes the current instructions for building with conda-installed tools on windows.

Reason for removal: (a) not all of the necessary software is offered through conda; (b) instructions do not work - e.g. setting `%TBBROOT%` the way it is suggested here would not result in the Makefile finding TBB (paths on windows are different, as they then have `lib`, `bin`, etc.).

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.

**Performance**

Not applicable.
