### PR TITLE
[CI] swap uxl self-hosted runners to github hosted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ concurrency:
 jobs:
   LinuxMakeDPCPP:
     if: github.repository == 'uxlfoundation/oneDAL'
-
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -45,7 +44,7 @@ jobs:
           - ISA: avx2
             runner: ubuntu-24.04
 
-    runs-on: matrix.runner
+    runs-on: ${{ matrix.runner }}
     name: LinuxMakeDPCPP(${{ matrix.ISA }})
     steps:
       - name: Checkout oneDAL
@@ -55,7 +54,7 @@ jobs:
           echo ${{ matrix.runner }}
           .ci/env/apt.sh dpcpp
       - name: temp
-        if: matrix.runner != 'ubuntu-24.04'
+        if: ${{ matrix.runner }} != 'ubuntu-24.04'
         run: echo "yes"
       - name: Install MKL
         run: .ci/env/apt.sh mkl
@@ -71,7 +70,7 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           .ci/scripts/describe_system.sh
       - name: Set environment variables
-        if: matrix.runner != 'ubuntu-24.04'
+        if: ${{ matrix.runner }} != 'ubuntu-24.04'
         run: |
           # reduce GPU driver/runner related memory issues
           echo "NEOReadDebugKeys=1" >> "$GITHUB_ENV"
@@ -102,7 +101,7 @@ jobs:
           name: __release_lnx
           path: ./__release_lnx
       - name: Make onedal
-        if: matrix.runner != 'ubuntu-24.04'
+        if: ${{ matrix.runner }} != 'ubuntu-24.04'
         run: |
           # generate new onedal portion for use in examples testing (due to issues with dpc debug build)
           source /opt/intel/oneapi/setvars.sh
@@ -118,7 +117,7 @@ jobs:
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/cpp --build-system cmake
       - name: oneapi/dpc examples
-        if: matrix.runner != 'ubuntu-24.04'
+        if: ${{ matrix.runner }} != 'ubuntu-24.04'
         run: |
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/dpc --build-system cmake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,6 @@ jobs:
           path: ./__release_lnx_main
       - name: Remove Cache build
         if: github.event_name != 'pull_request'
-        # clean up build directory due to space limitations
         run: rm -rf __release_lnx_main
       - name: Archive build
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,7 @@ jobs:
       - name: Checkout oneDAL
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install DPC++
-        run: |
-          echo ${{ matrix.runner }}
-          .ci/env/apt.sh dpcpp
-      - name: temp
-        if: matrix.runner != 'ubuntu-24.04'
-        run: echo "yes"
+        run: .ci/env/apt.sh dpcpp
       - name: Install MKL
         run: .ci/env/apt.sh mkl
       - name: Install Python
@@ -70,7 +65,7 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           .ci/scripts/describe_system.sh
       - name: Set environment variables
-        if: ${{ matrix.runner }} != 'ubuntu-24.04'
+        if: matrix.runner != 'ubuntu-24.04'
         run: |
           # reduce GPU driver/runner related memory issues
           echo "NEOReadDebugKeys=1" >> "$GITHUB_ENV"
@@ -81,7 +76,7 @@ jobs:
         run: |
           source /opt/intel/oneapi/setvars.sh
           .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target daal --debug symbols --jobs 20
-           #cp -r __work __work_daal
+           if [[ ${{ matrix.runner }} != ubuntu-24.04 ]];then cp -r __work __work_daal;fi
       - name: Make onedal debug
         id: onedal-dbg
         run: |
@@ -101,7 +96,7 @@ jobs:
           name: __release_lnx
           path: ./__release_lnx
       - name: Make onedal
-        if: ${{ matrix.runner }} != 'ubuntu-24.04'
+        if: matrix.runner != 'ubuntu-24.04'
         run: |
           # generate new onedal portion for use in examples testing (due to issues with dpc debug build)
           source /opt/intel/oneapi/setvars.sh
@@ -117,7 +112,7 @@ jobs:
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/cpp --build-system cmake
       - name: oneapi/dpc examples
-        if: ${{ matrix.runner }} != 'ubuntu-24.04'
+        if: matrix.runner != 'ubuntu-24.04'
         run: |
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/dpc --build-system cmake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           - ISA: avx2
             runner: ubuntu-24.04
 
-    runs-on: ${{ matrix.label }}
+    runs-on: matrix.runner
     name: LinuxMakeDPCPP(${{ matrix.ISA }})
     steps:
       - name: Checkout oneDAL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,12 +85,19 @@ jobs:
           # clean up build directory due to space limitations
           rm -rf __work
           echo "key=__release_lnx-$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Prepare Cache build
+        if: github.event_name != 'pull_request'
+        run: cp -r __release_lnx __release_lnx_main
       - name: Cache build
         if: github.event_name != 'pull_request'
         uses: actions/cache/save@v4
         with:
           key: ${{ steps.onedal-dbg.outputs.key }}
-          path: ./__release_lnx
+          path: ./__release_lnx_main
+      - name: Remove Cache build
+        if: github.event_name != 'pull_request'
+        # clean up build directory due to space limitations
+        run: rm -rf __release_lnx_main
       - name: Archive build
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -106,6 +113,7 @@ jobs:
           .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target onedal --jobs 20
       - name: daal/cpp examples
         run: |
+            rm -rf __release_lnx_main
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface daal/cpp --build-system cmake
       - name: oneapi/cpp examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,6 @@ jobs:
           .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target onedal --jobs 20
       - name: daal/cpp examples
         run: |
-            rm -rf __release_lnx_main
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface daal/cpp --build-system cmake
       - name: oneapi/cpp examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,10 @@ jobs:
   LinuxABICheck:
     name: ABI Conformance(avx2)
     needs: LinuxMakeDPCPP
-    if: github.repository == 'uxlfoundation/oneDAL' && github.event_name == 'pull_request' 
+    if: |
+      github.repository == 'uxlfoundation/oneDAL' &&
+      github.event_name == 'pull_request' &&
+      ! contains(toJson(github.event.pull_request.labels.*.name), '"API/ABI breaking change"')
     runs-on: ubuntu-24.04
     env:
       LIBABIGAIL_DEFAULT_USER_SUPPRESSION_FILE: ${{ github.workspace }}/.github/.abignore
@@ -162,6 +165,4 @@ jobs:
           echo "please rerun the main 'CI' workflow via GitHub's workflow dispatch to regenerate the cache."
           echo "Keep the branch up to date with oneDAL 'main' as it may otherwise not contain the latest changes "
           echo "in the ABI that can lead to erroneous failures in the ABI check."
-          .ci/scripts/abi_check.sh __release_lnx_main/daal/latest/lib/intel64/ __release_lnx/daal/latest/lib/intel64/ || $ABI_BREAK
-        env:
-          ABI_BREAK: contains(toJson(github.event.pull_request.labels.*.name), '"API/ABI breaking change"')
+          .ci/scripts/abi_check.sh __release_lnx_main/daal/latest/lib/intel64/ __release_lnx/daal/latest/lib/intel64/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
         run: |
           source /opt/intel/oneapi/setvars.sh
           .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target onedal --debug symbols --jobs 20
+          # clean up build directory due to space limitations
+          rm -rf __work
           echo "key=__release_lnx-$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Cache build
         if: github.event_name != 'pull_request'
@@ -100,7 +102,6 @@ jobs:
         run: |
           # generate new onedal portion for use in examples testing (due to issues with dpc debug build)
           source /opt/intel/oneapi/setvars.sh
-          rm -rf __work
           mv __work_daal __work
           .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target onedal --jobs 20
       - name: daal/cpp examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           echo ${{ matrix.runner }}
           .ci/env/apt.sh dpcpp
       - name: temp
-        if: ${{ matrix.runner }} != 'ubuntu-24.04'
+        if: matrix.runner != 'ubuntu-24.04'
         run: echo "yes"
       - name: Install MKL
         run: .ci/env/apt.sh mkl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,11 @@ env:
 
 jobs:
   LinuxMakeDPCPP:
+    name: LinuxMakeDPCPP(${{ env.ISA }})
     if: github.repository == 'uxlfoundation/oneDAL'
     runs-on: ubuntu-24.04
     timeout-minutes: 120
 
-    name: LinuxMakeDPCPP(${{ env.ISA }})
     steps:
       - name: Checkout oneDAL
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           .ci/scripts/describe_system.sh
       - name: Set environment variables
+        if: ${{ runner.name }} != 'ubuntu-24.04'
         run: |
           # reduce GPU driver/runner related memory issues
           echo "NEOReadDebugKeys=1" >> "$GITHUB_ENV"
@@ -73,7 +74,7 @@ jobs:
         run: |
           source /opt/intel/oneapi/setvars.sh
           .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target daal --debug symbols --jobs 20
-           cp -r __work __work_daal
+           #cp -r __work __work_daal
       - name: Make onedal debug
         id: onedal-dbg
         run: |
@@ -94,6 +95,7 @@ jobs:
           name: __release_lnx
           path: ./__release_lnx_main
       - name: Make onedal
+        if: ${{ runner.name }} != 'ubuntu-24.04'
         run: |
           # generate new onedal portion for use in examples testing (due to issues with dpc debug build)
           source /opt/intel/oneapi/setvars.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           name: __release_lnx
           path: ./__release_lnx
       - name: Make onedal
-        if: ${{ runner.name }} != 'ubuntu-24.04'
+        if: runner.name != 'ubuntu-24.04'
         run: |
           # generate new onedal portion for use in examples testing (due to issues with dpc debug build)
           source /opt/intel/oneapi/setvars.sh
@@ -110,7 +110,7 @@ jobs:
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/cpp --build-system cmake
       - name: oneapi/dpc examples
-        if: ${{ runner.name }} != 'ubuntu-24.04'
+        if: runner.name != 'ubuntu-24.04'
         run: |
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/dpc --build-system cmake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  ISA: avx2
+
 jobs:
   LinuxMakeDPCPP:
-    name: LinuxMakeDPCPP(AVX512)
     if: github.repository == 'uxlfoundation/oneDAL'
-    runs-on: uxl-gpu-4xlarge
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
 
+    name: LinuxMakeDPCPP(${{ env.ISA }})
     steps:
       - name: Checkout oneDAL
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -68,13 +71,13 @@ jobs:
       - name: Make daal debug
         run: |
           source /opt/intel/oneapi/setvars.sh
-          .ci/scripts/build.sh --compiler icx  --optimizations avx512 --target daal --debug symbols --jobs 20
+          .ci/scripts/build.sh --compiler icx  --optimizations $ISA --target daal --debug symbols --jobs 20
            cp -r __work __work_daal
       - name: Make onedal debug
         id: onedal-dbg
         run: |
           source /opt/intel/oneapi/setvars.sh
-          .ci/scripts/build.sh --compiler icx  --optimizations avx512 --target onedal --debug symbols --jobs 20
+          .ci/scripts/build.sh --compiler icx  --optimizations $ISA --target onedal --debug symbols --jobs 20
           cp -r __release_lnx __release_lnx_main
           echo "key=__release_lnx-$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Cache build
@@ -95,7 +98,7 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           rm -rf __work
           mv __work_daal __work
-          .ci/scripts/build.sh --compiler icx  --optimizations avx512 --target onedal --jobs 20
+          .ci/scripts/build.sh --compiler icx  --optimizations $ISA --target onedal --jobs 20
       - name: daal/cpp examples
         run: |
             source /opt/intel/oneapi/setvars.sh
@@ -105,6 +108,7 @@ jobs:
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/cpp --build-system cmake
       - name: oneapi/dpc examples
+        if: ${{ runner.name }} != 'ubuntu-24.04'
         run: |
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/dpc --build-system cmake
@@ -114,13 +118,10 @@ jobs:
             .ci/scripts/test.sh --test-kind samples --build-dir __release_lnx --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build-system cmake
 
   LinuxABICheck:
-    name: ABI Conformance(AVX512)
+    name: ABI Conformance(${{ env.ISA }})
     needs: LinuxMakeDPCPP
-    if: |
-      github.repository == 'uxlfoundation/oneDAL' &&
-      github.event_name == 'pull_request' &&
-      ! contains(toJson(github.event.pull_request.labels.*.name), '"API/ABI breaking change"')
-    runs-on: uxl-xlarge
+    if: github.repository == 'uxlfoundation/oneDAL' && github.event_name == 'pull_request' 
+    runs-on: ubuntu-24.04
     env:
       LIBABIGAIL_DEFAULT_USER_SUPPRESSION_FILE: ${{ github.workspace }}/.github/.abignore
     timeout-minutes: 20
@@ -157,4 +158,6 @@ jobs:
           echo "please rerun the main 'CI' workflow via GitHub's workflow dispatch to regenerate the cache."
           echo "Keep the branch up to date with oneDAL 'main' as it may otherwise not contain the latest changes "
           echo "in the ABI that can lead to erroneous failures in the ABI check."
-          .ci/scripts/abi_check.sh __release_lnx_main/daal/latest/lib/intel64/ __release_lnx/daal/latest/lib/intel64/
+          .ci/scripts/abi_check.sh __release_lnx_main/daal/latest/lib/intel64/ __release_lnx/daal/latest/lib/intel64/ || $ABI_BREAK
+        env:
+          ABI_BREAK: contains(toJson(github.event.pull_request.labels.*.name), '"API/ABI breaking change"')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,23 +36,26 @@ concurrency:
 jobs:
   LinuxMakeDPCPP:
     if: github.repository == 'uxlfoundation/oneDAL'
-    runs-on: ubuntu-24.04
+
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
-        ISA: [avx2]
+        include:
+          - ISA: avx2
+            runner: ubuntu-24.04
 
+    runs-on: ${{ matrix.label }}
     name: LinuxMakeDPCPP(${{ matrix.ISA }})
     steps:
       - name: Checkout oneDAL
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install DPC++
         run: |
-          echo ${{ runner.name }}
+          echo ${{ matrix.runner }}
           .ci/env/apt.sh dpcpp
       - name: temp
-        if: runner.name != 'ubuntu-24.04'
+        if: matrix.runner != 'ubuntu-24.04'
         run: echo "yes"
       - name: Install MKL
         run: .ci/env/apt.sh mkl
@@ -68,7 +71,7 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           .ci/scripts/describe_system.sh
       - name: Set environment variables
-        if: ${{ runner.name }} != 'ubuntu-24.04'
+        if: matrix.runner != 'ubuntu-24.04'
         run: |
           # reduce GPU driver/runner related memory issues
           echo "NEOReadDebugKeys=1" >> "$GITHUB_ENV"
@@ -99,7 +102,7 @@ jobs:
           name: __release_lnx
           path: ./__release_lnx
       - name: Make onedal
-        if: runner.name != 'ubuntu-24.04'
+        if: matrix.runner != 'ubuntu-24.04'
         run: |
           # generate new onedal portion for use in examples testing (due to issues with dpc debug build)
           source /opt/intel/oneapi/setvars.sh
@@ -115,7 +118,7 @@ jobs:
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/cpp --build-system cmake
       - name: oneapi/dpc examples
-        if: runner.name != 'ubuntu-24.04'
+        if: matrix.runner != 'ubuntu-24.04'
         run: |
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/dpc --build-system cmake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,16 +33,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
-env:
-  ISA: avx2
-
 jobs:
   LinuxMakeDPCPP:
-    name: LinuxMakeDPCPP(${{ env.ISA }})
     if: github.repository == 'uxlfoundation/oneDAL'
     runs-on: ubuntu-24.04
     timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        ISA: [avx2]
 
+    name: LinuxMakeDPCPP(${{ matrix.ISA }})
     steps:
       - name: Checkout oneDAL
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -71,13 +72,13 @@ jobs:
       - name: Make daal debug
         run: |
           source /opt/intel/oneapi/setvars.sh
-          .ci/scripts/build.sh --compiler icx  --optimizations $ISA --target daal --debug symbols --jobs 20
+          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target daal --debug symbols --jobs 20
            cp -r __work __work_daal
       - name: Make onedal debug
         id: onedal-dbg
         run: |
           source /opt/intel/oneapi/setvars.sh
-          .ci/scripts/build.sh --compiler icx  --optimizations $ISA --target onedal --debug symbols --jobs 20
+          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target onedal --debug symbols --jobs 20
           cp -r __release_lnx __release_lnx_main
           echo "key=__release_lnx-$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Cache build
@@ -98,7 +99,7 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           rm -rf __work
           mv __work_daal __work
-          .ci/scripts/build.sh --compiler icx  --optimizations $ISA --target onedal --jobs 20
+          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target onedal --jobs 20
       - name: daal/cpp examples
         run: |
             source /opt/intel/oneapi/setvars.sh
@@ -118,7 +119,7 @@ jobs:
             .ci/scripts/test.sh --test-kind samples --build-dir __release_lnx --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build-system cmake
 
   LinuxABICheck:
-    name: ABI Conformance(${{ env.ISA }})
+    name: ABI Conformance(avx2)
     needs: LinuxMakeDPCPP
     if: github.repository == 'uxlfoundation/oneDAL' && github.event_name == 'pull_request' 
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,12 @@ jobs:
       - name: Checkout oneDAL
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install DPC++
-        run: .ci/env/apt.sh dpcpp
+        run: |
+          echo ${{ runner.name }}
+          .ci/env/apt.sh dpcpp
+      - name: temp
+        if: runner.name != 'ubuntu-24.04'
+        run: echo "yes"
       - name: Install MKL
         run: .ci/env/apt.sh mkl
       - name: Install Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,20 +80,19 @@ jobs:
         run: |
           source /opt/intel/oneapi/setvars.sh
           .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target onedal --debug symbols --jobs 20
-          cp -r __release_lnx __release_lnx_main
           echo "key=__release_lnx-$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Cache build
         if: github.event_name != 'pull_request'
         uses: actions/cache/save@v4
         with:
           key: ${{ steps.onedal-dbg.outputs.key }}
-          path: ./__release_lnx_main
+          path: ./__release_lnx
       - name: Archive build
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: __release_lnx
-          path: ./__release_lnx_main
+          path: ./__release_lnx
       - name: Make onedal
         if: ${{ runner.name }} != 'ubuntu-24.04'
         run: |


### PR DESCRIPTION
## Description

This PR moves the UXL foundation self-hosted runners to github hosted runners (ideally on a temporary basis).

The following changes are made:
 - ISA is set from AVX512 to AVX2 due to runner limitations
 - A matrix value ```ISA``` is defined to control the ISA of the runners, which modifies the displayed job names. Unfortunately it must be lower case because of restrictions set by ```REQCPU```.
 - The GPU testing step is disabled by checking the runner name rather than being removed (in the hope that the GPU step removal is temporary).


This does not require performance benchmarking

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.
