### PR TITLE
Fix for float32 csr KMeans++ init inertia calculation. 

### DIFF
--- a/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
+++ b/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
@@ -291,8 +291,10 @@ public:
     // from current trial center to the rows in the block and update min distance
     
    //tell compiler not to in-line this.     
-    __attribute__((noinline))
-    algorithmFPType updateMinDistForITrials(algorithmFPType * const pDistSq, size_t iTrials, size_t nRowsToProcess,
+   #if defined(__INTEL_LLVM_COMPILER)
+   __attribute__((noinline))
+   #endif 
+   algorithmFPType updateMinDistForITrials(algorithmFPType * const pDistSq, size_t iTrials, size_t nRowsToProcess,
                                             const algorithmFPType * const pData, const size_t * const colIdx, const size_t * const rowIdx,
                                             const algorithmFPType * const pLastAddedCenter, const algorithmFPType * const aWeights,
                                             const algorithmFPType * const pDistSqBest)

--- a/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
+++ b/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
@@ -289,15 +289,15 @@ public:
 
     // For each data point from the provided data block, calculate squared distance
     // from current trial center to the rows in the block and update min distance
-    
-   //tell compiler not to in-line this.     
-   #if defined(__INTEL_LLVM_COMPILER)
-   __attribute__((noinline))
-   #endif 
-   algorithmFPType updateMinDistForITrials(algorithmFPType * const pDistSq, size_t iTrials, size_t nRowsToProcess,
-                                            const algorithmFPType * const pData, const size_t * const colIdx, const size_t * const rowIdx,
-                                            const algorithmFPType * const pLastAddedCenter, const algorithmFPType * const aWeights,
-                                            const algorithmFPType * const pDistSqBest)
+
+//tell compiler not to in-line this.
+#if defined(__INTEL_LLVM_COMPILER)
+    __attribute__((noinline))
+#endif
+    algorithmFPType
+        updateMinDistForITrials(algorithmFPType * const pDistSq, size_t iTrials, size_t nRowsToProcess, const algorithmFPType * const pData,
+                                const size_t * const colIdx, const size_t * const rowIdx, const algorithmFPType * const pLastAddedCenter,
+                                const algorithmFPType * const aWeights, const algorithmFPType * const pDistSqBest)
     {
         algorithmFPType sumOfDist2            = algorithmFPType(0);
         size_t csrCursor                      = 0u;

--- a/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
+++ b/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
@@ -290,12 +290,11 @@ public:
     // For each data point from the provided data block, calculate squared distance
     // from current trial center to the rows in the block and update min distance
 
-//tell compiler not to in-line this.
+//Temporary fix for KMeans conformance testing fix. Tell the compiler  not to in-line this. 
 #if defined(__INTEL_LLVM_COMPILER)
     __attribute__((noinline))
 #endif
-    algorithmFPType
-        updateMinDistForITrials(algorithmFPType * const pDistSq, size_t iTrials, size_t nRowsToProcess, const algorithmFPType * const pData,
+algorithmFPType updateMinDistForITrials(algorithmFPType * const pDistSq, size_t iTrials, size_t nRowsToProcess, const algorithmFPType * const pData,
                                 const size_t * const colIdx, const size_t * const rowIdx, const algorithmFPType * const pLastAddedCenter,
                                 const algorithmFPType * const aWeights, const algorithmFPType * const pDistSqBest)
     {

--- a/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
+++ b/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
@@ -289,6 +289,9 @@ public:
 
     // For each data point from the provided data block, calculate squared distance
     // from current trial center to the rows in the block and update min distance
+    
+   //tell compiler not to in-line this.     
+    __attribute__((noinline))
     algorithmFPType updateMinDistForITrials(algorithmFPType * const pDistSq, size_t iTrials, size_t nRowsToProcess,
                                             const algorithmFPType * const pData, const size_t * const colIdx, const size_t * const rowIdx,
                                             const algorithmFPType * const pLastAddedCenter, const algorithmFPType * const aWeights,


### PR DESCRIPTION
## Fix for float32 csr_matrix KMeans++ init issue.

Fix for float32 csr KMeans++ initial inertia issue not matching the double csr KMeans++ initial inertia numbers causing the  KMeans compliance test to fail for newer versions of icpx.   

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
