### PR TITLE
Fix: xcsrmv computation wrong arguments

### DIFF
--- a/cpp/daal/src/externals/service_spblas_mkl.h
+++ b/cpp/daal/src/externals/service_spblas_mkl.h
@@ -79,8 +79,9 @@ struct MklSpBlas<double, cpu>
         sparse_matrix_t csrA = NULL;
         struct matrix_descr descrA;
         descrA.type = SPARSE_MATRIX_TYPE_GENERAL;
-        mkl_sparse_d_create_csr(&csrA, SPARSE_INDEX_BASE_ONE, (const MKL_INT)*m, (const MKL_INT)*k, (MKL_INT *)pntre, (MKL_INT *)pntrb,
+        mkl_sparse_d_create_csr(&csrA, SPARSE_INDEX_BASE_ONE, (const MKL_INT)*m, (const MKL_INT)*k, (MKL_INT *)pntrb, (MKL_INT *)pntre,
                                 (MKL_INT *)indx, (double *)val);
+
         if (*transa == 'n' || *transa == 'N')
         {
             mkl_sparse_d_mv(SPARSE_OPERATION_NON_TRANSPOSE, *alpha, csrA, descrA, x, *beta, y);
@@ -184,7 +185,7 @@ struct MklSpBlas<float, cpu>
         sparse_matrix_t csrA = NULL;
         struct matrix_descr descrA;
         descrA.type = SPARSE_MATRIX_TYPE_GENERAL;
-        mkl_sparse_s_create_csr(&csrA, SPARSE_INDEX_BASE_ONE, (const MKL_INT)*m, (const MKL_INT)*k, (MKL_INT *)pntre, (MKL_INT *)pntrb,
+        mkl_sparse_s_create_csr(&csrA, SPARSE_INDEX_BASE_ONE, (const MKL_INT)*m, (const MKL_INT)*k, (MKL_INT *)pntrb, (MKL_INT *)pntre,
                                 (MKL_INT *)indx, (float *)val);
 
         if (*transa == 'n' || *transa == 'N')


### PR DESCRIPTION
## Description

Fix the `xcsrmv` function for correct covariance algorithm computation.

The issue was in incorrectly provided of beginnings and endings of rows in CSR

---

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
