### PR TITLE
[CI] swap uxl self-hosted runners to github hosted 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,16 @@ concurrency:
 
 jobs:
   LinuxMakeDPCPP:
-    name: LinuxMakeDPCPP(AVX512)
     if: github.repository == 'uxlfoundation/oneDAL'
-    runs-on: uxl-gpu-4xlarge
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ISA: avx2
+            runner: ubuntu-24.04
+
+    runs-on: ${{ matrix.runner }}
+    name: LinuxMakeDPCPP(${{ matrix.ISA }})
     timeout-minutes: 120
 
     steps:
@@ -67,34 +74,42 @@ jobs:
       - name: Make daal debug
         run: |
           source /opt/intel/oneapi/setvars.sh
-          .ci/scripts/build.sh --compiler icx  --optimizations avx512 --target daal --debug symbols --jobs 20
-           cp -r __work __work_daal
+          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target daal --debug symbols --jobs 20
+          if [[ ${{ matrix.runner }} != ubuntu-24.04 ]];then cp -r __work __work_daal;fi
       - name: Make onedal debug
         id: onedal-dbg
         run: |
           source /opt/intel/oneapi/setvars.sh
-          .ci/scripts/build.sh --compiler icx  --optimizations avx512 --target onedal --debug symbols --jobs 20
-          cp -r __release_lnx __release_lnx_main
+          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target onedal --debug symbols --jobs 20
+          # clean up build directory due to space limitations
+          rm -rf __work
           echo "key=__release_lnx-$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Prepare Cache build
+        if: github.event_name != 'pull_request'
+        run: cp -r __release_lnx __release_lnx_main
       - name: Cache build
         if: github.event_name != 'pull_request'
         uses: actions/cache/save@v4
         with:
           key: ${{ steps.onedal-dbg.outputs.key }}
           path: ./__release_lnx_main
+      - name: Remove Cache build
+        if: github.event_name != 'pull_request'
+        run: rm -rf __release_lnx_main
       - name: Archive build
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: __release_lnx
-          path: ./__release_lnx_main
+          path: ./__release_lnx
       - name: Make onedal
+        if: matrix.runner != 'ubuntu-24.04'
         run: |
           # generate new onedal portion for use in examples testing (due to issues with dpc debug build)
           source /opt/intel/oneapi/setvars.sh
           rm -rf __work
           mv __work_daal __work
-          .ci/scripts/build.sh --compiler icx  --optimizations avx512 --target onedal --jobs 20
+          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target onedal --jobs 20
       - name: daal/cpp examples
         run: |
             source /opt/intel/oneapi/setvars.sh
@@ -104,6 +119,7 @@ jobs:
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/cpp --build-system cmake
       - name: oneapi/dpc examples
+        if: matrix.runner != 'ubuntu-24.04'
         run: |
             source /opt/intel/oneapi/setvars.sh
             .ci/scripts/test.sh --test-kind examples --build-dir __release_lnx --compiler icx --interface oneapi/dpc --build-system cmake
@@ -113,13 +129,13 @@ jobs:
             .ci/scripts/test.sh --test-kind samples --build-dir __release_lnx --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build-system cmake
 
   LinuxABICheck:
-    name: ABI Conformance(AVX512)
+    name: ABI Conformance(avx2)
     needs: LinuxMakeDPCPP
     if: |
       github.repository == 'uxlfoundation/oneDAL' &&
       github.event_name == 'pull_request' &&
       ! contains(toJson(github.event.pull_request.labels.*.name), '"API/ABI breaking change"')
-    runs-on: uxl-xlarge
+    runs-on: ubuntu-24.04
     env:
       LIBABIGAIL_DEFAULT_USER_SUPPRESSION_FILE: ${{ github.workspace }}/.github/.abignore
     timeout-minutes: 20


### PR DESCRIPTION
## Description

Due to infrastructure issues, we need to swap back to using github hosted runners (previous PRs: #3176 and #3188).

This is a copy of that original PR, as some changes were made to the yaml file since this was last done.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
