### PR TITLE
Fix hyperparameterIdCount in Covariance

### DIFF
--- a/cpp/daal/src/algorithms/covariance/covariance_hyperparameter_impl.h
+++ b/cpp/daal/src/algorithms/covariance/covariance_hyperparameter_impl.h
@@ -43,7 +43,7 @@ enum HyperparameterId
 {
     denseUpdateStepBlockSize = 0,
     denseUpdateStepGrainSize = 1,
-    hyperparameterIdCount    = denseUpdateStepGrainSize + 2
+    hyperparameterIdCount    = denseUpdateStepGrainSize + 1
 };
 
 enum DoubleHyperparameterId

--- a/cpp/daal/src/algorithms/covariance/covariance_hyperparameter_impl.h
+++ b/cpp/daal/src/algorithms/covariance/covariance_hyperparameter_impl.h
@@ -43,7 +43,7 @@ enum HyperparameterId
 {
     denseUpdateStepBlockSize = 0,
     denseUpdateStepGrainSize = 1,
-    hyperparameterIdCount    = denseUpdateStepGrainSize + 1
+    hyperparameterIdCount    = 2
 };
 
 enum DoubleHyperparameterId


### PR DESCRIPTION
A typo in indexing was fixed.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.

**Performance**

not applicable.
