### PR TITLE
[CI, enhancement] set compute runtime GPU settings to improve GPU runner stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
         run: |
           source /opt/intel/oneapi/setvars.sh
           .ci/scripts/describe_system.sh
+      - name: Set environment variables
+        run: |
+          # reduce GPU driver/runner related memory issues
+          echo "NEOReadDebugKeys=1" >> "$GITHUB_ENV"
+          echo "EnableRecoverablePageFaults=1" >> "$GITHUB_ENV"
+          echo "DisableScratchPages=0" >> "$GITHUB_ENV"
+          echo "GpuFaultCheckThreshold=0" >> "$GITHUB_ENV"
       - name: Make daal debug
         run: |
           source /opt/intel/oneapi/setvars.sh
@@ -100,11 +107,6 @@ jobs:
       - name: oneapi/dpc examples
         run: |
             source /opt/intel/oneapi/setvars.sh
-            # reduce GPU driver/runner related memory issues
-            export NEOReadDebugKeys=1
-            export EnableRecoverablePageFaults=1
-            export DisableScratchPages=0
-            export GpuFaultCheckThreshold=0
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/dpc --build-system cmake
       - name: daal/cpp/mpi examples
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,11 @@ jobs:
       - name: oneapi/dpc examples
         run: |
             source /opt/intel/oneapi/setvars.sh
+            # reduce GPU driver/runner related memory issues
+            export NEOReadDebugKeys=1
+            export EnableRecoverablePageFaults=1
+            export DisableScratchPages=0
+            export GpuFaultCheckThreshold=0
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/dpc --build-system cmake
       - name: daal/cpp/mpi examples
         run: |


### PR DESCRIPTION
## Description

These settings are recommended with more recent Intel GPU drivers for memory usage and GPU stability. This may help improve the self_hosted GPU runner stability used in the LinuxMakeDPCPP(AVX512) github actions CI job.  It is only applied in the step which utilizes the GPU, the dpc example operation.  Note that this step currently doesn't fail, but it may be impacting the release of memory, which over multiple jobs may lead to a crash in the runner.  This is not a "causational" fix, but a more "best practices" one.
 
No performance benchmarks necessary

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
