### PR TITLE
fix: fix the perf for knn preidction

### DIFF
--- a/cpp/oneapi/dal/algo/knn/backend/model_conversion.hpp
+++ b/cpp/oneapi/dal/algo/knn/backend/model_conversion.hpp
@@ -57,8 +57,6 @@ inline auto convert_onedal_to_daal_knn_model(const model<Task>& m) {
 
     const auto trained_model = dynamic_cast_to_knn_model<Task, brute_force_model_impl<Task>>(m);
 
-    // Changed to perform a copy as far as we have similar logic
-    // for d4p patching; to allign performance with DAAL
     const auto daal_train_data = interop::convert_to_daal_table<Float>(trained_model->get_data());
     const auto daal_train_responses =
         interop::convert_to_daal_table<Float>(trained_model->get_responses());

--- a/cpp/oneapi/dal/algo/knn/backend/model_conversion.hpp
+++ b/cpp/oneapi/dal/algo/knn/backend/model_conversion.hpp
@@ -59,10 +59,9 @@ inline auto convert_onedal_to_daal_knn_model(const model<Task>& m) {
 
     // Changed to perform a copy as far as we have similar logic
     // for d4p patching; to allign performance with DAAL
-    const auto daal_train_data =
-        interop::copy_to_daal_homogen_table<Float>(trained_model->get_data());
+    const auto daal_train_data = interop::convert_to_daal_table<Float>(trained_model->get_data());
     const auto daal_train_responses =
-        interop::copy_to_daal_homogen_table<Float>(trained_model->get_responses());
+        interop::convert_to_daal_table<Float>(trained_model->get_responses());
 
     const auto model_ptr =
         create_daal_model_for_bf_knn<Float>(daal_train_data, daal_train_responses);


### PR DESCRIPTION
## Description

This PR improve the perf for knn prediction by using convert_to_daal_table 



---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
