### PR TITLE
FIX: Fix potential non-definitiness of BFGS approximation

### DIFF
--- a/cpp/daal/src/algorithms/optimization_solver/lbfgs/lbfgs_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/optimization_solver/lbfgs/lbfgs_dense_default_impl.i
@@ -41,6 +41,9 @@ namespace lbfgs
 {
 namespace internal
 {
+
+constexpr double min_curvature = 1e-8;
+
 template <CpuType cpu>
 bool getOptionalInputData(NumericTable * pCorrectionIndexInput, size_t & lastCorrectionIndex, size_t & lastIteration)
 {
@@ -577,7 +580,7 @@ void LBFGSTask<algorithmFPType, cpu>::computeCorrectionPairImpl(size_t correctio
         BlasInst<algorithmFPType, cpu>::xgemv(&trans, &n, &n, &one, const_cast<algorithmFPType *>(hessian), &n, s, &ione, &zero, y, &ione);
     }
     rho[correctionIndex] = dotProduct<algorithmFPType, cpu>(this->argumentSize, s, y);
-    if (rho[correctionIndex] >= 1e-8) // threshold
+    if (rho[correctionIndex] >= min_curvature) // threshold
     {
         rho[correctionIndex] = 1.0 / rho[correctionIndex];
     }
@@ -857,7 +860,7 @@ Status LBFGSTask<algorithmFPType, cpu>::initCorrectionPairs(NumericTable * corre
             auto s = correctionS + i * this->argumentSize;
             auto y = correctionY + i * this->argumentSize;
             rho[i] = dotProduct<algorithmFPType, cpu>(this->argumentSize, s, y);
-            if (rho[i] != 0.0) // threshold
+            if (rho[i] >= min_curvature) // threshold
             {
                 rho[i] = 1.0 / rho[i];
             }

--- a/cpp/daal/src/algorithms/optimization_solver/lbfgs/lbfgs_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/optimization_solver/lbfgs/lbfgs_dense_default_impl.i
@@ -577,7 +577,7 @@ void LBFGSTask<algorithmFPType, cpu>::computeCorrectionPairImpl(size_t correctio
         BlasInst<algorithmFPType, cpu>::xgemv(&trans, &n, &n, &one, const_cast<algorithmFPType *>(hessian), &n, s, &ione, &zero, y, &ione);
     }
     rho[correctionIndex] = dotProduct<algorithmFPType, cpu>(this->argumentSize, s, y);
-    if (rho[correctionIndex] != 0.0) // threshold
+    if (rho[correctionIndex] >= 1e-8) // threshold
     {
         rho[correctionIndex] = 1.0 / rho[correctionIndex];
     }


### PR DESCRIPTION
## Description

Currently, the L-BFGS code has a logic that discards correction pairs if their curvature is exactly equal to zero.

The approximation requires strict positiveness up to numerical precision, so this condition is insufficient:
* If there's no check for Wolfe conditions, the inner product might be negative, which would still make it pass this check.
* The product can be something very small, like 1e-100, in which case it would lead to issues like numbers turning to infinite.

This PR fixes it by hard-coding a more reasonable threshold, with >= condition.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
