### PR TITLE
MAINT: Avoid redundant check of error codes

### DIFF
--- a/cpp/daal/src/externals/service_rng_mkl.h
+++ b/cpp/daal/src/externals/service_rng_mkl.h
@@ -75,11 +75,6 @@ int uniformRNG(const size_t cn, size_t * r, void * stream, const size_t a, const
         int * rr   = (int *)r;
         __DAAL_VSLFN_CALL_NR_WHILE(iRngUniform, ((const MKL_INT)method, stream, (const MKL_INT)nn, rr, na, nb), errcode);
 
-        if (errcode != 0)
-        {
-            return errcode;
-        }
-
         size_t shift = a - na;
         for (size_t i = 0; i < n; i++)
         {
@@ -97,11 +92,6 @@ int uniformRNG(const size_t cn, size_t * r, void * stream, const size_t a, const
             int nn     = (int)n;
             int * rr   = (int *)r + n;
             __DAAL_VSLFN_CALL_NR_WHILE(iRngUniform, ((const MKL_INT)method, stream, (const MKL_INT)nn, rr, na, nb), errcode);
-
-            if (errcode != 0)
-            {
-                return errcode;
-            }
 
             rr           = (int *)r + n;
             size_t shift = a - na;
@@ -127,11 +117,6 @@ int uniformRNG(const size_t cn, size_t * r, void * stream, const size_t a, const
                 int nn                = (int)n;
                 unsigned __int64 * rr = cr;
                 __DAAL_VSLFN_CALL_NR_WHILE(iRngUniformBits64, ((const MKL_INT)method, stream, (const MKL_INT)nn, (unsigned MKL_INT64 *)rr), errcode);
-
-                if (errcode != 0)
-                {
-                    return errcode;
-                }
             }
             else
             {
@@ -144,11 +129,6 @@ int uniformRNG(const size_t cn, size_t * r, void * stream, const size_t a, const
                     unsigned __int64 * rr = cr + pos;
                     __DAAL_VSLFN_CALL_NR_WHILE(iRngUniformBits64, ((const MKL_INT)method, stream, (const MKL_INT)nn, (unsigned MKL_INT64 *)rr),
                                                errcode);
-
-                    if (errcode != 0)
-                    {
-                        return errcode;
-                    }
 
                     for (size_t i = pos; i < cn; i++)
                     {


### PR DESCRIPTION
## Description

Functions call a macro that checks the error code and makes it return from the function if an error is detected. The error code is then checked again after invocation of the macro, but it cannot signal an error as otherwise a return would have been forced from the macro.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.
</details>
