### PR TITLE
[ENH] Read Support for CSR tables in oneapi

### DIFF
--- a/cpp/oneapi/dal/detail/error_messages.cpp
+++ b/cpp/oneapi/dal/detail/error_messages.cpp
@@ -137,6 +137,13 @@ MSG(edge_values_are_empty, "Edge values are empty")
 /* IO */
 MSG(file_not_found, "File not found")
 MSG(unsupported_read_mode, "Unsupported read mode")
+MSG(invalid_sparse_indexing,
+    "Invalid sparse indexing type. "
+    "Supported values are zero_based and one_based")
+MSG(invalid_csr_format,
+    "Invalid CSR format. "
+    "Expected three lines: row offsets, column indices, and non-zero elements")
+MSG(invalid_feature_count, "Invalid feature count")
 
 /* Serialization */
 MSG(object_is_not_serializable, "Object is not serializable")

--- a/cpp/oneapi/dal/detail/error_messages.hpp
+++ b/cpp/oneapi/dal/detail/error_messages.hpp
@@ -153,6 +153,9 @@ public:
     /* I/O */
     MSG(file_not_found);
     MSG(unsupported_read_mode);
+    MSG(invalid_sparse_indexing);
+    MSG(invalid_csr_format);
+    MSG(invalid_feature_count);
 
     /* Serialization */
     MSG(object_is_not_serializable);

--- a/cpp/oneapi/dal/io/csv/backend/cpu/read_kernel.cpp
+++ b/cpp/oneapi/dal/io/csv/backend/cpu/read_kernel.cpp
@@ -23,6 +23,10 @@
 
 #endif
 
+#include <fstream>
+#include <sstream>
+#include <vector>
+
 #include "oneapi/dal/backend/interop/common.hpp"
 #include "oneapi/dal/backend/interop/error_converter.hpp"
 #include "oneapi/dal/backend/interop/table_conversion.hpp"
@@ -59,7 +63,97 @@ struct read_kernel_cpu<table, Float> {
     }
 };
 
+template <typename Float>
+struct read_kernel_cpu<csr_table, Float> {
+    csr_table operator()(const dal::backend::context_cpu& ctx,
+                         const detail::data_source_base& ds,
+                         const read_args<csr_table>& args) const {
+        std::ifstream file(ds.get_file_name());
+        if (!file.is_open()) {
+            throw dal::range_error(dal::detail::error_messages::file_not_found());
+        }
+
+        // csr table format:
+        // first line: row offsets, i.e., the indices (within non-zero elems array) of the first non-zero element in each row
+        // second line: column indices of the non-zero elements
+        // third line: non-zero elements of the original matrix
+
+        std::string line;
+        std::vector<std::int64_t> row_offsets;
+        std::vector<std::int64_t> col_indices;
+        std::vector<Float> values;
+
+        char delimiter = ds.get_delimiter();
+        std::int64_t feature_count = args.get_feature_count();
+        sparse_indexing indexing = ds.get_sparse_indexing();
+
+        // Read the first line (row offsets)
+        if (std::getline(file, line)) {
+            std::istringstream ss(line);
+            std::string value;
+            while (std::getline(ss, value, delimiter)) {
+                row_offsets.push_back(static_cast<std::int64_t>(std::stoi(value)));
+            }
+        }
+
+        // Read the second line (column indices)
+        if (std::getline(file, line)) {
+            std::istringstream ss(line);
+            std::string value;
+            while (std::getline(ss, value, delimiter)) {
+                col_indices.push_back(static_cast<std::int64_t>(std::stoi(value)));
+            }
+        }
+
+        // Read the third line (non-zero elements)
+        if (std::getline(file, line)) {
+            std::istringstream ss(line);
+            std::string value;
+            while (std::getline(ss, value, delimiter)) {
+                values.push_back(static_cast<Float>(std::stod(value)));
+            }
+        }
+
+        file.close();
+
+        std::int64_t row_offsets_checker = static_cast<std::int64_t>(values.size()) +
+                                           (indexing == sparse_indexing::one_based ? 1 : 0);
+        if (values.size() != col_indices.size() || row_offsets.size() == 0 ||
+            row_offsets[row_offsets.size() - 1] != row_offsets_checker) {
+            throw dal::invalid_argument(dal::detail::error_messages::invalid_csr_format());
+        }
+
+        if (!col_indices.empty() && feature_count == 0) {
+            // If feature count is not specified, we estimate it from the column indices
+            // This is a best-effort estimation
+            feature_count = *std::max_element(col_indices.begin(), col_indices.end());
+            if (indexing == sparse_indexing::zero_based) {
+                feature_count += 1;
+            }
+        }
+
+        // Transfer vector data to arrays
+        auto values_array = dal::array<Float>::empty(values.size());
+        auto col_indices_array = dal::array<std::int64_t>::empty(col_indices.size());
+        auto row_offsets_array = dal::array<std::int64_t>::empty(row_offsets.size());
+
+        std::copy(values.begin(), values.end(), values_array.get_mutable_data());
+        std::copy(col_indices.begin(), col_indices.end(), col_indices_array.get_mutable_data());
+        std::copy(row_offsets.begin(), row_offsets.end(), row_offsets_array.get_mutable_data());
+
+        return csr_table::wrap(values_array,
+                               col_indices_array,
+                               row_offsets_array,
+                               feature_count,
+                               indexing // sparse indexing
+        );
+    }
+};
+
 template struct read_kernel_cpu<table, float>;
 template struct read_kernel_cpu<table, double>;
+
+template struct read_kernel_cpu<csr_table, float>;
+template struct read_kernel_cpu<csr_table, double>;
 
 } // namespace oneapi::dal::csv::backend

--- a/cpp/oneapi/dal/io/csv/backend/gpu/read_kernel_dpc.cpp
+++ b/cpp/oneapi/dal/io/csv/backend/gpu/read_kernel_dpc.cpp
@@ -23,6 +23,10 @@
 
 #endif
 
+#include <fstream>
+#include <sstream>
+#include <vector>
+
 #include "oneapi/dal/backend/interop/common.hpp"
 #include "oneapi/dal/backend/interop/error_converter.hpp"
 #include "oneapi/dal/backend/interop/table_conversion.hpp"
@@ -79,7 +83,109 @@ struct read_kernel_gpu<table, Float> {
     }
 };
 
+template <typename Float>
+struct read_kernel_gpu<csr_table, Float> {
+    csr_table operator()(const dal::backend::context_gpu& ctx,
+                         const detail::data_source_base& ds,
+                         const read_args<csr_table>& args) const {
+        std::ifstream file(ds.get_file_name());
+        if (!file.is_open()) {
+            throw dal::range_error(dal::detail::error_messages::file_not_found());
+        }
+
+        // csr table format:
+        // first line: row offsets, i.e., the indices (within non-zero elems array) of the first non-zero element in each row
+        // second line: column indices of the non-zero elements
+        // third line: non-zero elements of the original matrix
+
+        std::string line;
+        std::vector<std::int64_t> row_offsets;
+        std::vector<std::int64_t> col_indices;
+        std::vector<Float> values;
+
+        char delimiter = ds.get_delimiter();
+        std::int64_t feature_count = args.get_feature_count();
+        sparse_indexing indexing = ds.get_sparse_indexing();
+
+        // Read the first line (row offsets)
+        if (std::getline(file, line)) {
+            std::istringstream ss(line);
+            std::string value;
+            while (std::getline(ss, value, delimiter)) {
+                row_offsets.push_back(static_cast<std::int64_t>(std::stoi(value)));
+            }
+        }
+
+        // Read the second line (column indices)
+        if (std::getline(file, line)) {
+            std::istringstream ss(line);
+            std::string value;
+            while (std::getline(ss, value, delimiter)) {
+                col_indices.push_back(static_cast<std::int64_t>(std::stoi(value)));
+            }
+        }
+
+        // Read the third line (non-zero elements)
+        if (std::getline(file, line)) {
+            std::istringstream ss(line);
+            std::string value;
+            while (std::getline(ss, value, delimiter)) {
+                values.push_back(static_cast<Float>(std::stod(value)));
+            }
+        }
+
+        file.close();
+
+        std::int64_t row_offsets_checker = static_cast<std::int64_t>(values.size()) +
+                                           (indexing == sparse_indexing::one_based ? 1 : 0);
+        if (values.size() != col_indices.size() || row_offsets.size() == 0 ||
+            row_offsets[row_offsets.size() - 1] != row_offsets_checker) {
+            throw dal::invalid_argument(dal::detail::error_messages::invalid_csr_format());
+        }
+
+        if (!col_indices.empty() && feature_count == 0) {
+            // If feature count is not specified, we estimate it from the column indices
+            // This is a best-effort estimation
+            feature_count = *std::max_element(col_indices.begin(), col_indices.end());
+            if (indexing == sparse_indexing::zero_based) {
+                feature_count += 1;
+            }
+        }
+
+        // moving to device memory
+        auto& queue = ctx.get_queue();
+        auto data_arr = array<Float>::empty(queue, values.size(), sycl::usm::alloc::device);
+        auto col_indices_arr =
+            array<std::int64_t>::empty(queue, col_indices.size(), sycl::usm::alloc::device);
+        auto row_offsets_arr =
+            array<std::int64_t>::empty(queue, row_offsets.size(), sycl::usm::alloc::device);
+
+        dal::detail::memcpy_host2usm(queue,
+                                     data_arr.get_mutable_data(),
+                                     values.data(),
+                                     sizeof(Float) * values.size());
+        dal::detail::memcpy_host2usm(queue,
+                                     col_indices_arr.get_mutable_data(),
+                                     col_indices.data(),
+                                     sizeof(std::int64_t) * col_indices.size());
+        dal::detail::memcpy_host2usm(queue,
+                                     row_offsets_arr.get_mutable_data(),
+                                     row_offsets.data(),
+                                     sizeof(std::int64_t) * row_offsets.size());
+
+        return csr_table::wrap(data_arr,
+                               col_indices_arr,
+                               row_offsets_arr,
+                               feature_count,
+                               indexing // sparse indexing
+        );
+    }
+};
+
 template struct read_kernel_gpu<table, float>;
 template struct read_kernel_gpu<table, double>;
+
+template struct read_kernel_gpu<csr_table, float>;
+template struct read_kernel_gpu<csr_table, double>;
 
 } // namespace oneapi::dal::csv::backend

--- a/cpp/oneapi/dal/io/csv/common.cpp
+++ b/cpp/oneapi/dal/io/csv/common.cpp
@@ -25,6 +25,7 @@ public:
     char delimiter = ',';
     bool parse_header = false;
     std::string file_name = "";
+    sparse_indexing indexing = sparse_indexing::zero_based;
 };
 
 data_source_base::data_source_base(const char* file_name) : impl_(new data_source_impl{}) {
@@ -43,6 +44,10 @@ const char* data_source_base::get_file_name_impl() const {
     return impl_->file_name.c_str();
 }
 
+sparse_indexing data_source_base::get_sparse_indexing_impl() const {
+    return impl_->indexing;
+}
+
 void data_source_base::set_delimiter_impl(char value) {
     impl_->delimiter = value;
 }
@@ -53,6 +58,13 @@ void data_source_base::set_parse_header_impl(bool value) {
 
 void data_source_base::set_file_name_impl(const char* value) {
     impl_->file_name = std::string(value);
+}
+
+void data_source_base::set_sparse_indexing_impl(sparse_indexing indexing) {
+    if (indexing != sparse_indexing::zero_based && indexing != sparse_indexing::one_based) {
+        throw dal::invalid_argument(dal::detail::error_messages::invalid_sparse_indexing());
+    }
+    impl_->indexing = indexing;
 }
 
 } // namespace v1

--- a/cpp/oneapi/dal/io/csv/common.hpp
+++ b/cpp/oneapi/dal/io/csv/common.hpp
@@ -51,14 +51,20 @@ public:
         return std::string(get_file_name_impl());
     }
 
+    sparse_indexing get_sparse_indexing() const {
+        return get_sparse_indexing_impl();
+    }
+
 protected:
     char get_delimiter_impl() const;
     bool get_parse_header_impl() const;
     const char* get_file_name_impl() const;
+    sparse_indexing get_sparse_indexing_impl() const;
 
     void set_delimiter_impl(char value);
     void set_parse_header_impl(bool value);
     void set_file_name_impl(const char*);
+    void set_sparse_indexing_impl(sparse_indexing indexing);
 
     dal::detail::pimpl<data_source_impl> impl_;
 };
@@ -112,6 +118,12 @@ public:
     /// Sets the file name for the data source via the C++-style std::string.
     auto& set_file_name(const std::string& value) {
         set_file_name_impl(value.c_str());
+        return *this;
+    }
+
+    /// Sets the sparse indexing type for the data source.
+    auto& set_sparse_indexing(sparse_indexing indexing) {
+        set_sparse_indexing_impl(indexing);
         return *this;
     }
 };

--- a/cpp/oneapi/dal/io/csv/detail/read_ops.cpp
+++ b/cpp/oneapi/dal/io/csv/detail/read_ops.cpp
@@ -17,6 +17,7 @@
 #include "oneapi/dal/io/csv/detail/read_ops.hpp"
 #include "oneapi/dal/backend/dispatcher.hpp"
 #include "oneapi/dal/io/csv/backend/cpu/read_kernel.hpp"
+#include "oneapi/dal/table/csr.hpp"
 
 namespace oneapi::dal::csv::detail {
 namespace v1 {
@@ -33,9 +34,24 @@ table read_ops_dispatcher<table, Float, host_policy>::operator()(
     return kernel_dispatcher_t()(policy, ds, args);
 }
 
+template <typename Float>
+csr_table read_ops_dispatcher<csr_table, Float, host_policy>::operator()(
+    const host_policy& policy,
+    const data_source_base& ds,
+    const read_args<csr_table>& args) const {
+    using kernel_dispatcher_t = dal::backend::kernel_dispatcher< //
+        KERNEL_SINGLE_NODE_CPU(backend::read_kernel_cpu<csr_table, Float>)>;
+    return kernel_dispatcher_t()(policy, ds, args);
+}
+
 #define INSTANTIATE(F) template struct ONEDAL_EXPORT read_ops_dispatcher<table, F, host_policy>;
 INSTANTIATE(float)
 INSTANTIATE(double)
+
+#define INSTANTIATE_CSR(F) \
+    template struct ONEDAL_EXPORT read_ops_dispatcher<csr_table, F, host_policy>;
+INSTANTIATE_CSR(float)
+INSTANTIATE_CSR(double)
 
 } // namespace v1
 } // namespace oneapi::dal::csv::detail

--- a/cpp/oneapi/dal/io/csv/detail/read_ops_dpc.cpp
+++ b/cpp/oneapi/dal/io/csv/detail/read_ops_dpc.cpp
@@ -18,6 +18,7 @@
 #include "oneapi/dal/io/csv/backend/cpu/read_kernel.hpp"
 #include "oneapi/dal/io/csv/backend/gpu/read_kernel.hpp"
 #include "oneapi/dal/io/csv/detail/read_ops.hpp"
+#include "oneapi/dal/table/csr.hpp"
 
 namespace oneapi::dal::csv::detail {
 namespace v1 {
@@ -34,10 +35,26 @@ table read_ops_dispatcher<table, Float, data_parallel_policy>::operator()(
     return kernel_dispatcher_t{}(ctx, ds, args);
 }
 
+template <typename Float>
+csr_table read_ops_dispatcher<csr_table, Float, data_parallel_policy>::operator()(
+    const data_parallel_policy& ctx,
+    const data_source_base& ds,
+    const read_args<csr_table>& args) const {
+    using kernel_dispatcher_t = dal::backend::kernel_dispatcher<
+        KERNEL_SINGLE_NODE_CPU(backend::read_kernel_cpu<csr_table, Float>),
+        KERNEL_SINGLE_NODE_GPU(backend::read_kernel_gpu<csr_table, Float>)>;
+    return kernel_dispatcher_t{}(ctx, ds, args);
+}
+
 #define INSTANTIATE(F) \
     template struct ONEDAL_EXPORT read_ops_dispatcher<table, F, data_parallel_policy>;
 INSTANTIATE(float)
 INSTANTIATE(double)
+
+#define INSTANTIATE_CSR(F) \
+    template struct ONEDAL_EXPORT read_ops_dispatcher<csr_table, F, data_parallel_policy>;
+INSTANTIATE_CSR(float)
+INSTANTIATE_CSR(double)
 
 } // namespace v1
 } // namespace oneapi::dal::csv::detail

--- a/cpp/oneapi/dal/io/csv/read_types.cpp
+++ b/cpp/oneapi/dal/io/csv/read_types.cpp
@@ -18,6 +18,7 @@
 #include "oneapi/dal/detail/common.hpp"
 #include "oneapi/dal/detail/memory.hpp"
 #include "oneapi/dal/table/common.hpp"
+#include "oneapi/dal/table/csr.hpp"
 
 namespace oneapi::dal::csv {
 
@@ -27,9 +28,33 @@ public:
     read_args_impl() {}
 };
 
+template <>
+class detail::v1::read_args_impl<csr_table> : public base {
+public:
+    read_args_impl() {}
+
+    std::int64_t feature_count = 0; // Used for csr_table to specify the number of features
+};
+
 namespace v1 {
 
 read_args<table>::read_args() : impl_(new detail::read_args_impl<table>()) {}
+
+read_args<csr_table>::read_args(std::int64_t feature_count)
+        : impl_(new detail::read_args_impl<csr_table>()) {
+    set_feature_count_impl(feature_count);
+}
+
+std::int64_t read_args<csr_table>::get_feature_count_impl() const {
+    return impl_->feature_count;
+}
+
+void read_args<csr_table>::set_feature_count_impl(std::int64_t feature_count) {
+    if (feature_count < 0) {
+        throw dal::invalid_argument(dal::detail::error_messages::invalid_feature_count());
+    }
+    impl_->feature_count = feature_count;
+}
 
 } // namespace v1
 } // namespace oneapi::dal::csv

--- a/cpp/oneapi/dal/io/csv/read_types.hpp
+++ b/cpp/oneapi/dal/io/csv/read_types.hpp
@@ -21,6 +21,7 @@
 #include "oneapi/dal/graph/common.hpp"
 #include "oneapi/dal/detail/error_messages.hpp"
 #include "oneapi/dal/detail/memory.hpp"
+#include "oneapi/dal/table/csr.hpp"
 
 namespace oneapi::dal::csv {
 
@@ -46,6 +47,28 @@ public:
 
 private:
     dal::detail::pimpl<detail::read_args_impl<table>> impl_;
+};
+
+template <>
+class ONEDAL_EXPORT read_args<csr_table> : public base {
+public:
+    read_args(const int64_t feature_count = 0);
+
+    std::int64_t get_feature_count() const {
+        return get_feature_count_impl();
+    }
+
+    read_args& set_feature_count(const int64_t feature_count) {
+        set_feature_count_impl(feature_count);
+        return *this;
+    }
+
+protected:
+    std::int64_t get_feature_count_impl() const;
+
+    void set_feature_count_impl(const int64_t feature_count);
+
+    dal::detail::pimpl<detail::read_args_impl<csr_table>> impl_;
 };
 
 } // namespace v1


### PR DESCRIPTION
## Description

This PR adds support for reading csr tables in oneapi, both CPU and GPU implementations. Relevant examples are introduced, showcasing the functionality of the `read_csr`.

P.S. draft pr, might update description further on

---

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
