### PR TITLE
FIX: Initialize pointer to null in topology struct

### DIFF
--- a/cpp/daal/src/services/service_topo.cpp
+++ b/cpp/daal/src/services/service_topo.cpp
@@ -2014,17 +2014,17 @@ void glktsn::FreeArrays()
     _INTERNAL_DAAL_FREE(perCache_detectedCoreCount.data);
     _INTERNAL_DAAL_FREE(perEachCache_detectedThreadCount.data);
 
-    if (glbl_obj.cpuid_values)
+    if (cpuid_values)
     {
-        for (unsigned int i = 0; i <= glbl_obj.OSProcessorCount; i++)
+        for (unsigned int i = 0; i <= OSProcessorCount; i++)
         {
-            _INTERNAL_DAAL_FREE(glbl_obj.cpuid_values[i].subleaf[0]);
+            _INTERNAL_DAAL_FREE(cpuid_values[i].subleaf[0]);
 
             if ((i == 0x4 || i == 0xb))
             {
-                for (unsigned int j = 1; j < glbl_obj.cpuid_values[i].subleaf_max; j++)
+                for (unsigned int j = 1; j < cpuid_values[i].subleaf_max; j++)
                 {
-                    _INTERNAL_DAAL_FREE(glbl_obj.cpuid_values[i].subleaf[j]);
+                    _INTERNAL_DAAL_FREE(cpuid_values[i].subleaf[j]);
                 }
             }
         }

--- a/cpp/daal/src/services/service_topo.h
+++ b/cpp/daal/src/services/service_topo.h
@@ -323,7 +323,7 @@ struct glktsn
     unsigned HWMT_SMTperCore;
     unsigned HWMT_SMTperPkg;
     // a data structure that can store simple leaves and complex subleaves of all supported leaf indices of CPUID
-    CPUIDinfox * cpuid_values;
+    CPUIDinfox * cpuid_values = nullptr;
     // workspace of our generic affinitymask structure to allow iteration over each logical processors in the system
     GenericAffinityMask cpu_generic_processAffinity;
     GenericAffinityMask cpu_generic_systemAffinity;


### PR DESCRIPTION
## Description

This PR initializes a pointer to null in the topology object, as otherwise it might get initialized to a random value which would trigger an unnecessary chain of frees and potentially bad memory accesses here:
https://github.com/uxlfoundation/oneDAL/blob/01f2d3c6fff7faa03dcc6a8feac65b3f3d4f6cdd/cpp/daal/src/services/service_topo.cpp#L2017

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
