### PR TITLE
[maint] remove descriptor_base_t alias

### DIFF
--- a/cpp/oneapi/dal/algo/basic_statistics/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/basic_statistics/detail/compute_ops.hpp
@@ -38,7 +38,6 @@ struct compute_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = compute_input<task_t>;
     using result_t = compute_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/basic_statistics/detail/finalize_compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/basic_statistics/detail/finalize_compute_ops.hpp
@@ -36,7 +36,6 @@ struct finalize_compute_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = partial_compute_result<task_t>;
     using result_t = compute_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& desc, const input_t& input) const {
         const auto compute_mode = desc.get_result_options();

--- a/cpp/oneapi/dal/algo/basic_statistics/detail/partial_compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/basic_statistics/detail/partial_compute_ops.hpp
@@ -36,7 +36,6 @@ struct partial_compute_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = partial_compute_input<task_t>;
     using result_t = partial_compute_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/connected_components/detail/vertex_partitioning_ops.hpp
+++ b/cpp/oneapi/dal/algo/connected_components/detail/vertex_partitioning_ops.hpp
@@ -46,7 +46,6 @@ struct vertex_partitioning_ops {
     using graph_t = Graph;
     using input_t = vertex_partitioning_input<graph_t, task_t>;
     using result_t = vertex_partitioning_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     template <typename Policy>
     auto operator()(const Policy &policy, const Descriptor &desc, input_t &input) const {

--- a/cpp/oneapi/dal/algo/correlation_distance/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/correlation_distance/detail/compute_ops.hpp
@@ -45,7 +45,6 @@ struct compute_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = compute_input<task_t>;
     using result_t = compute_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/cosine_distance/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/cosine_distance/detail/compute_ops.hpp
@@ -45,7 +45,6 @@ struct compute_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = compute_input<task_t>;
     using result_t = compute_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/covariance/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/covariance/detail/compute_ops.hpp
@@ -44,7 +44,6 @@ struct compute_ops {
     using input_t = compute_input<task_t>;
     using result_t = compute_result<task_t>;
     using param_t = compute_parameters<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/covariance/detail/finalize_compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/covariance/detail/finalize_compute_ops.hpp
@@ -36,7 +36,6 @@ struct finalize_compute_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = partial_compute_result<task_t>;
     using result_t = compute_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         ONEDAL_ASSERT(input.get_partial_n_rows().has_data());

--- a/cpp/oneapi/dal/algo/covariance/detail/partial_compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/covariance/detail/partial_compute_ops.hpp
@@ -36,7 +36,6 @@ struct partial_compute_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = partial_compute_input<task_t>;
     using result_t = partial_compute_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/dbscan/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/dbscan/detail/compute_ops.hpp
@@ -36,7 +36,6 @@ struct compute_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = compute_input<task_t>;
     using result_t = compute_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
@@ -45,7 +45,6 @@ struct infer_ops {
     using input_t = infer_input<task_t>;
     using result_t = infer_result<task_t>;
     using param_t = infer_parameters<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/decision_forest/detail/train_ops.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/train_ops.hpp
@@ -45,7 +45,6 @@ struct train_ops {
     using input_t = train_input<task_t>;
     using result_t = train_result<task_t>;
     using param_t = train_parameters<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/decision_forest/detail/train_ops.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/train_ops.hpp
@@ -100,7 +100,7 @@ struct train_ops {
         params.check_ranges();
         const auto result = train_ops_dispatcher<Context, float_t, task_t, method_t>{}(
             ctx,
-            dynamic_cast<const descriptor_base_t&>(desc),
+            dynamic_cast<const descriptor_base<task_t>&>(desc),
             params,
             input);
         check_postconditions(desc, input, result);

--- a/cpp/oneapi/dal/algo/finiteness_checker/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/finiteness_checker/detail/compute_ops.hpp
@@ -44,7 +44,6 @@ struct compute_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = compute_input<task_t>;
     using result_t = compute_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/jaccard/detail/vertex_similarity_ops.hpp
+++ b/cpp/oneapi/dal/algo/jaccard/detail/vertex_similarity_ops.hpp
@@ -52,7 +52,6 @@ struct vertex_similarity_ops {
     using graph_t = Graph;
     using input_t = vertex_similarity_input<graph_t, task_t>;
     using result_t = vertex_similarity_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor &param, input_t &input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/kmeans/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/detail/infer_ops.hpp
@@ -36,7 +36,6 @@ struct infer_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = infer_input<task_t>;
     using result_t = infer_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/kmeans/detail/train_ops.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/detail/train_ops.hpp
@@ -36,7 +36,6 @@ struct train_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = train_input<task_t>;
     using result_t = train_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/kmeans_init/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/detail/compute_ops.hpp
@@ -36,7 +36,6 @@ struct compute_ops {
     using method_t = typename Descriptor::method_t;
     using input_t = compute_input<task_t>;
     using result_t = compute_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/knn/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/knn/detail/infer_ops.hpp
@@ -36,7 +36,6 @@ struct infer_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = infer_input<task_t>;
     using result_t = infer_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/knn/detail/train_ops.hpp
+++ b/cpp/oneapi/dal/algo/knn/detail/train_ops.hpp
@@ -36,7 +36,6 @@ struct train_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = train_input<task_t>;
     using result_t = train_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/linear_kernel/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/detail/compute_ops.hpp
@@ -44,7 +44,6 @@ struct compute_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = compute_input<task_t>;
     using result_t = compute_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/linear_regression/detail/finalize_train_ops.hpp
+++ b/cpp/oneapi/dal/algo/linear_regression/detail/finalize_train_ops.hpp
@@ -45,7 +45,6 @@ struct finalize_train_ops {
     using input_t = partial_train_result<task_t>;
     using result_t = train_result<task_t>;
     using param_t = train_parameters<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/linear_regression/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/linear_regression/detail/infer_ops.hpp
@@ -36,7 +36,6 @@ struct infer_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = infer_input<task_t>;
     using result_t = infer_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/linear_regression/detail/partial_train_ops.hpp
+++ b/cpp/oneapi/dal/algo/linear_regression/detail/partial_train_ops.hpp
@@ -44,7 +44,6 @@ struct partial_train_ops {
     using param_t = train_parameters<task_t>;
     using input_t = partial_train_input<task_t>;
     using result_t = partial_train_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/linear_regression/detail/train_ops.hpp
+++ b/cpp/oneapi/dal/algo/linear_regression/detail/train_ops.hpp
@@ -45,7 +45,6 @@ struct train_ops {
     using input_t = train_input<task_t>;
     using result_t = train_result<task_t>;
     using param_t = train_parameters<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/logistic_regression/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/detail/infer_ops.hpp
@@ -36,7 +36,6 @@ struct infer_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = infer_input<task_t>;
     using result_t = infer_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/logistic_regression/detail/train_ops.hpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/detail/train_ops.hpp
@@ -45,7 +45,6 @@ struct train_ops {
     using input_t = train_input<task_t>;
     using result_t = train_result<task_t>;
     using param_t = train_parameters<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/louvain/detail/vertex_partitioning_ops.hpp
+++ b/cpp/oneapi/dal/algo/louvain/detail/vertex_partitioning_ops.hpp
@@ -46,7 +46,6 @@ struct vertex_partitioning_ops {
     using graph_t = Graph;
     using input_t = vertex_partitioning_input<graph_t, task_t>;
     using result_t = vertex_partitioning_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor &desc, input_t &input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/objective_function/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/objective_function/detail/compute_ops.hpp
@@ -36,7 +36,6 @@ struct compute_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = compute_input<task_t>;
     using result_t = compute_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/pca/detail/finalize_train_ops.hpp
+++ b/cpp/oneapi/dal/algo/pca/detail/finalize_train_ops.hpp
@@ -36,7 +36,6 @@ struct finalize_train_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = partial_train_result<task_t>;
     using result_t = train_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         ONEDAL_ASSERT(input.get_partial_n_rows().has_data());

--- a/cpp/oneapi/dal/algo/pca/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/pca/detail/infer_ops.hpp
@@ -36,7 +36,6 @@ struct infer_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = infer_input<task_t>;
     using result_t = infer_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& desc, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/pca/detail/partial_train_ops.hpp
+++ b/cpp/oneapi/dal/algo/pca/detail/partial_train_ops.hpp
@@ -36,7 +36,6 @@ struct partial_train_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = partial_train_input<task_t>;
     using result_t = partial_train_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/pca/detail/train_ops.hpp
+++ b/cpp/oneapi/dal/algo/pca/detail/train_ops.hpp
@@ -45,7 +45,6 @@ struct train_ops {
     using input_t = train_input<task_t>;
     using result_t = train_result<task_t>;
     using param_t = train_parameters<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& desc, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/polynomial_kernel/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/polynomial_kernel/detail/compute_ops.hpp
@@ -45,7 +45,6 @@ struct compute_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = compute_input<task_t>;
     using result_t = compute_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/rbf_kernel/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/detail/compute_ops.hpp
@@ -45,7 +45,6 @@ struct compute_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = compute_input<task_t>;
     using result_t = compute_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/shortest_paths/detail/traverse_ops.hpp
+++ b/cpp/oneapi/dal/algo/shortest_paths/detail/traverse_ops.hpp
@@ -45,7 +45,6 @@ struct traverse_ops {
     using graph_t = Graph;
     using input_t = traverse_input<graph_t, task_t>;
     using result_t = traverse_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     template <typename T = task_t,
               typename M = method_t,

--- a/cpp/oneapi/dal/algo/sigmoid_kernel/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/sigmoid_kernel/detail/compute_ops.hpp
@@ -45,7 +45,6 @@ struct compute_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = compute_input<task_t>;
     using result_t = compute_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/subgraph_isomorphism/detail/graph_matching_ops.hpp
+++ b/cpp/oneapi/dal/algo/subgraph_isomorphism/detail/graph_matching_ops.hpp
@@ -65,7 +65,6 @@ struct graph_matching_ops {
     using graph_t = Graph;
     using input_t = graph_matching_input<graph_t, task_t>;
     using result_t = graph_matching_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor &desc, input_t &input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/svm/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/svm/detail/infer_ops.hpp
@@ -36,7 +36,6 @@ struct infer_ops {
     using task_t = typename Descriptor::task_t;
     using input_t = infer_input<task_t>;
     using result_t = infer_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/svm/detail/train_ops.hpp
+++ b/cpp/oneapi/dal/algo/svm/detail/train_ops.hpp
@@ -37,7 +37,6 @@ struct train_ops {
     using kernel_t = typename Descriptor::kernel_t;
     using input_t = train_input<task_t>;
     using result_t = train_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;

--- a/cpp/oneapi/dal/algo/triangle_counting/detail/vertex_ranking_ops.hpp
+++ b/cpp/oneapi/dal/algo/triangle_counting/detail/vertex_ranking_ops.hpp
@@ -51,7 +51,6 @@ struct vertex_ranking_ops {
     using graph_t = Graph;
     using input_t = vertex_ranking_input<graph_t, task_t>;
     using result_t = vertex_ranking_result<task_t>;
-    using descriptor_base_t = descriptor_base<task_t>;
 
     template <typename Policy>
     auto operator()(const Policy &policy, const Descriptor &desc, input_t &input) const {


### PR DESCRIPTION
## Description

Its aliased everywhere but only used once. Unlike ```tags_t``` (which is vital for dispatching) this is useless. Given the importance of other aliases, it is best to remove unused components.

No performance benchmarks necessary, no change to ABI.
---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
