### PR TITLE
FIX: Fix incorrect comparison for small rows threshold of linear regression

### DIFF
--- a/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
@@ -274,7 +274,7 @@ Status UpdateKernel<algorithmFPType, cpu>::compute(const NumericTable & xTable, 
         DAAL_CHECK_STATUS_VAR(status);
     }
 
-    const bool use_non_batched_route = nBetas >= maxColsBatched || (nRows >= smallRowsThreshold && nBetas >= smallRowsMaxColsBatched);
+    const bool use_non_batched_route = nBetas >= maxColsBatched || (nRows <= smallRowsThreshold && nBetas >= smallRowsMaxColsBatched);
     if (use_non_batched_route)
     {
         const DAAL_INT nCols = xTable.getNumberOfColumns();


### PR DESCRIPTION
## Description

Fixes incorrect direction of the comparison about the small rows threshold for linear regression, which changes what the threshold on number of columns should be for switching between the batched and the non-batched route.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
