### PR TITLE
Revert "[CI] swap uxl self-hosted runners to github hosted"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,17 +35,11 @@ concurrency:
 
 jobs:
   LinuxMakeDPCPP:
+    name: LinuxMakeDPCPP(AVX512)
     if: github.repository == 'uxlfoundation/oneDAL'
+    runs-on: uxl-gpu-4xlarge
     timeout-minutes: 120
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - ISA: avx2
-            runner: ubuntu-24.04
 
-    runs-on: ${{ matrix.runner }}
-    name: LinuxMakeDPCPP(${{ matrix.ISA }})
     steps:
       - name: Checkout oneDAL
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -65,7 +59,6 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           .ci/scripts/describe_system.sh
       - name: Set environment variables
-        if: matrix.runner != 'ubuntu-24.04'
         run: |
           # reduce GPU driver/runner related memory issues
           echo "NEOReadDebugKeys=1" >> "$GITHUB_ENV"
@@ -75,41 +68,34 @@ jobs:
       - name: Make daal debug
         run: |
           source /opt/intel/oneapi/setvars.sh
-          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target daal --debug symbols --jobs 20
-           if [[ ${{ matrix.runner }} != ubuntu-24.04 ]];then cp -r __work __work_daal;fi
+          .ci/scripts/build.sh --compiler icx  --optimizations avx512 --target daal --debug symbols --jobs 20
+           cp -r __work __work_daal
       - name: Make onedal debug
         id: onedal-dbg
         run: |
           source /opt/intel/oneapi/setvars.sh
-          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target onedal --debug symbols --jobs 20
-          # clean up build directory due to space limitations
-          rm -rf __work
+          .ci/scripts/build.sh --compiler icx  --optimizations avx512 --target onedal --debug symbols --jobs 20
+          cp -r __release_lnx __release_lnx_main
           echo "key=__release_lnx-$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      - name: Prepare Cache build
-        if: github.event_name != 'pull_request'
-        run: cp -r __release_lnx __release_lnx_main
       - name: Cache build
         if: github.event_name != 'pull_request'
         uses: actions/cache/save@v4
         with:
           key: ${{ steps.onedal-dbg.outputs.key }}
           path: ./__release_lnx_main
-      - name: Remove Cache build
-        if: github.event_name != 'pull_request'
-        run: rm -rf __release_lnx_main
       - name: Archive build
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: __release_lnx
-          path: ./__release_lnx
+          path: ./__release_lnx_main
       - name: Make onedal
-        if: matrix.runner != 'ubuntu-24.04'
         run: |
           # generate new onedal portion for use in examples testing (due to issues with dpc debug build)
           source /opt/intel/oneapi/setvars.sh
+          rm -rf __work
           mv __work_daal __work
-          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target onedal --jobs 20
+          .ci/scripts/build.sh --compiler icx  --optimizations avx512 --target onedal --jobs 20
       - name: daal/cpp examples
         run: |
             source /opt/intel/oneapi/setvars.sh
@@ -119,7 +105,6 @@ jobs:
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/cpp --build-system cmake
       - name: oneapi/dpc examples
-        if: matrix.runner != 'ubuntu-24.04'
         run: |
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/dpc --build-system cmake
@@ -129,13 +114,13 @@ jobs:
             .ci/scripts/test.sh --test-kind samples --build-dir __release_lnx --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build-system cmake
 
   LinuxABICheck:
-    name: ABI Conformance(avx2)
+    name: ABI Conformance(AVX512)
     needs: LinuxMakeDPCPP
     if: |
       github.repository == 'uxlfoundation/oneDAL' &&
       github.event_name == 'pull_request' &&
       ! contains(toJson(github.event.pull_request.labels.*.name), '"API/ABI breaking change"')
-    runs-on: ubuntu-24.04
+    runs-on: uxl-xlarge
     env:
       LIBABIGAIL_DEFAULT_USER_SUPPRESSION_FILE: ${{ github.workspace }}/.github/.abignore
     timeout-minutes: 20


### PR DESCRIPTION
Reverts uxlfoundation/oneDAL#3176

changes made to the runners are complete. ABI check is disabled, see #3176 as to why.