### PR TITLE
FIX: Fix extra comma resulting in syntax error depending on defined macros

### DIFF
--- a/cpp/oneapi/dal/detail/cpu.hpp
+++ b/cpp/oneapi/dal/detail/cpu.hpp
@@ -44,8 +44,9 @@ enum class cpu_vendor { unknown = 0, intel = 1, amd = 2, arm = 3, riscv64 = 4 };
 /// CPU extension enumeration.
 /// This enum is used to represent the highest supported CPU extension.
 enum class cpu_extension : uint64_t {
-    none = 0U,
+    none = 0U
 #if defined(TARGET_X86_64)
+    ,
     sse2 = 1U << 0, /// Intel(R) Streaming SIMD Extensions 2 (Intel(R) SSE2)
     sse42 = 1U << 2, /// Intel(R) Streaming SIMD Extensions 4.2 (Intel(R) SSE4.2)
     avx2 = 1U << 4, /// Intel(R) Advanced Vector Extensions 2 (Intel(R) AVX2)
@@ -53,15 +54,18 @@ enum class cpu_extension : uint64_t {
         1U
         << 5 /// Intel(R) Xeon(R) processors based on Intel(R) Advanced Vector Extensions 512 (Intel(R) AVX-512)
 #elif defined(TARGET_ARM)
+    ,
     sve = 1U << 0 /// Arm(R) processors based on Arm's Scalable Vector Extension (SVE)
 #elif defined(TARGET_RISCV64)
+    ,
     rv64 = 1U << 0 /// RISC-V 64-bit architecture
 #endif
 };
 
 enum class cpu_feature : uint64_t {
-    unknown = 0ULL,
+    unknown = 0ULL
 #if defined(TARGET_X86_64)
+    ,
     sstep = 1ULL << 0, /// Intel(R) SpeedStep
     tb = 1ULL << 1, /// Intel(R) Turbo Boost
     avx512_bf16 = 1ULL << 2, /// AVX512 bfloat16
@@ -74,8 +78,9 @@ enum class cpu_feature : uint64_t {
 /// This map is used to convert CPU feature bitmasks to human-readable strings.
 /// Keys are bitflags representing CPU features. They are defined in daal::CpuFeature enumeration.
 inline const std::map<uint64_t, const std::string> cpu_feature_map = {
-    { uint64_t(cpu_feature::unknown), "Unknown" },
+    { uint64_t(cpu_feature::unknown), "Unknown" }
 #if defined(TARGET_X86_64)
+    ,
     { uint64_t(cpu_feature::sstep), "Intel(R) SpeedStep" },
     { uint64_t(cpu_feature::tb), "Intel(R) Turbo Boost" },
     { uint64_t(cpu_feature::avx512_bf16), "AVX-512 bfloat16" },


### PR DESCRIPTION
## Description

This PR fixes a potentially invalid syntax issue that would prevent compilation of the cpu-related files when disabling features or when compiling for other platforms.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.