### PR TITLE
Add error handling in cw_atomic to prevent erroneous method usage 

### DIFF
--- a/cpp/oneapi/dal/backend/primitives/reduction/reduction_rm_cw_atomic_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/reduction/reduction_rm_cw_atomic_dpc.cpp
@@ -147,6 +147,11 @@ sycl::event reduction_rm_cw_atomic<Float, BinaryOp, UnaryOp>::operator()(
     const UnaryOp& unary,
     const event_vector& deps,
     const bool override_init) const {
+    throw unimplemented(dal::detail::error_messages::method_not_implemented());
+
+    /*
+    TODO: This implementation contains a bug that prevents it from working correctly.
+          It is commented out to avoid compilation errors, but it should be fixed in the future.
     event_vector new_deps{ deps };
     if (override_init) {
         auto view = ndview<Float, 1>::wrap(output, { width });
@@ -162,6 +167,7 @@ sycl::event reduction_rm_cw_atomic<Float, BinaryOp, UnaryOp>::operator()(
                                                                                  unary,
                                                                                  new_deps);
     return res;
+    */
 }
 
 template <typename Float, typename BinaryOp, typename UnaryOp>


### PR DESCRIPTION
## Description

Add an exception and a note in `reduction_rm_cw_atomic` primitive that contains a bug.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**
not applicable
