### PR TITLE
Regression algorithm Coverity fixes (rule-of-three violation)

### DIFF
--- a/cpp/daal/include/algorithms/regression/regression_predict_types.h
+++ b/cpp/daal/include/algorithms/regression/regression_predict_types.h
@@ -90,6 +90,7 @@ public:
     /** Default constructor */
     Input(size_t nElements = 0);
     Input(const Input & other);
+    Input & operator=(const Input & other);
 
     /**
      * Returns an input object for making the regression model-based prediction

--- a/cpp/daal/include/algorithms/regression/regression_training_types.h
+++ b/cpp/daal/include/algorithms/regression/regression_training_types.h
@@ -85,6 +85,7 @@ public:
      */
     Input(size_t nElements = lastInputId + 1);
     Input(const Input & other);
+    Input & operator=(const Input & other);
 
     virtual ~Input() {}
 

--- a/cpp/daal/src/algorithms/regression/regression_prediction_batch.cpp
+++ b/cpp/daal/src/algorithms/regression/regression_prediction_batch.cpp
@@ -42,6 +42,7 @@ __DAAL_REGISTER_SERIALIZATION_CLASS(Result, SERIALIZATION_REGRESSION_PREDICTION_
 
 Input::Input(size_t nElements) : daal::algorithms::Input(nElements) {}
 Input::Input(const Input & other) : daal::algorithms::Input(other) {}
+Input & Input::operator=(const Input & other) = default;
 
 NumericTablePtr Input::get(NumericTableInputId id) const
 {

--- a/cpp/daal/src/algorithms/regression/regression_training_input.cpp
+++ b/cpp/daal/src/algorithms/regression/regression_training_input.cpp
@@ -39,6 +39,7 @@ using namespace daal::data_management;
 using namespace daal::services;
 Input::Input(size_t nElements) : daal::algorithms::Input(nElements) {}
 Input::Input(const Input & other) : daal::algorithms::Input(other) {}
+Input & Input::operator=(const Input & other) = default;
 
 data_management::NumericTablePtr Input::get(InputId id) const
 {


### PR DESCRIPTION
## Description

Adds copy assignment operator to Regression Algorithm.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
