### PR TITLE
MAINT: Avoid instantiation that generates problems under some compilers

### DIFF
--- a/cpp/oneapi/dal/detail/cpu.hpp
+++ b/cpp/oneapi/dal/detail/cpu.hpp
@@ -73,7 +73,7 @@ enum class cpu_feature : uint64_t {
 /// A map of CPU features to their string representations.
 /// This map is used to convert CPU feature bitmasks to human-readable strings.
 /// Keys are bitflags representing CPU features. They are defined in daal::CpuFeature enumeration.
-inline const std::map<uint64_t, const std::string> cpu_feature_map = {
+inline const std::map<uint64_t, const char*> cpu_feature_map = {
     { uint64_t(cpu_feature::unknown), "Unknown" },
 #if defined(TARGET_X86_64)
     { uint64_t(cpu_feature::sstep), "Intel(R) SpeedStep" },


### PR DESCRIPTION
## Description

This instantiation of a map with `const std::string` variables created out of string literals appear to result in memory corruptions under some platforms and compiler options. Note that after this, there would still be other memory corruptions happening, so it's unclear whether this solves an actual issue or just pushes elsewhere in way that evades detection by automated tools.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
