### PR TITLE
FIX: Fix incorrect size of loop when converting sparse data to base1

### DIFF
--- a/cpp/oneapi/dal/table/backend/interop/host_csr_table_adapter.cpp
+++ b/cpp/oneapi/dal/table/backend/interop/host_csr_table_adapter.cpp
@@ -148,7 +148,8 @@ host_csr_table_adapter<Data>::host_csr_table_adapter(const csr_table& table, sta
         one_based_row_offsets_.reset(row_count + 1);
         size_t* one_based_column_indices_ptr = one_based_column_indices_.get_mutable_data();
         size_t* one_based_row_offsets_ptr = one_based_row_offsets_.get_mutable_data();
-        for (std::int64_t i = 0; i < column_count; i++) {
+        const std::size_t nnz = one_based_row_offsets_[row_count] - one_based_row_offsets_[0];
+        for (std::size_t i = 0; i < nnz; i++) {
             one_based_column_indices_ptr[i] = column_indices[i] + 1;
         }
         column_indices = one_based_column_indices_ptr;


### PR DESCRIPTION
## Description

Fixes incorrect logic in handling of zero-based sparse matrices.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
