### PR TITLE
FIX: Prevent infinite loop for empty trees

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/gbt/treeshap.cpp
+++ b/cpp/daal/src/algorithms/dtrees/gbt/treeshap.cpp
@@ -39,6 +39,8 @@ void extendPath(PathElement * uniquePath, size_t uniqueDepth, float zeroFraction
     uniquePath[uniqueDepth].oneFraction   = oneFraction;
     uniquePath[uniqueDepth].partialWeight = (uniqueDepth == 0 ? 1.0f : 0.0f);
 
+    if (!uniqueDepth) return;
+
     const float constant = 1.0f / static_cast<float>(uniqueDepth + 1);
     for (int i = uniqueDepth - 1; i >= 0; --i)
     {


### PR DESCRIPTION
## Description

Function uses an unsigned variable minus one to start an iteration. If the variable is zero, it will underflow and start from the maximum positive number instead of from -1 as would be desired.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
