### PR TITLE
fix(docs): Install dependencies fails over debian-installed packages

### DIFF
--- a/.ci/pipeline/docs.yml
+++ b/.ci/pipeline/docs.yml
@@ -33,12 +33,12 @@ steps:
 - script: |
     set -euo pipefail
     cd docs
+    sudo apt-get update
     sudo apt-get install python3-setuptools
     python3 -m venv venv
     source venv/bin/activate
     pip install --upgrade pip
     pip install -r requirements.txt
-    sudo apt-get update
     sudo apt-get install doxygen
   displayName: 'Install requirements'
 

--- a/.ci/pipeline/docs.yml
+++ b/.ci/pipeline/docs.yml
@@ -31,6 +31,7 @@ pool:
 
 steps:
 - script: |
+    set -euo pipefail
     cd docs
     sudo apt-get install python3-setuptools
     sudo pip3 install -r requirements.txt

--- a/.ci/pipeline/docs.yml
+++ b/.ci/pipeline/docs.yml
@@ -34,13 +34,18 @@ steps:
     set -euo pipefail
     cd docs
     sudo apt-get install python3-setuptools
-    sudo pip3 install -r requirements.txt
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install --upgrade pip
+    pip install -r requirements.txt
     sudo apt-get update
     sudo apt-get install doxygen
   displayName: 'Install requirements'
 
 - script: |
+    set -euo pipefail
     cd docs
+    source venv/bin/activate
     make html
   displayName: 'Build documentation'
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -30,6 +30,7 @@ help:
 create_rst_examples:
 	@echo "Creating rST files for oneAPI Examples..."
 	python3 rst_examples.py
+	@echo "Done"
 
 doxygen:
 	cd doxygen/oneapi && doxygen

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -30,7 +30,6 @@ help:
 create_rst_examples:
 	@echo "Creating rST files for oneAPI Examples..."
 	python3 rst_examples.py
-	@echo "Done"
 
 doxygen:
 	cd doxygen/oneapi && doxygen


### PR DESCRIPTION
## Description

Create a `venv` for the python packages in the install step. Also add `set -euo pipefail` to fail the correct step if a problem occurs.

## What it fixes

Building docs sometimes fails at the `Install requirements` step, preventing the installation of the requirements. The subsequent `Build documentation` will fail with `sphinx-build: not found`.

![image](https://github.com/user-attachments/assets/96976770-2555-457a-8f1a-3711f62acebb)

Example: https://dev.azure.com/daal/DAAL/_build/results?buildId=45831&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=5caf77c8-9b10-50ef-b5c7-ca89c63e1c86
