### PR TITLE
CI: Print correct version of clang-format being executed

### DIFF
--- a/.ci/scripts/clang-format.sh
+++ b/.ci/scripts/clang-format.sh
@@ -15,12 +15,12 @@
 # limitations under the License.
 #===============================================================================
 
-echo "Using clang-format version: $(clang-format --version)"
-echo "Starting format check..."
-
 RETURN_CODE=0
 
 CLANG_FORMAT_EXE=${CLANG_FORMAT_EXE:-clang-format-14}
+
+echo "Using clang-format version: $(${CLANG_FORMAT_EXE} --version)"
+echo "Starting format check..."
 
 for sources_path in cpp/daal cpp/oneapi examples/oneapi examples/daal samples/oneapi samples/daal; do
     pushd ${sources_path} || exit 1


### PR DESCRIPTION
## Description

This PR fixes the clang-format script to accurately print the version that gets used when linting the files.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.
