### PR TITLE
[bugfix] make shared-libasan default option for ```REQSAN=address```

### DIFF
--- a/makefile
+++ b/makefile
@@ -143,7 +143,7 @@ y           := $(notdir $(filter $(_OS)/%,lnx/so win/dll mac/dylib))
 # quietly hide the lack of support (e.g. gnu will fail with REQSAN=memory). The sanitizer must be
 # explicitly specified. ASan can be statically linked with special value "static", normal use of ASan set with REQSAN=address.
 -sanitize   := $(if $(REQSAN),$(if $(COMPILER_is_vc),/,-)fsanitize=$(if ifeq ($(REQSAN),static),address,$(REQSAN)) -fno-omit-frame-pointer)
--lsanitize  := $(if $(REQSAN),$(if $(COMPILER_is_vc),/,-)fsanitize=$(if ifeq ($(REQSAN),static),address -static-libasan,$(REQSAN)))
+-lsanitize  := $(if $(REQSAN),$(if $(COMPILER_is_vc),/,-)fsanitize=$(if ifeq ($(REQSAN),static),address -static-libasan,$(REQSAN)$(if ifeq ($(REQSAN),address), -shared-libasan)))
 -EHsc       := $(if $(OS_is_win),-EHsc,)
 -isystem    := $(if $(OS_is_win),-I,-isystem)
 -sGRP       := $(if $(OS_is_lnx),-Wl$(comma)--start-group,)
@@ -1141,9 +1141,11 @@ Flags:
   REQPROFILE - flag that enables kernel profiling using <ittnotify.h>
   REQSAN - flag that integrates a Google sanitizer (e.g. AddressSanitizer).
       The sanitizer must be specified as the flag value, except for the
-      value of "static". This value will link with the static ASan library.
-      Use on Windows is unverified, with the available sanitizers dependent
-      on the compiler. It is recommended to use in tandem with REQDBG.
+      value of "static". This value will link with the static ASan library,
+      ASan is otherwise linked dynamically by default for all compilers.
+      Use of sanitizers on Windows is unverified, with the available 
+      sanitizers and their default linking mode dependent on the compiler.
+      It is recommended to use in tandem with REQDBG.
       special values: static, address, memory, thread, leak, undefined
   CODE_COVERAGE - flag that integrates the gcov code coverage tool
       can only be enabled when set to value "yes" with the icx compiler on

--- a/makefile
+++ b/makefile
@@ -142,8 +142,8 @@ y           := $(notdir $(filter $(_OS)/%,lnx/so win/dll mac/dylib))
 # NOTE: only some compilers support other sanitizers, failure is expected by design in order to not
 # quietly hide the lack of support (e.g. gnu will fail with REQSAN=memory). The sanitizer must be
 # explicitly specified. ASan can be statically linked with special value "static", normal use of ASan set with REQSAN=address.
--sanitize   := $(if $(REQSAN),$(if $(COMPILER_is_vc),/,-)fsanitize=$(if ifeq ($(REQSAN),static),address,$(REQSAN)) -fno-omit-frame-pointer)
--lsanitize  := $(if $(REQSAN),$(if $(COMPILER_is_vc),/,-)fsanitize=$(if ifeq ($(REQSAN),static),address -static-libasan,$(REQSAN)$(if ifeq ($(REQSAN),address), -shared-libasan)))
+-sanitize   := $(if $(REQSAN),$(if $(COMPILER_is_vc),/,-)fsanitize=$(if $(filter static,$(word 1,$(REQSAN))),address,$(REQSAN)) -fno-omit-frame-pointer)
+-lsanitize  := $(if $(REQSAN),$(if $(COMPILER_is_vc),/,-)fsanitize=$(if $(filter static,$(word 1,$(REQSAN))),address -static-libasan,$(REQSAN)$(if $(filter address,$(word 1,$(REQSAN))), -shared-libasan)))
 -EHsc       := $(if $(OS_is_win),-EHsc,)
 -isystem    := $(if $(OS_is_win),-I,-isystem)
 -sGRP       := $(if $(OS_is_lnx),-Wl$(comma)--start-group,)


### PR DESCRIPTION
## Description

To mirror the special value of ```REQSAN=static```, the default linking for ```REQSAN=address``` will be shared because of how the tracing in AddressSanitizer works, it needs the various shared libraries to have a centralized libasan to inspect into the other shared objects of onedal.  By default, gnu vs clang act differently by default at linking, this will make it a standard interface for simpler compiler-to-compiler use.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
