### PR TITLE
ENH: Improve KMeans numerical precision by using temporary accumulator

### DIFF
--- a/cpp/daal/src/algorithms/kmeans/kmeans_lloyd_impl.i
+++ b/cpp/daal/src/algorithms/kmeans/kmeans_lloyd_impl.i
@@ -302,7 +302,8 @@ Status TaskKMeansLloyd<algorithmFPType, cpu>::addNTToTaskThreadedCSR(const Numer
         SpBlasInst<algorithmFPType, cpu>::xxcsrmm(&transa, &_n, &_c, &_p, &alpha, matdescra, data, (DAAL_INT *)colIdx, (DAAL_INT *)rowIdx, inClusters,
                                                   &_p, &beta, x_clusters, &_n);
 
-        size_t csrCursor = 0;
+        algorithmFPType goal = 0;
+        size_t csrCursor     = 0;
         for (size_t i = 0; i < blockSize; i++)
         {
             algorithmFPType minGoalVal = clustersSq[0] - x_clusters[i];
@@ -329,7 +330,7 @@ Status TaskKMeansLloyd<algorithmFPType, cpu>::addNTToTaskThreadedCSR(const Numer
 
             kmeansInsertCandidate(tt, minGoalVal, k * blockSizeDefault + i);
 
-            *trg += minGoalVal;
+            goal += minGoalVal;
 
             cS0[minIdx]++;
 
@@ -339,6 +340,7 @@ Status TaskKMeansLloyd<algorithmFPType, cpu>::addNTToTaskThreadedCSR(const Numer
                 assignments[i] = (int)minIdx;
             }
         }
+        *trg += goal;
     });
     return safeStat.detach();
 }


### PR DESCRIPTION
## Description

This PR improves a bit the numerical precision of the sparse Lloyd KMeans algorithm by starting an accumulator from zero at every iteration and summing it afterwards to the running total, instead of summing to the non-zero running total every time; just like it is done in the dense version.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.