### PR TITLE
MAINT: Don't ignore `$CXXFLAGS` and `$LDFLAGS`

### DIFF
--- a/dev/make/compiler_definitions/clang.32e.mk
+++ b/dev/make/compiler_definitions/clang.32e.mk
@@ -51,13 +51,13 @@ else
 endif
 
 COMPILER.mac.clang = clang++ -m64 -fgnu-runtime -stdlib=libc++ -mmacosx-version-min=10.15 -fwrapv \
-                     -Werror -Wreturn-type
+                     -Werror -Wreturn-type ${CXXFLAGS}
 COMPILER.lnx.clang = clang++ -m64 \
-                     -Werror -Wreturn-type
+                     -Werror -Wreturn-type ${CXXFLAGS}
 
 linker.ld.flag := $(if $(LINKER),-fuse-ld=$(LINKER),)
 link.dynamic.mac.clang = clang++ $(linker.ld.flag) -m64
-link.dynamic.lnx.clang = clang++ $(linker.ld.flag) -m64
+link.dynamic.lnx.clang = clang++ $(linker.ld.flag) -m64 ${LDFLAGS}
 
 pedantic.opts.mac.clang = $(pedantic.opts.clang)
 pedantic.opts.lnx.clang = $(pedantic.opts.clang)

--- a/dev/make/compiler_definitions/gnu.32e.mk
+++ b/dev/make/compiler_definitions/gnu.32e.mk
@@ -47,10 +47,10 @@ else
 endif
 
 COMPILER.all.gnu =  ${CXX} -m64 -fwrapv -fno-strict-overflow -fno-delete-null-pointer-checks \
-                    -Werror -Wreturn-type
+                    -Werror -Wreturn-type ${CXXFLAGS}
 
 linker.ld.flag := $(if $(LINKER),-fuse-ld=$(LINKER),)
-link.dynamic.all.gnu = ${CXX} $(linker.ld.flag) -m64
+link.dynamic.all.gnu = ${CXX} $(linker.ld.flag) -m64 ${LDFLAGS}
 
 pedantic.opts.lnx.gnu = $(pedantic.opts.all.gnu)
 pedantic.opts.mac.gnu = $(pedantic.opts.all.gnu)

--- a/dev/make/compiler_definitions/icc.mkl.32e.mk
+++ b/dev/make/compiler_definitions/icc.mkl.32e.mk
@@ -64,17 +64,17 @@ endif
 -Qopt = $(if $(OS_is_win),-Qopt-,-qopt-)
 
 COMPILER.lnx.icc  = $(if $(COVFILE),cov01 -1; covc --no-banner -i )icc -qopenmp-simd \
-                    -Werror -Wreturn-type -diag-disable=10441
+                    -Werror -Wreturn-type -diag-disable=10441 ${CXXFLAGS}
 COMPILER.lnx.icc += $(if $(COVFILE), $(-Q)m64)
-COMPILER.win.icc = icl $(if $(MSVC_RT_is_release),-MD, -MDd /debug:none) -nologo -WX -Qopenmp-simd -Qdiag-disable:10441
+COMPILER.win.icc = icl $(if $(MSVC_RT_is_release),-MD, -MDd /debug:none) -nologo -WX -Qopenmp-simd -Qdiag-disable:10441 ${CXXFLAGS}
 COMPILER.mac.icc = icc -stdlib=libc++ -mmacosx-version-min=10.15 \
-				   -Werror -Wreturn-type -diag-disable=10441
+				   -Werror -Wreturn-type -diag-disable=10441 ${CXXFLAGS}
 
 linker.ld.flag := $(if $(LINKER),-fuse-ld=$(LINKER),)
 
-link.dynamic.lnx.icc = icc $(linker.ld.flag) -no-cilk -diag-disable=10441
-link.dynamic.mac.icc = icc -diag-disable=10441
-link.dynamic.win.icc = icc $(linker.ld.flag)
+link.dynamic.lnx.icc = icc $(linker.ld.flag) -no-cilk -diag-disable=10441 ${LDFLAGS}
+link.dynamic.mac.icc = icc -diag-disable=10441 ${LDFLAGS}
+link.dynamic.win.icc = icc $(linker.ld.flag) ${LDFLAGS}
 
 pedantic.opts.lnx.icc = -pedantic \
                         -Wall \

--- a/dev/make/compiler_definitions/icx.mkl.32e.mk
+++ b/dev/make/compiler_definitions/icx.mkl.32e.mk
@@ -68,15 +68,15 @@ endif
 -Qopt = $(if $(OS_is_win),-Qopt-,-qopt-)
 
 COMPILER.lnx.icx = icx -m64 \
-                     -Werror -Wreturn-type -qopenmp-simd
+                     -Werror -Wreturn-type -qopenmp-simd ${CXXFLAGS}
 COMPILER.lnx.icx += $(if $(filter yes,$(GCOV_ENABLED)),-coverage,)
-COMPILER.win.icx = icx $(if $(MSVC_RT_is_release),-MD -Qopenmp-simd, -MDd) -nologo -WX -Wno-deprecated-declarations
+COMPILER.win.icx = icx $(if $(MSVC_RT_is_release),-MD -Qopenmp-simd, -MDd) -nologo -WX -Wno-deprecated-declarations ${CXXFLAGS}
 
 linker.ld.flag := $(if $(LINKER),-fuse-ld=$(LINKER),)
 
-link.dynamic.lnx.icx = icx $(linker.ld.flag) -m64 -no-intel-lib
+link.dynamic.lnx.icx = icx $(linker.ld.flag) -m64 -no-intel-lib ${LDFLAGS}
 link.dynamic.lnx.icx += $(if $(filter yes,$(GCOV_ENABLED)),-coverage,)
-link.dynamic.win.icc = icx $(linker.ld.flag)
+link.dynamic.win.icc = icx $(linker.ld.flag) ${LDFLAGS}
 
 pedantic.opts.lnx.icx = -pedantic \
                         -Wall \

--- a/dev/make/compiler_definitions/vc.mkl.32e.mk
+++ b/dev/make/compiler_definitions/vc.mkl.32e.mk
@@ -39,9 +39,9 @@ endif
 -asanshared.vc =
 
 # Disable C4661 because of false positives
-COMPILER.win.vc = cl $(if $(MSVC_RT_is_release),-MD, -MDd) -nologo -EHsc -wd4661 -WX
+COMPILER.win.vc = cl $(if $(MSVC_RT_is_release),-MD, -MDd) -nologo -EHsc -wd4661 -WX ${CXXFLAGS}
 
-link.dynamic.win.vc = /DEPENDENTLOADFLAG:0x2000
+link.dynamic.win.vc = /DEPENDENTLOADFLAG:0x2000 ${LDFLAGS}
 
 p4_OPT.vc   =
 mc3_OPT.vc  =


### PR DESCRIPTION
## Description

Currently, setting environment variables such as `${CXXFLAGS}` doesn't have any effect when building oneDAL, because those are ignored as oneDAL sets its own compiler and similar.

This PR makes it forcibly add `${CXXFLAGS}` and `${LDFLAGS}` if they are set. Note that it still ignores other variables like `${CPPFLAGS}` and related, but I cannot think of a good solution to include them all.

Flags are purposefully not set for the DPC++ compiler as it takes other kinds of flags from the usual compilers.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
