### PR TITLE
[enhancement] Add ability to integrate sanitizers in oneDAL Make builds

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -173,13 +173,13 @@ On **Linux\*** it is possible to build debug version of oneDAL or the version th
 
 It is possible to integrate various sanitizers by specifying the REQSAN flag, available sanitizers are dependent on the compiler.
 
-- To build oneDAL with [AddressSanitizer](https://github.com/google/sanitizers/wiki/addresssanitizer) integration, run:
+- To integrate [AddressSanitizer](https://github.com/google/sanitizers/wiki/addresssanitizer) in a oneDAL release, run:
 
     _Note: Windows support of REQSAN in oneDAL is experimental, static AddressSanitizer can be set with value: static_
 
             make -f makefile daal oneapi_c PLAT=lnx32e REQSAN=address REQDBG=yes
 
-- To build oneDAL with [MemorySanitizer](https://github.com/google/sanitizers/wiki/memorysanitizer), run:
+- To integrate [MemorySanitizer](https://github.com/google/sanitizers/wiki/memorysanitizer) in a oneDAL release, run:
 
     _Note: Clang and Clang-derived compilers support MSan and TSan (including the Intel DPC++ compiler)_
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -171,6 +171,12 @@ To build oneDAL to include only debug symbols, run:
 
             make -f makefile daal oneapi_c PLAT=lnx32e REQDBG=symbols
 
+- To build oneDAL with [AddressSanitizer](https://github.com/google/sanitizers/wiki/addresssanitizer) integration, run:
+
+    _Note: Windows support of ASan in oneDAL is experimental, static linking of ASan possible with REQASAN=static_
+
+            make -f makefile daal oneapi_c PLAT=lnx32e REQASAN=yes
+
 - To build oneDAL with kernel profiling information (`REQPROFILE=yes`):
 
     _Note: if you used the general oneAPI setvars script from a Base Toolkit installation, those steps will not be necessary as Intel(R) VTune(TM) Profiler will already have been set up._

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -181,7 +181,7 @@ It is possible to integrate various sanitizers by specifying the REQSAN flag, av
 
 - To integrate [MemorySanitizer](https://github.com/google/sanitizers/wiki/memorysanitizer) in a debug oneDAL build, run:
 
-    _Note: Clang and Clang-derived compilers support MSan and TSan (including the Intel DPC++ compiler)_
+    _Note: Clang and Clang-derived compilers (including the Intel DPC++ compiler) support additional sanitizers such MSan, TSan, and UBSan_
 
             make -f makefile daal oneapi_c PLAT=lnx32e REQSAN=memory REQDBG=yes
   

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -171,15 +171,17 @@ On **Linux\*** it is possible to build debug version of oneDAL or the version th
 
             make -f makefile daal oneapi_c PLAT=lnx32e REQDBG=symbols
 
+It is possible to integrate various sanitizers by specifying the REQSAN flag, available sanitizers are dependent on the compiler.
+
 - To build oneDAL with [AddressSanitizer](https://github.com/google/sanitizers/wiki/addresssanitizer) integration, run:
 
-    _Note: Windows support of ASan in oneDAL is experimental, AddressSanitizer is the default_
+    _Note: Windows support of REQSAN in oneDAL is experimental, static AddressSanitizer can be set with value: static_
 
-            make -f makefile daal oneapi_c PLAT=lnx32e REQSAN=yes
+            make -f makefile daal oneapi_c PLAT=lnx32e REQSAN=address REQDBG=yes
 
 - To build oneDAL with [MemorySanitizer](https://github.com/google/sanitizers/wiki/memorysanitizer), run:
 
-    _Note: Only available on Clang and Clang-derived compilers_
+    _Note: Clang and Clang-derived compilers support MSan and TSan (including the Intel DPC++ compiler)_
 
             make -f makefile daal oneapi_c PLAT=lnx32e REQSAN=memory
   

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -175,25 +175,19 @@ On **Linux\*** it is possible to build debug version of oneDAL or the version th
 
     _Note: Windows support of ASan in oneDAL is experimental, AddressSanitizer is the default_
 
-            make -f makefile daal oneapi_c PLAT=lnx32e REQASAN=yes
+            make -f makefile daal oneapi_c PLAT=lnx32e REQSAN=yes
 
-- To build oneDAL with [MemorySanitizer](https://github.com/google/sanitizers/wiki/memorysanitizer) and static linking, run:
+- To build oneDAL with [MemorySanitizer](https://github.com/google/sanitizers/wiki/memorysanitizer), run:
 
     _Note: Only available on Clang and Clang-derived compilers_
 
-            make -f makefile daal oneapi_c PLAT=lnx32e REQASAN="memory static"
+            make -f makefile daal oneapi_c PLAT=lnx32e REQSAN=memory
   
 - To build oneDAL with gcov code coverage tool integration, run:
 
     _Note: Only available when building with the Intel DPC++ compiler on Linux operating systems_
 
             make -f makefile daal oneapi_c PLAT=lnx32e CODE_COVERAGE=yes  
-
-- To build oneDAL with [AddressSanitizer](https://github.com/google/sanitizers/wiki/addresssanitizer) integration, run:
-
-    _Note: Windows support of ASan in oneDAL is experimental, static linking of ASan possible with REQASAN=static_
-
-            make -f makefile daal oneapi_c PLAT=lnx32e REQASAN=yes
 
 - To build oneDAL with kernel profiling information (`REQPROFILE=yes`):
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -173,17 +173,17 @@ On **Linux\*** it is possible to build debug version of oneDAL or the version th
 
 It is possible to integrate various sanitizers by specifying the REQSAN flag, available sanitizers are dependent on the compiler.
 
-- To integrate [AddressSanitizer](https://github.com/google/sanitizers/wiki/addresssanitizer) in a oneDAL release, run:
+- To integrate [AddressSanitizer](https://github.com/google/sanitizers/wiki/addresssanitizer) in a debug oneDAL build (recommended), run:
 
     _Note: Windows support of REQSAN in oneDAL is experimental, static AddressSanitizer can be set with value: static_
 
             make -f makefile daal oneapi_c PLAT=lnx32e REQSAN=address REQDBG=yes
 
-- To integrate [MemorySanitizer](https://github.com/google/sanitizers/wiki/memorysanitizer) in a oneDAL release, run:
+- To integrate [MemorySanitizer](https://github.com/google/sanitizers/wiki/memorysanitizer) in a debug oneDAL build, run:
 
     _Note: Clang and Clang-derived compilers support MSan and TSan (including the Intel DPC++ compiler)_
 
-            make -f makefile daal oneapi_c PLAT=lnx32e REQSAN=memory
+            make -f makefile daal oneapi_c PLAT=lnx32e REQSAN=memory REQDBG=yes
   
 - To build oneDAL with gcov code coverage tool integration, run:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -170,6 +170,18 @@ On **Linux\*** it is possible to build debug version of oneDAL or the version th
 - To build oneDAL to include only debug symbols, run:
 
             make -f makefile daal oneapi_c PLAT=lnx32e REQDBG=symbols
+
+- To build oneDAL with [AddressSanitizer](https://github.com/google/sanitizers/wiki/addresssanitizer) integration, run:
+
+    _Note: Windows support of ASan in oneDAL is experimental, AddressSanitizer is the default_
+
+            make -f makefile daal oneapi_c PLAT=lnx32e REQASAN=yes
+
+- To build oneDAL with [MemorySanitizer](https://github.com/google/sanitizers/wiki/memorysanitizer) and static linking, run:
+
+    _Note: Only available on Clang and Clang-derived compilers_
+
+            make -f makefile daal oneapi_c PLAT=lnx32e REQASAN="memory static"
   
 - To build oneDAL with gcov code coverage tool integration, run:
 

--- a/makefile
+++ b/makefile
@@ -142,8 +142,8 @@ y           := $(notdir $(filter $(_OS)/%,lnx/so win/dll mac/dylib))
 # NOTE: only some compilers support other sanitizers, failure is expected by design in order to not
 # quietly hide the lack of support (e.g. gnu will fail with REQSAN=memory). The sanitizer must be
 # explicitly specified. ASan can be statically linked with special value "static", normal use of ASan set with REQSAN=address.
--sanitize   := $(if $(REQSAN),$(if $(COMPILER_is_vc),/fsanitize=,-fsanitize=)$(if ifeq ($(REQSAN),static),address,$(REQSAN)))
--lsanitize  := $(-sanitize) $(if $(REQSAN),$(if ifeq ($(REQSAN),static),-static-libasan))
+-sanitize   := $(if $(REQSAN),$(if $(COMPILER_is_vc),/,-)fsanitize=$(if ifeq ($(REQSAN),static),address,$(REQSAN)) -fno-omit-frame-pointer)
+-lsanitize  := $(if $(REQSAN),$(if $(COMPILER_is_vc),/,-)fsanitize=$(if ifeq ($(REQSAN),static),address -static-libasan,$(REQSAN)))
 -EHsc       := $(if $(OS_is_win),-EHsc,)
 -isystem    := $(if $(OS_is_win),-I,-isystem)
 -sGRP       := $(if $(OS_is_lnx),-Wl$(comma)--start-group,)

--- a/makefile
+++ b/makefile
@@ -140,7 +140,8 @@ y           := $(notdir $(filter $(_OS)/%,lnx/so win/dll mac/dylib))
 -DEBC_DPCPP := $(if $(REQDBG),$(if $(filter symbols,$(REQDBG)),$(-DEBC.dpcpp),$(-DEBC.dpcpp) -DDEBUG_ASSERT -DONEDAL_ENABLE_ASSERT))
 -DEBL       := $(if $(REQDBG),$(if $(OS_is_win),-debug,))
 # NOTE: only some compilers support other sanitizers, failure is expected by design in order to not
-# quietly hide the lack of support (e.g. gnu will fail with REQASAN=memory). Default `address` is universally supported.
+# quietly hide the lack of support (e.g. gnu will fail with REQSAN=memory). The default is AddressSanitizer
+# as it is available by all compilers which build oneDAL.
 -sanitize   := $(if $(REQSAN),$(if $(COMPILER_is_vc),/fsanitize=,-fsanitize=)$(if $(filter memory,$(REQSAN)),memory,$(if $(filter thread,$(REQSAN)),thread,address)))
 -lsanitize  := $(-sanitize) $(if $(REQSAN),$(if $(filter static,$(REQSAN)),-static-libasan))
 -EHsc       := $(if $(OS_is_win),-EHsc,)

--- a/makefile
+++ b/makefile
@@ -1138,7 +1138,7 @@ Flags:
       except value "symbols" which will only add debug symbols.
       special value: symbols
   REQPROFILE - flag that enables kernel profiling using <ittnotify.h>
-  REQSAN - flag that integrates a Google sanitizer (ASan, TSan, and MSan).
+  REQSAN - flag that integrates a Google sanitizer (ASan, TSan, or MSan).
       Any value will enable ASan integration. A value of "static" will use 
       the static ASan library (use on Windows is unverified). A value of 
       "memory" will use the MemorySanitizer, and "thread" will integrate 

--- a/makefile
+++ b/makefile
@@ -141,7 +141,7 @@ y           := $(notdir $(filter $(_OS)/%,lnx/so win/dll mac/dylib))
 -DEBL       := $(if $(REQDBG),$(if $(OS_is_win),-debug,))
 # NOTE: only some compilers support other sanitizers, failure is expected by design in order to not
 # quietly hide the lack of support (e.g. gnu will fail with REQSAN=memory). The sanitizer must be
-# explicitly specified. ASan can be statically linked with special value "static", ASan set with REQSAN=address.
+# explicitly specified. ASan can be statically linked with special value "static", normal use of ASan set with REQSAN=address.
 -sanitize   := $(if $(REQSAN),$(if $(COMPILER_is_vc),/fsanitize=,-fsanitize=)$(if ifeq ($(REQSAN),static),address,$(REQSAN)))
 -lsanitize  := $(-sanitize) $(if $(REQSAN),$(if ifeq ($(REQSAN),static),-static-libasan))
 -EHsc       := $(if $(OS_is_win),-EHsc,)

--- a/makefile
+++ b/makefile
@@ -140,8 +140,8 @@ y           := $(notdir $(filter $(_OS)/%,lnx/so win/dll mac/dylib))
 -DEBC_DPCPP := $(if $(REQDBG),$(if $(filter symbols,$(REQDBG)),$(-DEBC.dpcpp),$(-DEBC.dpcpp) -DDEBUG_ASSERT -DONEDAL_ENABLE_ASSERT))
 -DEBL       := $(if $(REQDBG),$(if $(OS_is_win),-debug,))
 # NOTE: only some compilers support other sanitizers, failure is expected by design in order to not
-# quietly hide the lack of support (e.g. gnu will fail with REQSAN=memory). The default is AddressSanitizer
-# as it is available by all compilers which build oneDAL, and can be set by REQSAN=address.
+# quietly hide the lack of support (e.g. gnu will fail with REQSAN=memory). The sanitizer must be
+# explicitly specified. ASan can be statically linked with special value "static", ASan set with REQSAN=address.
 -sanitize   := $(if $(REQSAN),$(if $(COMPILER_is_vc),/fsanitize=,-fsanitize=)$(if ifeq ($(REQSAN),static),address,$(REQSAN)))
 -lsanitize  := $(-sanitize) $(if $(REQSAN),$(if ifeq ($(REQSAN),static),-static-libasan))
 -EHsc       := $(if $(OS_is_win),-EHsc,)

--- a/makefile
+++ b/makefile
@@ -141,9 +141,9 @@ y           := $(notdir $(filter $(_OS)/%,lnx/so win/dll mac/dylib))
 -DEBL       := $(if $(REQDBG),$(if $(OS_is_win),-debug,))
 # NOTE: only some compilers support other sanitizers, failure is expected by design in order to not
 # quietly hide the lack of support (e.g. gnu will fail with REQSAN=memory). The default is AddressSanitizer
-# as it is available by all compilers which build oneDAL.
--sanitize   := $(if $(REQSAN),$(if $(COMPILER_is_vc),/fsanitize=,-fsanitize=)$(if $(filter memory,$(REQSAN)),memory,$(if $(filter thread,$(REQSAN)),thread,address)))
--lsanitize  := $(-sanitize) $(if $(REQSAN),$(if $(filter static,$(REQSAN)),-static-libasan))
+# as it is available by all compilers which build oneDAL, and can be set by REQSAN=address.
+-sanitize   := $(if $(REQSAN),$(if $(COMPILER_is_vc),/fsanitize=,-fsanitize=)$(if ifeq ($(REQSAN),static),address,$(REQSAN)))
+-lsanitize  := $(-sanitize) $(if $(REQSAN),$(if ifeq ($(REQSAN),static),-static-libasan))
 -EHsc       := $(if $(OS_is_win),-EHsc,)
 -isystem    := $(if $(OS_is_win),-I,-isystem)
 -sGRP       := $(if $(OS_is_lnx),-Wl$(comma)--start-group,)
@@ -1139,12 +1139,12 @@ Flags:
       except value "symbols" which will only add debug symbols.
       special value: symbols
   REQPROFILE - flag that enables kernel profiling using <ittnotify.h>
-  REQSAN - flag that integrates a Google sanitizer (ASan, TSan, or MSan).
-      Any value will enable ASan integration. A value of "static" will use 
-      the static ASan library (use on Windows is unverified). A value of 
-      "memory" will use the MemorySanitizer, and "thread" will integrate 
-      the ThreadSanitizer.
-      special values: static memory thread
+  REQSAN - flag that integrates a Google sanitizer (e.g. AddressSanitizer).
+      The sanitizer must be specified as the flag value, except for the
+      value of "static". This value will use the static ASan library.
+      Use on Windows is unverified, with the available sanitizers dependent
+      on the compiler. It is recommended to use in tandem with REQDBG.
+      special values: static
   CODE_COVERAGE - flag that integrates the gcov code coverage tool
       can only be enabled when set to value "yes" with the icx compiler on
       a Linux OS

--- a/makefile
+++ b/makefile
@@ -139,6 +139,7 @@ y           := $(notdir $(filter $(_OS)/%,lnx/so win/dll mac/dylib))
 -DEBC       := $(if $(REQDBG),$(if $(filter symbols,$(REQDBG)),$(-DEBC.$(COMPILER)),$(-DEBC.$(COMPILER)) -DDEBUG_ASSERT -DONEDAL_ENABLE_ASSERT)) -DTBB_SUPPRESS_DEPRECATED_MESSAGES -D__TBB_LEGACY_MODE
 -DEBC_DPCPP := $(if $(REQDBG),$(if $(filter symbols,$(REQDBG)),$(-DEBC.dpcpp),$(-DEBC.dpcpp) -DDEBUG_ASSERT -DONEDAL_ENABLE_ASSERT))
 -DEBL       := $(if $(REQDBG),$(if $(OS_is_win),-debug,))
+-sanitize   := $(if $(REQASAN),$(if $(COMPILER_is_vc),/fsanitize=address,-fsanitize=address))
 -EHsc       := $(if $(OS_is_win),-EHsc,)
 -isystem    := $(if $(OS_is_win),-I,-isystem)
 -sGRP       := $(if $(OS_is_lnx),-Wl$(comma)--start-group,)
@@ -522,7 +523,7 @@ $(CORE.objs_a): COPT += @$(CORE.tmpdir_a)/inc_a_folders.txt
 $(eval $(call append_uarch_copt,$(CORE.objs_a)))
 
 $(CORE.objs_y): $(CORE.tmpdir_y)/inc_y_folders.txt
-$(CORE.objs_y): COPT += $(-fPIC) $(-cxx17) $(-Zl) $(-visibility) $(-DEBC) $(-DMKL_ILP64) $(-DPROFILER)
+$(CORE.objs_y): COPT += $(-fPIC) $(-cxx17) $(-Zl) $(-visibility) $(-sanitize) $(-DEBC) $(-DMKL_ILP64) $(-DPROFILER)
 $(CORE.objs_y): COPT += -D__DAAL_IMPLEMENTATION \
                         -D__TBB_NO_IMPLICIT_LINKAGE -DDAAL_NOTHROW_EXCEPTIONS \
                         -DDAAL_HIDE_DEPRECATED -DTBB_USE_ASSERT=0 -D_ENABLE_ATOMIC_ALIGNMENT_FIX \
@@ -705,7 +706,7 @@ $(eval $(call update_copt_from_dispatcher_tag,$(ONEAPI.objs_a.dpc),.dpcpp))
 
 # Set compilation options to the object files which are part of DYNAMIC lib
 $(ONEAPI.objs_y): $(ONEAPI.dispatcher_cpu) $(ONEAPI.tmpdir_y)/inc_y_folders.txt
-$(ONEAPI.objs_y): COPT += $(-fPIC) $(-cxx17) $(-Zl) $(-visibility) $(-DMKL_ILP64) $(-DEBC) $(-EHsc) $(pedantic.opts) \
+$(ONEAPI.objs_y): COPT += $(-fPIC) $(-cxx17) $(-Zl) $(-visibility) $(-sanitize) $(-DMKL_ILP64) $(-DEBC) $(-EHsc) $(pedantic.opts) \
                           -DDAAL_NOTHROW_EXCEPTIONS \
                           -DDAAL_HIDE_DEPRECATED \
                           -D_ENABLE_ATOMIC_ALIGNMENT_FIX \
@@ -721,7 +722,7 @@ $(eval $(call update_copt_from_dispatcher_tag,$(ONEAPI.objs_y)))
 # When compiling with the debug flag $(-DEBC_DPCPP), linking with libonedal_dpc.so may cause indefinite linking times
 # due to the extensive processing of debug information. For debugging, please use the static library version (libonedal_dpc.a).
 $(ONEAPI.objs_y.dpc): $(ONEAPI.dispatcher_cpu) $(ONEAPI.tmpdir_y.dpc)/inc_y_folders.txt
-$(ONEAPI.objs_y.dpc): COPT += $(-fPIC) $(-cxx17) $(-Zl_DPCPP) $(-visibility) $(-DMKL_ILP64) $(-EHsc) $(pedantic.opts.dpcpp) \
+$(ONEAPI.objs_y.dpc): COPT += $(-fPIC) $(-cxx17) $(-Zl_DPCPP) $(-visibility) $(-sanitize) $(-DMKL_ILP64) $(-EHsc) $(pedantic.opts.dpcpp) \
                               -DDAAL_NOTHROW_EXCEPTIONS \
                               -DDAAL_HIDE_DEPRECATED \
                               -DONEDAL_DATA_PARALLEL \
@@ -1129,6 +1130,7 @@ Flags:
       except value "symbols" which will only add debug symbols.
       special value: symbols
   REQPROFILE - flag that enables kernel profiling using <ittnotify.h>
+  REQASAN - flag that integrates AddressSanitizer (ASan)
 endef
 
 daal_dbg:

--- a/makefile
+++ b/makefile
@@ -140,6 +140,7 @@ y           := $(notdir $(filter $(_OS)/%,lnx/so win/dll mac/dylib))
 -DEBC_DPCPP := $(if $(REQDBG),$(if $(filter symbols,$(REQDBG)),$(-DEBC.dpcpp),$(-DEBC.dpcpp) -DDEBUG_ASSERT -DONEDAL_ENABLE_ASSERT))
 -DEBL       := $(if $(REQDBG),$(if $(OS_is_win),-debug,))
 -sanitize   := $(if $(REQASAN),$(if $(COMPILER_is_vc),/fsanitize=address,-fsanitize=address))
+-lsanitize  := $(-sanitize) $(if $(REQASAN),$(if $(filter static,$(REQASAN)),-static-libasan))
 -EHsc       := $(if $(OS_is_win),-EHsc,)
 -isystem    := $(if $(OS_is_win),-I,-isystem)
 -sGRP       := $(if $(OS_is_lnx),-Wl$(comma)--start-group,)
@@ -505,6 +506,7 @@ $(WORKDIR.lib)/$(core_a):                   $(daaldep.math_backend.ext) $(VTUNES
 
 $(WORKDIR.lib)/$(core_y): LOPT += $(-fPIC)
 $(WORKDIR.lib)/$(core_y): LOPT += $(daaldep.rt.seq)
+$(WORKDIR.lib)/$(core_y): LOPT += $(-lsanitize)
 $(WORKDIR.lib)/$(core_y): LOPT += $(if $(OS_is_win),-IMPLIB:$(@:%.$(MAJORBINARY).dll=%_dll.lib),)
 ifdef OS_is_win
 $(WORKDIR.lib)/$(core_y:%.$(MAJORBINARY).dll=%_dll.lib): $(WORKDIR.lib)/$(core_y)
@@ -778,6 +780,7 @@ $(WORKDIR.lib)/$(oneapi_y): \
     $(ONEAPI.tmpdir_y)/$(oneapi_y:%.$y=%_link.txt) ; $(LINK.DYNAMIC) ; $(LINK.DYNAMIC.POST)
 $(WORKDIR.lib)/$(oneapi_y): LOPT += $(-fPIC)
 $(WORKDIR.lib)/$(oneapi_y): LOPT += $(daaldep.rt.seq)
+$(WORKDIR.lib)/$(oneapi_y): LOPT += $(-lsanitize)
 $(WORKDIR.lib)/$(oneapi_y): LOPT += $(if $(OS_is_win),-IMPLIB:$(@:%.$(MAJORBINARY).dll=%_dll.lib),)
 $(WORKDIR.lib)/$(oneapi_y): LOPT += $(if $(OS_is_win),$(WORKDIR.lib)/$(core_y:%.$(MAJORBINARY).dll=%_dll.lib))
 ifdef OS_is_win
@@ -792,6 +795,7 @@ $(WORKDIR.lib)/$(parameters_y): \
     $(ONEAPI.tmpdir_y)/$(parameters_y:%.$y=%_link.txt) ; $(LINK.DYNAMIC) ; $(LINK.DYNAMIC.POST)
 $(WORKDIR.lib)/$(parameters_y): LOPT += $(-fPIC)
 $(WORKDIR.lib)/$(parameters_y): LOPT += $(daaldep.rt.seq)
+$(WORKDIR.lib)/$(parameters_y): LOPT += $(-lsanitize)
 $(WORKDIR.lib)/$(parameters_y): LOPT += $(if $(OS_is_win),-IMPLIB:$(@:%.$(MAJORBINARY).dll=%_dll.lib),)
 $(WORKDIR.lib)/$(parameters_y): LOPT += $(if $(OS_is_win),$(WORKDIR.lib)/$(core_y:%.$(MAJORBINARY).dll=%_dll.lib))
 ifdef OS_is_win
@@ -812,6 +816,7 @@ $(WORKDIR.lib)/$(oneapi_y.dpc): \
 $(WORKDIR.lib)/$(oneapi_y.dpc): LOPT += $(-fPIC)
 $(WORKDIR.lib)/$(oneapi_y.dpc): LOPT += $(daaldep.rt.dpc)
 $(WORKDIR.lib)/$(oneapi_y.dpc): LOPT += $(if $(REQDBG),-flink-huge-device-code,)
+$(WORKDIR.lib)/$(oneapi_y.dpc): LOPT += $(-lsanitize)
 $(WORKDIR.lib)/$(oneapi_y.dpc): LOPT += $(if $(OS_is_win),-IMPLIB:$(@:%.$(MAJORBINARY).dll=%_dll.lib),)
 $(WORKDIR.lib)/$(oneapi_y.dpc): LOPT += $(if $(OS_is_win),$(WORKDIR.lib)/$(core_y:%.$(MAJORBINARY).dll=%_dll.lib))
 $(WORKDIR.lib)/$(oneapi_y.dpc): LOPT += $(if $(OS_is_win),sycl$d.lib OpenCL.lib)
@@ -829,6 +834,7 @@ $(WORKDIR.lib)/$(parameters_y.dpc): \
     $(ONEAPI.tmpdir_y.dpc)/$(parameters_y.dpc:%.$y=%_link.txt) ; $(DPC.LINK.DYNAMIC) ; $(LINK.DYNAMIC.POST)
 $(WORKDIR.lib)/$(parameters_y.dpc): LOPT += $(-fPIC)
 $(WORKDIR.lib)/$(parameters_y.dpc): LOPT += $(daaldep.rt.dpc)
+$(WORKDIR.lib)/$(parameters_y.dpc): LOPT += $(-lsanitize)
 $(WORKDIR.lib)/$(parameters_y.dpc): LOPT += $(if $(OS_is_win),-IMPLIB:$(@:%.$(MAJORBINARY).dll=%_dll.lib),)
 $(WORKDIR.lib)/$(parameters_y.dpc): LOPT += $(if $(OS_is_win),$(WORKDIR.lib)/$(core_y:%.$(MAJORBINARY).dll=%_dll.lib))
 $(WORKDIR.lib)/$(parameters_y.dpc): LOPT += $(if $(OS_is_win), $(if $(libsycl),$(libsycl),$(libsycl.default)) OpenCL.lib)
@@ -861,7 +867,7 @@ THR_TBB.objs_y := $(addprefix $(THR.tmpdir_y)/,$(THR.srcs:%.cpp=%_tbb.$o))
 $(WORKDIR.lib)/$(thr_tbb_a): LOPT:=
 $(WORKDIR.lib)/$(thr_tbb_a): $(THR_TBB.objs_a) ; $(LINK.STATIC)
 
-$(WORKDIR.lib)/$(thr_tbb_y): LOPT += $(-fPIC) $(daaldep.rt.thr)
+$(WORKDIR.lib)/$(thr_tbb_y): LOPT += $(-fPIC) $(daaldep.rt.thr) $(-lsanitize)
 $(WORKDIR.lib)/$(thr_tbb_y): LOPT += $(if $(OS_is_win),-IMPLIB:$(@:%.dll=%_dll.lib),)
 $(WORKDIR.lib)/$(thr_tbb_y): $(THR_TBB.objs_y) $(if $(OS_is_win),$(THR.tmpdir_y)/dll_tbb.res,) ; $(LINK.DYNAMIC) ; $(LINK.DYNAMIC.POST)
 
@@ -1130,7 +1136,10 @@ Flags:
       except value "symbols" which will only add debug symbols.
       special value: symbols
   REQPROFILE - flag that enables kernel profiling using <ittnotify.h>
-  REQASAN - flag that integrates AddressSanitizer (ASan)
+  REQASAN - flag that integrates AddressSanitizer (ASan). Any value will
+      enable ASan integration. A value of "static" will use the static ASan
+      library (use on Windows is unverified).
+      special value: static
 endef
 
 daal_dbg:

--- a/makefile
+++ b/makefile
@@ -1144,7 +1144,7 @@ Flags:
       value of "static". This value will link with the static ASan library.
       Use on Windows is unverified, with the available sanitizers dependent
       on the compiler. It is recommended to use in tandem with REQDBG.
-      special values: static
+      special values: static, address, memory, thread, leak, undefined
   CODE_COVERAGE - flag that integrates the gcov code coverage tool
       can only be enabled when set to value "yes" with the icx compiler on
       a Linux OS

--- a/makefile
+++ b/makefile
@@ -141,8 +141,8 @@ y           := $(notdir $(filter $(_OS)/%,lnx/so win/dll mac/dylib))
 -DEBL       := $(if $(REQDBG),$(if $(OS_is_win),-debug,))
 # NOTE: only some compilers support other sanitizers, failure is expected by design in order to not
 # quietly hide the lack of support (e.g. gnu will fail with REQASAN=memory). Default `address` is universally supported.
--sanitize   := $(if $(REQASAN),$(if $(COMPILER_is_vc),/fsanitize=,-fsanitize=)$(if $(filter memory,$(REQASAN)),memory,$(if $(filter thread,$(REQASAN)),thread,address)))
--lsanitize  := $(-sanitize) $(if $(REQASAN),$(if $(filter static,$(REQASAN)),-static-libasan))
+-sanitize   := $(if $(REQSAN),$(if $(COMPILER_is_vc),/fsanitize=,-fsanitize=)$(if $(filter memory,$(REQSAN)),memory,$(if $(filter thread,$(REQSAN)),thread,address)))
+-lsanitize  := $(-sanitize) $(if $(REQSAN),$(if $(filter static,$(REQSAN)),-static-libasan))
 -EHsc       := $(if $(OS_is_win),-EHsc,)
 -isystem    := $(if $(OS_is_win),-I,-isystem)
 -sGRP       := $(if $(OS_is_lnx),-Wl$(comma)--start-group,)
@@ -1138,7 +1138,7 @@ Flags:
       except value "symbols" which will only add debug symbols.
       special value: symbols
   REQPROFILE - flag that enables kernel profiling using <ittnotify.h>
-  REQSAN - flag that integrates Google sanitizers (ASan, TSan, and MSan).
+  REQSAN - flag that integrates a Google sanitizer (ASan, TSan, and MSan).
       Any value will enable ASan integration. A value of "static" will use 
       the static ASan library (use on Windows is unverified). A value of 
       "memory" will use the MemorySanitizer, and "thread" will integrate 

--- a/makefile
+++ b/makefile
@@ -1141,7 +1141,7 @@ Flags:
   REQPROFILE - flag that enables kernel profiling using <ittnotify.h>
   REQSAN - flag that integrates a Google sanitizer (e.g. AddressSanitizer).
       The sanitizer must be specified as the flag value, except for the
-      value of "static". This value will use the static ASan library.
+      value of "static". This value will link with the static ASan library.
       Use on Windows is unverified, with the available sanitizers dependent
       on the compiler. It is recommended to use in tandem with REQDBG.
       special values: static

--- a/makefile
+++ b/makefile
@@ -514,7 +514,7 @@ $(WORKDIR.lib)/$(core_y):                   $(daaldep.math_backend.ext) $(VTUNES
                                             $(CORE.tmpdir_y)/$(core_y:%.$y=%_link.txt) ; $(LINK.DYNAMIC) ; $(LINK.DYNAMIC.POST)
 
 $(CORE.objs_a): $(CORE.tmpdir_a)/inc_a_folders.txt
-$(CORE.objs_a): COPT += $(-fPIC) $(-cxx17) $(-Zl) $(-DEBC) $(-DMKL_ILP64) $(-DPROFILER)
+$(CORE.objs_a): COPT += $(-fPIC) $(-cxx17) $(-Zl) $(-sanitize) $(-DEBC) $(-DMKL_ILP64) $(-DPROFILER)
 $(CORE.objs_a): COPT += -D__TBB_NO_IMPLICIT_LINKAGE -DDAAL_NOTHROW_EXCEPTIONS \
                         -DDAAL_HIDE_DEPRECATED -DTBB_USE_ASSERT=0 -D_ENABLE_ATOMIC_ALIGNMENT_FIX \
                         $(if $(CHECK_DLL_SIG),-DDAAL_CHECK_DLL_SIG)
@@ -682,7 +682,7 @@ $(ONEAPI.tmpdir_y.dpc)/inc_y_folders.txt: | $(ONEAPI.tmpdir_y.dpc)/.
 
 # Set compilation options to the object files which are part of STATIC lib
 $(ONEAPI.objs_a): $(ONEAPI.dispatcher_cpu) $(ONEAPI.tmpdir_a)/inc_a_folders.txt
-$(ONEAPI.objs_a): COPT += $(-fPIC) $(-cxx17) $(-Zl) $(-DMKL_ILP64) $(-DEBC) $(-EHsc) $(pedantic.opts) \
+$(ONEAPI.objs_a): COPT += $(-fPIC) $(-cxx17) $(-Zl) $(-sanitize) $(-DMKL_ILP64) $(-DEBC) $(-EHsc) $(pedantic.opts) \
                           -DDAAL_NOTHROW_EXCEPTIONS \
                           -DDAAL_HIDE_DEPRECATED \
                           -D_ENABLE_ATOMIC_ALIGNMENT_FIX \
@@ -693,7 +693,7 @@ $(ONEAPI.objs_a): COPT += $(-fPIC) $(-cxx17) $(-Zl) $(-DMKL_ILP64) $(-DEBC) $(-E
 $(eval $(call update_copt_from_dispatcher_tag,$(ONEAPI.objs_a)))
 
 $(ONEAPI.objs_a.dpc): $(ONEAPI.dispatcher_cpu) $(ONEAPI.tmpdir_a.dpc)/inc_a_folders.txt
-$(ONEAPI.objs_a.dpc): COPT += $(-fPIC) $(-cxx17) $(-Zl_DPCPP) $(-DMKL_ILP64) $(-DEBC_DPCPP) $(-EHsc) $(pedantic.opts.dpcpp) \
+$(ONEAPI.objs_a.dpc): COPT += $(-fPIC) $(-cxx17) $(-Zl_DPCPP) $(-sanitize) $(-DMKL_ILP64) $(-DEBC_DPCPP) $(-EHsc) $(pedantic.opts.dpcpp) \
                               -DDAAL_NOTHROW_EXCEPTIONS \
                               -DDAAL_HIDE_DEPRECATED \
                               -DONEDAL_DATA_PARALLEL \

--- a/makefile
+++ b/makefile
@@ -1138,10 +1138,11 @@ Flags:
       except value "symbols" which will only add debug symbols.
       special value: symbols
   REQPROFILE - flag that enables kernel profiling using <ittnotify.h>
-  REQASAN - flag that integrates AddressSanitizer (ASan). Any value will
-      enable ASan integration. A value of "static" will use the static ASan
-      library (use on Windows is unverified). A value of "memory" will use
-      the MemorySanitizer, and "thread" will integrate the ThreadSanitizer.
+  REQSAN - flag that integrates Google sanitizers (ASan, TSan, and MSan).
+      Any value will enable ASan integration. A value of "static" will use 
+      the static ASan library (use on Windows is unverified). A value of 
+      "memory" will use the MemorySanitizer, and "thread" will integrate 
+      the ThreadSanitizer.
       special values: static memory thread
   CODE_COVERAGE - flag that integrates the gcov code coverage tool
       can only be enabled when set to value "yes" with the icx compiler on


### PR DESCRIPTION
## Description

This adds the ```REQSAN``` flag to the make build which can trigger dynamic linking of an available sanitizer into oneDAL.  This will allow for enhanced memory leak and race condition checking among other possibilities. These are determined from the compiler, and is expected to be the responsibilty of the developer to chose a sanitizer which is available. The most standard practice should be to use ```REQDBG=yes REQSAN=address```

The only special case is value ```static``` which will integrate ASan and link its static version, which requires a special linker flag ```-static-libasan```

No performance benchmarks necessary.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
