### PR TITLE
fix: use github action instead of gh-pages

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -22,6 +22,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  contents: read
   
 jobs:
   build-docs:
@@ -73,25 +75,19 @@ jobs:
         cd docs
         make html
 
-    - name: Deploy Documentation to gh-pages
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+
+    - name: Prepare Documentation for Deployment
       run: |
-        # Set git auth for push changes 
-        git config --global user.name "GitHub Actions"
-        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        mkdir -p _site        
+        cp -r docs/build/* _site/
+        
+    - name: Upload artifact for GitHub Pages
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: '_site'
 
-        # Copy the build folder to a temporary location
-        cp -R docs/build/. /tmp/build
-
-        # Checkout the gh-pages branch
-        git checkout gh-pages
-
-        # Replace existing files with new build files
-        git rm -rf .
-        cp -R /tmp/build/. .
-
-        # Push to gh-pages
-        git add -A
-        git commit -m "Automatic doc update for version $DOC_VERSION"
-        git push origin gh-pages
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -22,8 +22,8 @@ on:
 
 permissions:
   contents: write
-  id-token: write
-  contents: read
+  pages: write
+  id-token: write  
   
 jobs:
   build-docs:

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -20,23 +20,24 @@ on:
     tags:
       - '[0-9][0-9][0-9][0-9]\.[0-9][0-9]?\.[0-9]' # Trigger on tag pushes
 
-permissions:
-  contents: write
-  pages: write
-  id-token: write  
-  
+permissions: read-all
+
 jobs:
   build-docs:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0  # Ensures all tags are fetched
 
     - name: Set Up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: "3.11"
 
@@ -76,7 +77,7 @@ jobs:
         make html
 
     - name: Setup Pages
-      uses: actions/configure-pages@v4
+      uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b #5.0.0
 
     - name: Prepare Documentation for Deployment
       run: |
@@ -84,10 +85,10 @@ jobs:
         cp -r docs/build/* _site/
         
     - name: Upload artifact for GitHub Pages
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
       with:
         path: '_site'
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Description

Similarly to intelex, now we are using github action instead of gh-pages. It is simpler setup as onedal does not need to track all versions

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.
