### PR TITLE
FIX: Check status code after every call

### DIFF
--- a/cpp/daal/src/algorithms/k_nearest_neighbors/bf_knn_classification_train_container.h
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/bf_knn_classification_train_container.h
@@ -64,6 +64,7 @@ services::Status BatchContainer<algorithmFpType, method, cpu>::compute()
 
     const bool copy = (par->dataUseInModel == doNotUse);
     status |= r->impl()->setData<algorithmFpType>(x, copy);
+    DAAL_CHECK_STATUS_VAR(status);
     if ((par->resultsToEvaluate & daal::algorithms::classifier::computeClassLabels) != 0)
     {
         const NumericTablePtr y = input->get(classifier::training::labels);


### PR DESCRIPTION
## Description

Small fix to not proceed with a further op if an error has occurred already.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.