### PR TITLE
[bugfix] make makefile.ver work with POSIX shells

### DIFF
--- a/makefile.ver
+++ b/makefile.ver
@@ -63,7 +63,7 @@ update_headers_version:
 	@relfile=$(RELEASEDIR.include)/services/library_version_info.h && \
 	workfile=$(CPPDIR.daal)/include/services/library_version_info.h && \
 	file=$$relfile && \
-	if ls $$relfile > /dev/null 2>&1; then file=$$file.tmp; fi && mark="#define __INTEL_DAAL" && \
+	if [ -a "$$relfile" ]; then file=$$file.tmp; fi && mark="#define __INTEL_DAAL" && \
         sed $(sed.-b) \
 		-e "s/_DAAL_BUILD_DATE.*/_DAAL_BUILD_DATE $(BUILD)$(sed.eol)/" \
 		-e "s/\($${mark}__\).*/\1 $(MAJOR)$(sed.eol)/" \
@@ -75,6 +75,6 @@ update_headers_version:
 	        $$workfile > $$file && \
 	if ! cmp -s $$file $$relfile; then \
 		mv $$file $$relfile; \
-	elif ls $$relfile.tmp > /dev/null 2>&1; then \
+	elif [ -a "$$relfile.tmp" ]; then \
 		rm $$relfile.tmp; \
 	fi

--- a/makefile.ver
+++ b/makefile.ver
@@ -63,7 +63,7 @@ update_headers_version:
 	@relfile=$(RELEASEDIR.include)/services/library_version_info.h && \
 	workfile=$(CPPDIR.daal)/include/services/library_version_info.h && \
 	file=$$relfile && \
-	if [ -a $$relfile ]; then file=$$file.tmp; fi && mark="#define __INTEL_DAAL" && \
+	if ls $$relfile > /dev/null 2>&1; then file=$$file.tmp; fi && mark="#define __INTEL_DAAL" && \
         sed $(sed.-b) \
 		-e "s/_DAAL_BUILD_DATE.*/_DAAL_BUILD_DATE $(BUILD)$(sed.eol)/" \
 		-e "s/\($${mark}__\).*/\1 $(MAJOR)$(sed.eol)/" \
@@ -75,6 +75,6 @@ update_headers_version:
 	        $$workfile > $$file && \
 	if ! cmp -s $$file $$relfile; then \
 		mv $$file $$relfile; \
-	elif [ -a $$relfile.tmp ]; then \
+	elif ls $$relfile.tmp > /dev/null 2>&1; then \
 		rm $$relfile.tmp; \
 	fi


### PR DESCRIPTION
## Description

This failure comes from the /bin/sh not understanding the syntax of what was recently implemented in makefile.ver.  This adds quotation marks as per @david-cortes-intel 's suggestion.
Error case can be found here: https://github.com/uxlfoundation/oneDAL/actions/runs/14181809300/job/39729447102
another: https://github.com/uxlfoundation/oneDAL/actions/runs/14194610762/job/39766744941

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
