### PR TITLE
[bug] fix intermittent failures in LinuxMakeDPCPP(AVX512) github action

### DIFF
--- a/makefile
+++ b/makefile
@@ -1057,8 +1057,8 @@ $(CORE.incdirs): _release_c_h
 
 define .release.dd
 $3: $2
-$2: $1 ; $(value mkdir)$(value cpy)
-	$(if $(filter %library_version_info.h,$2),+$(daalmake) -f makefile update_headers_version)
+$2: $1 ; $(value mkdir)
+	$(if $(filter %library_version_info.h,$2),+$(daalmake) -f makefile update_headers_version, $(value cpy))
 	$(if $(USECPUS.out.defs.filter),$(if $(filter %daal_kernel_defines.h,$2),$(USECPUS.out.defs.filter) $2; rm -rf $(subst .h,.h.bak,$2)))
 endef
 $(foreach d,$(release.HEADERS.COMMON),$(eval $(call .release.dd,$d,$(subst $(CPPDIR.daal)/include/,$(RELEASEDIR.include)/,$d),_release_c_h)))

--- a/makefile.ver
+++ b/makefile.ver
@@ -62,16 +62,15 @@ $(VERSION_DATA_FILE): | $(WORKDIR)/.
 update_headers_version:
 	@relfile=$(RELEASEDIR.include)/services/library_version_info.h && \
 	workfile=$(CPPDIR.daal)/include/services/library_version_info.h && mark="#define __INTEL_DAAL" && \
-	cp -fp $$workfile $$relfile.tmp && \
-        sed $(sed.-b) $(sed.-i) \
-		-e "s/_DAAL_BUILD_DATE.*/_DAAL_BUILD_DATE $(BUILD)$(sed.eol)/" \
-		-e "s/\($${mark}__\).*/\1 $(MAJOR)$(sed.eol)/" \
-		-e "s/\($${mark}_MINOR__\).*/\1 $(MINOR)$(sed.eol)/" \
-		-e "s/\($${mark}_MAJOR_BINARY__\).*/\1 $(MAJORBINARY)$(sed.eol)/" \
-		-e "s/\($${mark}_MINOR_BINARY__\).*/\1 $(MINORBINARY)$(sed.eol)/" \
-		-e "s/\($${mark}_UPDATE__\).*/\1 $(UPDATE)$(sed.eol)/" \
-		-e "s/\($${mark}_STATUS__\).*/\1 \"$(STATUS)\"$(sed.eol)/" \
-	        $$relfile.tmp && \
+        sed $(sed.-b) \
+		-e "H;1h;$!d;x;s/_DAAL_BUILD_DATE.*/_DAAL_BUILD_DATE $(BUILD)$(sed.eol)/" \
+		-e "H;1h;$!d;x;s/\($${mark}__\).*/\1 $(MAJOR)$(sed.eol)/" \
+		-e "H;1h;$!d;x;s/\($${mark}_MINOR__\).*/\1 $(MINOR)$(sed.eol)/" \
+		-e "H;1h;$!d;x;s/\($${mark}_MAJOR_BINARY__\).*/\1 $(MAJORBINARY)$(sed.eol)/" \
+		-e "H;1h;$!d;x;s/\($${mark}_MINOR_BINARY__\).*/\1 $(MINORBINARY)$(sed.eol)/" \
+		-e "H;1h;$!d;x;s/\($${mark}_UPDATE__\).*/\1 $(UPDATE)$(sed.eol)/" \
+		-e "H;1h;$!d;x;s/\($${mark}_STATUS__\).*/\1 \"$(STATUS)\"$(sed.eol)/" \
+	        $$workfile > $$relfile.tmp && \
 	if ! cmp -s $$relfile.tmp $$relfile; then \
 		mv $$relfile.tmp $$relfile; \
 	else \

--- a/makefile.ver
+++ b/makefile.ver
@@ -61,7 +61,7 @@ $(VERSION_DATA_FILE): | $(WORKDIR)/.
 # update public headers in release directory with actual version data
 update_headers_version:
 	@relfile=$(RELEASEDIR.include)/services/library_version_info.h && \
-	@workfile=$(CPPDIR.daal)/include/services/library_version_info.h && mark="#define __INTEL_DAAL" && \
+	workfile=$(CPPDIR.daal)/include/services/library_version_info.h && mark="#define __INTEL_DAAL" && \
 	sed $(sed.-b) \
 		-e "s/_DAAL_BUILD_DATE.*/_DAAL_BUILD_DATE $(BUILD)$(sed.eol)/" \
 		-e "s/\($${mark}__\).*/\1 $(MAJOR)$(sed.eol)/" \

--- a/makefile.ver
+++ b/makefile.ver
@@ -62,7 +62,8 @@ $(VERSION_DATA_FILE): | $(WORKDIR)/.
 update_headers_version:
 	@relfile=$(RELEASEDIR.include)/services/library_version_info.h && \
 	workfile=$(CPPDIR.daal)/include/services/library_version_info.h && mark="#define __INTEL_DAAL" && \
-	sed $(sed.-b) \
+	cp -fp $$workfile $$relfile.tmp \
+        sed $(sed.-b) $(sed.-i) \
 		-e "s/_DAAL_BUILD_DATE.*/_DAAL_BUILD_DATE $(BUILD)$(sed.eol)/" \
 		-e "s/\($${mark}__\).*/\1 $(MAJOR)$(sed.eol)/" \
 		-e "s/\($${mark}_MINOR__\).*/\1 $(MINOR)$(sed.eol)/" \
@@ -70,7 +71,7 @@ update_headers_version:
 		-e "s/\($${mark}_MINOR_BINARY__\).*/\1 $(MINORBINARY)$(sed.eol)/" \
 		-e "s/\($${mark}_UPDATE__\).*/\1 $(UPDATE)$(sed.eol)/" \
 		-e "s/\($${mark}_STATUS__\).*/\1 \"$(STATUS)\"$(sed.eol)/" \
-		$$workfile > $$relfile.tmp && \
+	        $$relfile.tmp && \
 	if ! cmp -s $$relfile.tmp $$relfile; then \
 		mv $$relfile.tmp $$relfile; \
 	else \

--- a/makefile.ver
+++ b/makefile.ver
@@ -61,7 +61,10 @@ $(VERSION_DATA_FILE): | $(WORKDIR)/.
 # update public headers in release directory with actual version data
 update_headers_version:
 	@file=$(RELEASEDIR.include)/services/library_version_info.h && mark="#define __INTEL_DAAL" && \
-	sed $(sed.-b) -i \
+	# update public headers in release directory with actual version data
+update_headers_version:
+	@file=$(RELEASEDIR.include)/services/library_version_info.h && mark="#define __INTEL_DAAL" && \
+	sed $(sed.-b) \
 		-e "s/_DAAL_BUILD_DATE.*/_DAAL_BUILD_DATE $(BUILD)$(sed.eol)/" \
 		-e "s/\($${mark}__\).*/\1 $(MAJOR)$(sed.eol)/" \
 		-e "s/\($${mark}_MINOR__\).*/\1 $(MINOR)$(sed.eol)/" \
@@ -69,4 +72,9 @@ update_headers_version:
 		-e "s/\($${mark}_MINOR_BINARY__\).*/\1 $(MINORBINARY)$(sed.eol)/" \
 		-e "s/\($${mark}_UPDATE__\).*/\1 $(UPDATE)$(sed.eol)/" \
 		-e "s/\($${mark}_STATUS__\).*/\1 \"$(STATUS)\"$(sed.eol)/" \
-		$$file 
+		$$file > $$file.tmp && \
+	if ! cmp -s $$file.tmp $$file; then \
+		mv $$file.tmp $$file; \
+	else \
+		rm $$file.tmp; \
+	fi

--- a/makefile.ver
+++ b/makefile.ver
@@ -62,7 +62,7 @@ $(VERSION_DATA_FILE): | $(WORKDIR)/.
 update_headers_version:
 	@relfile=$(RELEASEDIR.include)/services/library_version_info.h && \
 	workfile=$(CPPDIR.daal)/include/services/library_version_info.h && mark="#define __INTEL_DAAL" && \
-	cp -fp $$workfile $$relfile.tmp \
+	cp -fp $$workfile $$relfile.tmp && \
         sed $(sed.-b) $(sed.-i) \
 		-e "s/_DAAL_BUILD_DATE.*/_DAAL_BUILD_DATE $(BUILD)$(sed.eol)/" \
 		-e "s/\($${mark}__\).*/\1 $(MAJOR)$(sed.eol)/" \

--- a/makefile.ver
+++ b/makefile.ver
@@ -60,7 +60,8 @@ $(VERSION_DATA_FILE): | $(WORKDIR)/.
 
 # update public headers in release directory with actual version data
 update_headers_version:
-	@file=$(RELEASEDIR.include)/services/library_version_info.h && mark="#define __INTEL_DAAL" && \
+	@relfile=$(RELEASEDIR.include)/services/library_version_info.h && \
+	@workfile=$(CPPDIR.daal)/include/services/library_version_info.h && mark="#define __INTEL_DAAL" && \
 	sed $(sed.-b) \
 		-e "s/_DAAL_BUILD_DATE.*/_DAAL_BUILD_DATE $(BUILD)$(sed.eol)/" \
 		-e "s/\($${mark}__\).*/\1 $(MAJOR)$(sed.eol)/" \
@@ -69,9 +70,9 @@ update_headers_version:
 		-e "s/\($${mark}_MINOR_BINARY__\).*/\1 $(MINORBINARY)$(sed.eol)/" \
 		-e "s/\($${mark}_UPDATE__\).*/\1 $(UPDATE)$(sed.eol)/" \
 		-e "s/\($${mark}_STATUS__\).*/\1 \"$(STATUS)\"$(sed.eol)/" \
-		$$file > $$file.tmp && \
-	if ! cmp -s $$file.tmp $$file; then \
-		mv $$file.tmp $$file; \
+		$$workfile > $$relfile.tmp && \
+	if ! cmp -s $$relfile.tmp $$relfile; then \
+		mv $$relfile.tmp $$relfile; \
 	else \
-		rm $$file.tmp; \
+		rm $$relfile.tmp; \
 	fi

--- a/makefile.ver
+++ b/makefile.ver
@@ -61,9 +61,6 @@ $(VERSION_DATA_FILE): | $(WORKDIR)/.
 # update public headers in release directory with actual version data
 update_headers_version:
 	@file=$(RELEASEDIR.include)/services/library_version_info.h && mark="#define __INTEL_DAAL" && \
-	# update public headers in release directory with actual version data
-update_headers_version:
-	@file=$(RELEASEDIR.include)/services/library_version_info.h && mark="#define __INTEL_DAAL" && \
 	sed $(sed.-b) \
 		-e "s/_DAAL_BUILD_DATE.*/_DAAL_BUILD_DATE $(BUILD)$(sed.eol)/" \
 		-e "s/\($${mark}__\).*/\1 $(MAJOR)$(sed.eol)/" \

--- a/makefile.ver
+++ b/makefile.ver
@@ -61,18 +61,20 @@ $(VERSION_DATA_FILE): | $(WORKDIR)/.
 # update public headers in release directory with actual version data
 update_headers_version:
 	@relfile=$(RELEASEDIR.include)/services/library_version_info.h && \
-	workfile=$(CPPDIR.daal)/include/services/library_version_info.h && mark="#define __INTEL_DAAL" && \
+	workfile=$(CPPDIR.daal)/include/services/library_version_info.h && \
+	file=$$relfile && \
+	if [ -a $$relfile ]; then file=$$file.tmp; fi && mark="#define __INTEL_DAAL" && \
         sed $(sed.-b) \
-		-e "H;1h;$!d;x;s/_DAAL_BUILD_DATE.*/_DAAL_BUILD_DATE $(BUILD)$(sed.eol)/" \
-		-e "H;1h;$!d;x;s/\($${mark}__\).*/\1 $(MAJOR)$(sed.eol)/" \
-		-e "H;1h;$!d;x;s/\($${mark}_MINOR__\).*/\1 $(MINOR)$(sed.eol)/" \
-		-e "H;1h;$!d;x;s/\($${mark}_MAJOR_BINARY__\).*/\1 $(MAJORBINARY)$(sed.eol)/" \
-		-e "H;1h;$!d;x;s/\($${mark}_MINOR_BINARY__\).*/\1 $(MINORBINARY)$(sed.eol)/" \
-		-e "H;1h;$!d;x;s/\($${mark}_UPDATE__\).*/\1 $(UPDATE)$(sed.eol)/" \
-		-e "H;1h;$!d;x;s/\($${mark}_STATUS__\).*/\1 \"$(STATUS)\"$(sed.eol)/" \
-	        $$workfile > $$relfile.tmp && \
-	if ! cmp -s $$relfile.tmp $$relfile; then \
-		mv $$relfile.tmp $$relfile; \
-	else \
+		-e "s/_DAAL_BUILD_DATE.*/_DAAL_BUILD_DATE $(BUILD)$(sed.eol)/" \
+		-e "s/\($${mark}__\).*/\1 $(MAJOR)$(sed.eol)/" \
+		-e "s/\($${mark}_MINOR__\).*/\1 $(MINOR)$(sed.eol)/" \
+		-e "s/\($${mark}_MAJOR_BINARY__\).*/\1 $(MAJORBINARY)$(sed.eol)/" \
+		-e "s/\($${mark}_MINOR_BINARY__\).*/\1 $(MINORBINARY)$(sed.eol)/" \
+		-e "s/\($${mark}_UPDATE__\).*/\1 $(UPDATE)$(sed.eol)/" \
+		-e "s/\($${mark}_STATUS__\).*/\1 \"$(STATUS)\"$(sed.eol)/" \
+	        $$workfile > $$file && \
+	if ! cmp -s $$file $$relfile; then \
+		mv $$file $$relfile; \
+	elif [ -a $$relfile.tmp ]; then \
 		rm $$relfile.tmp; \
 	fi

--- a/makefile.ver
+++ b/makefile.ver
@@ -61,7 +61,7 @@ $(VERSION_DATA_FILE): | $(WORKDIR)/.
 # update public headers in release directory with actual version data
 update_headers_version:
 	@file=$(RELEASEDIR.include)/services/library_version_info.h && mark="#define __INTEL_DAAL" && \
-	sed $(sed.-b) \
+	sed $(sed.-b) -i \
 		-e "s/_DAAL_BUILD_DATE.*/_DAAL_BUILD_DATE $(BUILD)$(sed.eol)/" \
 		-e "s/\($${mark}__\).*/\1 $(MAJOR)$(sed.eol)/" \
 		-e "s/\($${mark}_MINOR__\).*/\1 $(MINOR)$(sed.eol)/" \
@@ -69,9 +69,4 @@ update_headers_version:
 		-e "s/\($${mark}_MINOR_BINARY__\).*/\1 $(MINORBINARY)$(sed.eol)/" \
 		-e "s/\($${mark}_UPDATE__\).*/\1 $(UPDATE)$(sed.eol)/" \
 		-e "s/\($${mark}_STATUS__\).*/\1 \"$(STATUS)\"$(sed.eol)/" \
-		$$file > $$file.tmp; \
-	if ! cmp -s $$file.tmp $$file; then \
-		mv $$file.tmp $$file; \
-	else \
-		rm $$file.tmp; \
-	fi
+		$$file 


### PR DESCRIPTION
## Description

Not always, but often the following error will occur:

```mv: cannot stat './__release_lnx/daal/latest/include/services/library_version_info.h.tmp': No such file or directory```

Which signifies that the ```makefile.ver``` command ```update_headers_version``` is not completing correctly, specifically the commands of ```sed``` or ```cp``` are not completing before ```mv``` is called, causing the failure. New logic is added which will avoid the ```mv``` entirely by only writing to a temporary file if the release file exists, which will then trigger the logic introduced in  #2949.  The copy is removed for this case as the ```sed``` call will accomplish this task.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
