### PR TITLE
Update CMake version in examples to 3.5

### DIFF
--- a/examples/daal/cpp/CMakeLists.txt
+++ b/examples/daal/cpp/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #===============================================================================
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 set(ONEDAL_USE_DPCPP no)
 set(ONEDAL_INTERFACE no)

--- a/examples/oneapi/cpp/CMakeLists.txt
+++ b/examples/oneapi/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 #===============================================================================
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 set(ONEDAL_USE_DPCPP no)
 set(ONEDAL_INTERFACE yes)

--- a/examples/oneapi/dpc/CMakeLists.txt
+++ b/examples/oneapi/dpc/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 #===============================================================================
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 set(ONEDAL_USE_DPCPP yes)
 set(ONEDAL_INTERFACE yes)


### PR DESCRIPTION
Minimal supported CMake version was updated to 3.5 in examples.
Because CMake dropped compatibility with the previous versions.

---

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.

The failure in [CI (LinuxSklearnex Python311)](https://github.com/uxlfoundation/oneDAL/pull/3156/checks?check_run_id=39911039202) step exists in the main branch and is not related to my changes.

Internal CI failed due to infrastructure reasons, also not related to my changes.

**Performance**

Not applicable.
