### PR TITLE
DOC: Add instructions for DPL on conda

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -262,6 +262,7 @@ conda install -y \
     make "python>=3.9" `# used by the build system` \
     dpcpp-cpp-rt dpcpp_linux-64 intel-sycl-rt `# Intel compiler packages` \
     tbb tbb-devel `# required TBB packages` \
+    onedpl-devel `# required oneDPL package` \
     mkl mkl-devel mkl-static mkl-dpcpp mkl-devel-dpcpp `# required MKL packages` \
     cmake `# required to build the examples only`
 ```
@@ -269,8 +270,9 @@ conda install -y \
 Then modify the relevant environment variables to point to the conda-installed libraries:
 
 ```shell
-export MKLROOT=${CONDA_PREFIX}
-export TBBROOT=${CONDA_PREFIX}
+export MKLROOT="${CONDA_PREFIX}"
+export TBBROOT="${CONDA_PREFIX}"
+export DPL_ROOT="${CONDA_PREFIX}"
 export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"
 export LIBRARY_PATH="${CONDA_PREFIX}/lib:${LIBRARY_PATH}"
 export CPATH="${CONDA_PREFIX}/include:${CPATH}"


### PR DESCRIPTION
## Description

This PR adds instructions for installing oneDPL through conda. Somehow they were lost on an earlier PR.

CC @Alexandr-Solovev 

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.

**Performance**

Not applicable.
