### PR TITLE
FIX: Prevent log probabilities from turning to infinite

### DIFF
--- a/cpp/daal/src/algorithms/logistic_regression/logistic_regression_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/logistic_regression/logistic_regression_predict_dense_default_batch_impl.i
@@ -109,11 +109,15 @@ public:
 
             if (_prob || _logProb)
             {
-                ll::internal::LogLossKernel<algorithmFPType, ll::defaultDense, cpu>::sigmoid(buff, buff, nRowsToProcess);
-            }
+                if (_logProb)
+                {
+                    ll::internal::LogLossKernel<algorithmFPType, ll::defaultDense, cpu>::sigmoid_clipped(buff, buff, nRowsToProcess);
+                }
+                else
+                {
+                    ll::internal::LogLossKernel<algorithmFPType, ll::defaultDense, cpu>::sigmoid(buff, buff, nRowsToProcess);
+                }
 
-            if (_prob || _logProb)
-            {
                 auto ntForProb = _prob ? _prob : _logProb;
                 WriteOnlyRows<algorithmFPType, cpu> probBD(ntForProb, iStartRow, nRowsToProcess);
                 DAAL_CHECK_BLOCK_STATUS_THR(probBD);

--- a/cpp/daal/src/algorithms/objective_function/logistic_loss/logistic_loss_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/objective_function/logistic_loss/logistic_loss_dense_default_batch_impl.i
@@ -113,6 +113,26 @@ static void sigmoids(algorithmFPType * exp, size_t n, size_t offset)
 }
 
 template <typename algorithmFPType, Method method, CpuType cpu>
+void LogLossKernel<algorithmFPType, method, cpu>::sigmoid_clipped(const algorithmFPType * f, algorithmFPType * s, size_t n)
+{
+    const algorithmFPType bottom = sizeof(algorithmFPType) == 4 ? 1e-7 : 1e-15;
+    const algorithmFPType top    = algorithmFPType(1.0) - bottom;
+
+    //s = exp(-f)
+    vexp<algorithmFPType, cpu>(f, s, n);
+    //s = sigm(f)
+    PRAGMA_FORCE_SIMD
+    PRAGMA_VECTOR_ALWAYS
+    for (size_t i = 0; i < n; ++i)
+    {
+        algorithmFPType sigm = static_cast<algorithmFPType>(1.0) / (static_cast<algorithmFPType>(1.0) + s[i]);
+        if (sigm < bottom) sigm = bottom;
+        if (sigm > top) sigm = top;
+        s[i] = sigm;
+    }
+}
+
+template <typename algorithmFPType, Method method, CpuType cpu>
 void LogLossKernel<algorithmFPType, method, cpu>::sigmoid(const algorithmFPType * f, algorithmFPType * s, size_t n)
 {
     //s = exp(-f)

--- a/cpp/daal/src/algorithms/objective_function/logistic_loss/logistic_loss_dense_default_batch_kernel.h
+++ b/cpp/daal/src/algorithms/objective_function/logistic_loss/logistic_loss_dense_default_batch_kernel.h
@@ -52,6 +52,7 @@ public:
     static void applyBeta(const algorithmFPType * x, const algorithmFPType * beta, algorithmFPType * xb, size_t nRows, size_t nCols, bool bIntercept);
 
     static void sigmoid(const algorithmFPType * f, algorithmFPType * s, size_t n);
+    static void sigmoid_clipped(const algorithmFPType * f, algorithmFPType * s, size_t n);
 
 protected:
     services::Status doCompute(const NumericTable * dataNT, const NumericTable * dependentVariablesNT, size_t n, size_t p, NumericTable * betaNT,


### PR DESCRIPTION
## Description

This PR adds the same fix as in https://github.com/uxlfoundation/oneDAL/pull/3293 for the prediction function that outputs log probabilities, so that sklearnex's `predict_log_proba` doesn't end up returning infinites.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
