### PR TITLE
Fix: Nightly CI failures

### DIFF
--- a/cpp/oneapi/dal/backend/primitives/reduction/reduction_rm_cw_wrapper_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/reduction/reduction_rm_cw_wrapper_dpc.cpp
@@ -32,6 +32,7 @@ auto reduction_rm_cw<Float, BinaryOp, UnaryOp>::propose_method(std::int64_t widt
         return reduction_method::blocking;
     }
 
+    /* TODO: The implementation of rm_cw_atomic reduction contains a bug that prevents it from working correctly.
     {
         const auto fwidth = device_max_wg_size(q_);
         const auto twidth = fwidth * atomic_t::max_folding;
@@ -40,6 +41,7 @@ auto reduction_rm_cw<Float, BinaryOp, UnaryOp>::propose_method(std::int64_t widt
             return reduction_method::atomic;
         }
     }
+    */
     return reduction_method::naive;
 }
 

--- a/cpp/oneapi/dal/backend/primitives/reduction/test/reduction_rm_random_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/reduction/test/reduction_rm_random_dpc.cpp
@@ -280,7 +280,8 @@ TEMPLATE_LIST_TEST_M(reduction_rm_test_random,
     this->generate();
     SKIP_IF(this->should_be_skipped());
     this->test_raw_cw_reduce_naive();
-    this->test_raw_cw_reduce_atomic();
+    // TODO: Investigation into atomic reduction discrepancies ongoing
+    // this->test_raw_cw_reduce_atomic();
     this->test_raw_cw_reduce_wrapper();
 }
 
@@ -332,7 +333,8 @@ TEMPLATE_LIST_TEST_M(infinite_sum_rm_test_random,
     this->generate(use_infnan);
     SKIP_IF(this->should_be_skipped());
     this->test_raw_cw_reduce_naive();
-    this->test_raw_cw_reduce_atomic();
+    // TODO: Investigation into atomic reduction discrepancies ongoing
+    // this->test_raw_cw_reduce_atomic();
     this->test_raw_cw_reduce_wrapper();
 }
 
@@ -390,7 +392,7 @@ TEMPLATE_LIST_TEST_M(single_infinite_rm_test_random,
     SECTION("Reduce Naive") {
         this->test_raw_cw_reduce_naive();
     }
-    // Investigation into atomic reduction discrepancies ongoing
+    // TODO: Investigation into atomic reduction discrepancies ongoing
     //SECTION("Reduce Atomic") {
     // this->test_raw_cw_reduce_atomic();
     //}

--- a/cpp/oneapi/dal/backend/primitives/reduction/test/reduction_rm_uniform_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/reduction/test/reduction_rm_uniform_dpc.cpp
@@ -367,7 +367,8 @@ TEMPLATE_LIST_TEST_M(reduction_rm_test_uniform,
     this->generate();
     SKIP_IF(this->should_be_skipped());
     this->test_raw_cw_reduce_naive();
-    this->test_raw_cw_reduce_atomic();
+    // TODO: Investigation into atomic reduction discrepancies ongoing
+    // this->test_raw_cw_reduce_atomic();
     this->test_raw_cw_reduce_wrapper();
 }
 


### PR DESCRIPTION
## Description

Fix failures after [#3283](https://github.com/uxlfoundation/oneDAL/pull/3283) merging.

cw_atomic reduction  was marked as unimplemented in the #3283 because of a bug in the implementation.
Some tests started to fail due to that added exception.

 This PR removes those failing testcases.
 
 And also fixes the reduction method dispatcher in order not to choose the cw_atomic kernel.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- All CI jobs are green or I have provided justification why they aren't.

Internal CI failed due to infrastructure exception.
The errors in public CI also do not look related to these changes.

