### PR TITLE
Use aligned loads and stores where possible in DAAL memory management

### DIFF
--- a/cpp/daal/include/services/daal_defines.h
+++ b/cpp/daal/include/services/daal_defines.h
@@ -203,6 +203,7 @@ struct IsSameType<U, U>
 };
 
 const size_t DAAL_MALLOC_DEFAULT_ALIGNMENT = 64;
+const size_t DAAL_DEFAULT_ALIGNMENT_MASK   = DAAL_MALLOC_DEFAULT_ALIGNMENT - 1;
 
 const int SERIALIZATION_HOMOGEN_NT_ID             = 1000;
 const int SERIALIZATION_AOS_NT_ID                 = 3000;

--- a/cpp/daal/src/externals/service_memory.cpp
+++ b/cpp/daal/src/externals/service_memory.cpp
@@ -39,10 +39,7 @@ void * daal::services::daal_calloc(size_t size, size_t alignment)
 
     char * cptr = (char *)ptr;
 
-    for (size_t i = 0; i < size; i++)
-    {
-        cptr[i] = '\0';
-    }
+    daal::services::internal::service_memset_seq<char, DAAL_BASE_CPU>(cptr, '\0', size);
 
     return ptr;
 }

--- a/cpp/daal/src/externals/service_memory.h
+++ b/cpp/daal/src/externals/service_memory.h
@@ -50,6 +50,11 @@ namespace internal
 template <typename T, CpuType cpu>
 void service_memset_seq(T * const ptr, const T value, const size_t num)
 {
+    /// TODO: 1. Add aligned branch for the case when num is greater than UINT_MAX
+    ///          and ptr is aligned.
+    ///       2. When possible, split the loop into two parts:
+    ///          - the first part uses unaligned stores until the first aligned address,
+    ///          - the second part uses aligned stores until the end of the block.
     if (num < UINT_MAX && !((DAAL_UINT64)ptr & DAAL_DEFAULT_ALIGNMENT_MASK))
     {
         /// Use aligned stores

--- a/cpp/daal/src/externals/service_memory.h
+++ b/cpp/daal/src/externals/service_memory.h
@@ -115,7 +115,7 @@ struct ServiceInitializer
 template <typename T, CpuType cpu>
 T * service_calloc(size_t size, size_t alignment = DAAL_MALLOC_DEFAULT_ALIGNMENT)
 {
-    T * ptr = (T *)daal::services::daal_malloc(size, alignment);
+    T * ptr = (T *)daal::services::daal_malloc(size * sizeof(T), alignment);
     if (ptr == NULL)
     {
         return NULL;

--- a/cpp/daal/src/externals/service_memory.h
+++ b/cpp/daal/src/externals/service_memory.h
@@ -100,7 +100,7 @@ struct ServiceInitializer
     template <typename T>
     static void memset(T * const ptr, const size_t num)
     {
-        char * cptr = (char *)ptr;
+        char * cptr       = (char *)ptr;
         const size_t size = num * sizeof(T);
 
         service_memset_seq<char, cpu>(cptr, '\0', size);

--- a/cpp/daal/src/externals/service_memory.h
+++ b/cpp/daal/src/externals/service_memory.h
@@ -29,34 +29,133 @@
 #include "src/services/service_defines.h"
 #include "src/threading/threading.h"
 
+#include <climits>     // UINT_MAX
+#include <type_traits> // is_trivially_default_constructible
+
 namespace daal
 {
 namespace services
 {
 namespace internal
 {
+
+/// Initialize block of memory of length num with value.
+///
+/// @tparam T   Data type of the elements in the block.
+/// @tparam cpu Variant of the CPU instruction set: SSE2, SSE4.2, AVX2, AVX512, ARM SVE, etc.
+///
+/// @param ptr      Pointer to the block of memory.
+/// @param value    Value to initialize the block with.
+/// @param num      Number of elements in the block.
 template <typename T, CpuType cpu>
-T * service_calloc(size_t size, size_t alignment = 64)
+void service_memset_seq(T * const ptr, const T value, const size_t num)
 {
-    T * ptr = (T *)daal::services::daal_malloc(size * sizeof(T), alignment);
+    if (num < UINT_MAX && !((DAAL_UINT64)ptr & DAAL_DEFAULT_ALIGNMENT_MASK))
+    {
+        /// Use aligned stores
+        const unsigned int num32 = static_cast<unsigned int>(num);
+        PRAGMA_IVDEP
+        PRAGMA_VECTOR_ALWAYS
+        PRAGMA_VECTOR_ALIGNED
+        for (unsigned int i = 0; i < num32; i++)
+        {
+            ptr[i] = value;
+        }
+    }
+    else
+    {
+        PRAGMA_IVDEP
+        PRAGMA_VECTOR_ALWAYS
+        for (size_t i = 0; i < num; i++)
+        {
+            ptr[i] = value;
+        }
+    }
+}
+
+template <CpuType cpu>
+struct ServiceInitializer
+{
+    template <typename T>
+    static void memset_default(T * const ptr, const size_t num)
+    {
+        service_memset_seq<T, cpu>(ptr, T(), num);
+    }
+
+    template <typename T>
+    static void memset(T * const ptr, const size_t num)
+    {
+        char * cptr = (char *)ptr;
+        size_t size = num * sizeof(T);
+
+        if (size < UINT_MAX && !((DAAL_UINT64)cptr & DAAL_DEFAULT_ALIGNMENT_MASK))
+        {
+            /// Use aligned stores
+            unsigned int size32 = static_cast<unsigned int>(size);
+            PRAGMA_IVDEP
+            PRAGMA_VECTOR_ALWAYS
+            PRAGMA_VECTOR_ALIGNED
+            for (unsigned int i = 0; i < size32; i++)
+            {
+                cptr[i] = '\0';
+            }
+        }
+        else
+        {
+            PRAGMA_IVDEP
+            PRAGMA_VECTOR_ALWAYS
+            for (size_t i = 0; i < size; i++)
+            {
+                cptr[i] = '\0';
+            }
+        }
+    }
+};
+
+template <typename T, CpuType cpu>
+T * service_calloc(size_t size, size_t alignment = DAAL_MALLOC_DEFAULT_ALIGNMENT)
+{
+    T * ptr = (T *)daal::services::daal_malloc(size, alignment);
     if (ptr == NULL)
     {
         return NULL;
     }
 
-    char * const cptr        = (char *)ptr;
-    const size_t sizeInBytes = size * sizeof(T);
-
-    for (size_t i = 0; i < sizeInBytes; i++)
+    if constexpr (std::is_trivially_default_constructible_v<T>)
     {
-        cptr[i] = '\0';
+        ServiceInitializer<cpu>::template memset_default<T>(ptr, size);
+    }
+    else
+    {
+        ServiceInitializer<cpu>::template memset<T>(ptr, size);
     }
 
     return ptr;
 }
 
 template <typename T, CpuType cpu>
-T * service_malloc(size_t size, size_t alignment = 64)
+T * service_scalable_calloc(size_t size, size_t alignment = DAAL_MALLOC_DEFAULT_ALIGNMENT)
+{
+    T * ptr = (T *)threaded_scalable_malloc(size * sizeof(T), alignment);
+    if (!ptr)
+    {
+        return nullptr;
+    }
+
+    if constexpr (std::is_trivially_default_constructible_v<T>)
+    {
+        ServiceInitializer<cpu>::template memset_default<T>(ptr, size);
+    }
+    else
+    {
+        ServiceInitializer<cpu>::template memset<T>(ptr, size);
+    }
+
+    return ptr;
+}
+
+template <typename T, CpuType cpu>
+T * service_malloc(size_t size, size_t alignment = DAAL_MALLOC_DEFAULT_ALIGNMENT)
 {
     return (T *)daal::services::daal_malloc(size * sizeof(T), alignment);
 }
@@ -68,28 +167,7 @@ void service_free(T * ptr)
 }
 
 template <typename T, CpuType cpu>
-T * service_scalable_calloc(size_t size, size_t alignment = 64)
-{
-    T * ptr = (T *)threaded_scalable_malloc(size * sizeof(T), alignment);
-
-    if (ptr == NULL)
-    {
-        return NULL;
-    }
-
-    char * const cptr        = (char *)ptr;
-    const size_t sizeInBytes = size * sizeof(T);
-
-    for (size_t i = 0; i < sizeInBytes; i++)
-    {
-        cptr[i] = '\0';
-    }
-
-    return ptr;
-}
-
-template <typename T, CpuType cpu>
-T * service_scalable_malloc(size_t size, size_t alignment = 64)
+T * service_scalable_malloc(size_t size, size_t alignment = DAAL_MALLOC_DEFAULT_ALIGNMENT)
 {
     return (T *)threaded_scalable_malloc(size * sizeof(T), alignment);
 }
@@ -125,18 +203,6 @@ T * service_memset(T * const ptr, const T value, const size_t num)
         }
     });
     return ptr;
-}
-
-/* Initialize block of memory of length num value */
-template <typename T, CpuType cpu>
-void service_memset_seq(T * const ptr, const T value, const size_t num)
-{
-    PRAGMA_IVDEP
-    PRAGMA_VECTOR_ALWAYS
-    for (size_t i = 0; i < num; i++)
-    {
-        ptr[i] = value;
-    }
 }
 
 /* Initialize block of memory of length num with entries [startValue, ..., startValue + num -1]*/

--- a/cpp/daal/src/externals/service_memory.h
+++ b/cpp/daal/src/externals/service_memory.h
@@ -101,9 +101,9 @@ struct ServiceInitializer
     static void memset(T * const ptr, const size_t num)
     {
         char * cptr = (char *)ptr;
-        size_t size = num * sizeof(T);
+        const size_t size = num * sizeof(T);
 
-        service_memset_seq<char, cpu>(cptr, '\0', num);
+        service_memset_seq<char, cpu>(cptr, '\0', size);
     }
 };
 

--- a/cpp/daal/src/externals/service_memory.h
+++ b/cpp/daal/src/externals/service_memory.h
@@ -103,7 +103,7 @@ struct ServiceInitializer
         char * cptr = (char *)ptr;
         size_t size = num * sizeof(T);
 
-        service_memset_seq<char, cpu>(сptr, '\0', num);
+        service_memset_seq<char, cpu>(cptr, '\0', num);
     }
 };
 

--- a/dev/bazel/daal.bzl
+++ b/dev/bazel/daal.bzl
@@ -40,7 +40,7 @@ def daal_module(name, features=[], lib_tag="daal",
     cc_module(
         name = name,
         lib_tag = lib_tag,
-        features = [ "c++11" ] + features,
+        features = [ "c++17" ] + features,
         cpu_defines = {
             "sse2":       [ "DAAL_CPU=sse2"       ],
             "sse42":      [ "DAAL_CPU=sse42"      ],


### PR DESCRIPTION
## Description

* `service_memset_seq`, `service_calloc` and `service_scalable_calloc` functions were modified to use aligned memory loads and stores for aligned data.

* C++ standard version was increased from C++11 to C++17 in `daal_module` in bazel build. This was done to simplify the implementations of `service_calloc` and `service_scalable_calloc` by the use of C++17 features like `if constexpr`.

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.

Total geomean speedup across the algorithms is **1.02** on 112-core SPR system. No significant performance changes.

- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.

The quality metrics had not changed because the computations logic is not affected.
