### PR TITLE
[bugfix] separate stability issues of ```intel/cve-bin-tool-action``` from nightly-build

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -16,6 +16,9 @@
 
 name: Nightly-build
 
+# Note: This action is only for building oneDAL, implement tests in Nightly-test
+# It is a dependency of uxlfoundation/scikit-learn-intelex's `CI` GitHub action
+
 on:
   schedule:
     - cron: '0 21 * * *'

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -145,30 +145,3 @@ jobs:
         with:
           name: opencl_rt_installer
           path: .\opencl_rt.msi
-
-  cve-bin-tool-scan:
-    needs: [build_lnx, build_win]
-    runs-on: "ubuntu-24.04"
-    permissions:
-      security-events: write
-    env:
-      BUILD_FOLDER: "builds"
-    steps:
-      - name: Download oneDAL build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          pattern: "__release*"
-          # W/A (Pt. 1): The `cve-bin-tool-action` uses `actions/checkout`, which cleans up the working
-          #              directory, so the artifacts there will be removed. To avoid this, we store these
-          #              artifacts in a temporary directory and then copy them back later using `build_command`.
-          path: "${{ runner.temp }}/${{ env.BUILD_FOLDER }}"
-      # Remove the `tbb`, as it is not part of the oneDAL library
-      - run: "find ${{ runner.temp }}/${{ env.BUILD_FOLDER }} -type d -name 'tbb' -exec rm -rf {} +"
-      - uses: intel/cve-bin-tool-action@8783168b8d484b7cb7746cdba69176cc2a9f749d # untagged main
-        with:
-          scan_mode: repo-only
-          exclude_dir: ".git"
-          alerts_based_on_file: true
-          # W/A (Pt. 2): This is not the actual 'build_command'; it just copies the artifacts
-          #              downloaded in the previous step to the working directory
-          build_command: "mv ${{ runner.temp }}/${{ env.BUILD_FOLDER }} ./"

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -18,7 +18,7 @@ name: Nightly-test
 
 on:
   workflow_run:
-    workflows: [nightly-build]
+    workflows: [Nightly-build]
     types:
       - completed
 

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -1,0 +1,51 @@
+#===============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+name: Nightly-test
+
+on:
+  workflow_run:
+    workflows: [nightly-build]
+    types:
+      - completed
+
+jobs:
+
+  cve-bin-tool-scan:
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
+    env:
+      BUILD_FOLDER: "builds"
+    steps:
+      - name: Download oneDAL build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: "__release*"
+          # W/A (Pt. 1): The `cve-bin-tool-action` uses `actions/checkout`, which cleans up the working
+          #              directory, so the artifacts there will be removed. To avoid this, we store these
+          #              artifacts in a temporary directory and then copy them back later using `build_command`.
+          path: "${{ runner.temp }}/${{ env.BUILD_FOLDER }}"
+      # Remove the `tbb`, as it is not part of the oneDAL library
+      - run: "find ${{ runner.temp }}/${{ env.BUILD_FOLDER }} -type d -name 'tbb' -exec rm -rf {} +"
+      - uses: intel/cve-bin-tool-action@8783168b8d484b7cb7746cdba69176cc2a9f749d # untagged main
+        with:
+          scan_mode: repo-only
+          exclude_dir: ".git"
+          alerts_based_on_file: true
+          # W/A (Pt. 2): This is not the actual 'build_command'; it just copies the artifacts
+          #              downloaded in the previous step to the working directory
+          build_command: "mv ${{ runner.temp }}/${{ env.BUILD_FOLDER }} ./"

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Download oneDAL build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
           pattern: "__release*"
           # W/A (Pt. 1): The `cve-bin-tool-action` uses `actions/checkout`, which cleans up the working
           #              directory, so the artifacts there will be removed. To avoid this, we store these
@@ -41,7 +43,7 @@ jobs:
           path: "${{ runner.temp }}/${{ env.BUILD_FOLDER }}"
       # Remove the `tbb`, as it is not part of the oneDAL library
       - run: "find ${{ runner.temp }}/${{ env.BUILD_FOLDER }} -type d -name 'tbb' -exec rm -rf {} +"
-      - uses: intel/cve-bin-tool-action@8783168b8d484b7cb7746cdba69176cc2a9f749d # untagged main
+      - uses: intel/cve-bin-tool-action@dbccafa2c31e51271ab1cb996e51c6b91670d75b # untagged main
         with:
           scan_mode: repo-only
           exclude_dir: ".git"

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -22,6 +22,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
 
   cve-bin-tool-scan:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -29,6 +29,7 @@ jobs:
 
   cve-bin-tool-scan:
     runs-on: ubuntu-24.04
+    if: ${{ github.repository == 'uxlfoundation/oneDAL' && github.event.workflow_run.conclusion == 'success' }}
     permissions:
       security-events: write
     env:


### PR DESCRIPTION
## Description

Since being integrated in #3204, the nightly has failed.  To improve stability and properly follow the naming schemes the test aspect added is now added in a separate yaml file which is run after completion of a successful build.  This should allow for th sklearnex dependence on Nightly-build to be more stable, while still allowing testing using this cve analysis tool.

No benchmarks or internal CI runs necessary

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
