### PR TITLE
Fix insufficient memory allocation in csr_table conversion

### DIFF
--- a/cpp/oneapi/dal/algo/basic_statistics/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/basic_statistics/test/batch.cpp
@@ -67,11 +67,14 @@ TEMPLATE_LIST_TEST_M(basic_statistics_batch_test,
                      "[basic_statistics][integration][batch]",
                      basic_statistics_sparse_types) {
     SKIP_IF(this->not_float64_friendly());
-    const auto data = GENERATE_COPY(te::csr_table_builder(5, 5),
-                                    te::csr_table_builder(7, 10),
-                                    te::csr_table_builder(100, 100),
-                                    te::csr_table_builder(1000, 1000),
-                                    te::csr_table_builder(15000, 1000));
+    const float nnz_fraction = 0.05;
+    this->data_indexing_ = GENERATE(sparse_indexing::zero_based, sparse_indexing::one_based);
+    const auto data =
+        GENERATE_COPY(te::csr_table_builder(5, 5, nnz_fraction, this->data_indexing_),
+                      te::csr_table_builder(7, 10, nnz_fraction, this->data_indexing_),
+                      te::csr_table_builder(100, 100, nnz_fraction, this->data_indexing_),
+                      te::csr_table_builder(1000, 1000, nnz_fraction, this->data_indexing_),
+                      te::csr_table_builder(15000, 1000, nnz_fraction, this->data_indexing_));
     SKIP_IF(this->not_cpu_friendly(data));
     const bs::result_option_id res_min_max = result_options::min | result_options::max;
     const bs::result_option_id res_mean_varc = result_options::mean | result_options::variance;

--- a/cpp/oneapi/dal/algo/basic_statistics/test/fixture.hpp
+++ b/cpp/oneapi/dal/algo/basic_statistics/test/fixture.hpp
@@ -41,6 +41,7 @@ constexpr inline std::uint64_t mask_full = 0xffffffffffffffff;
 template <typename TestType, typename Derived>
 class basic_statistics_test : public te::crtp_algo_fixture<TestType, Derived> {
 public:
+    sparse_indexing data_indexing_; // for sparse data testing
     using float_t = std::tuple_element_t<0, TestType>;
     using method_t = std::tuple_element_t<1, TestType>;
     using input_t = bs::compute_input<>;

--- a/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
@@ -103,6 +103,7 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
     // This test is not stable on CPU
     // TODO: Remove the following `SKIP_IF` once stability problem is resolved
     SKIP_IF(this->get_policy().is_cpu());
+    SKIP_IF(!this->get_policy().has_native_float64());
     SKIP_IF(this->is_sparse_method());
     SKIP_IF(this->not_float64_friendly());
     this->check_on_large_data_with_one_cluster();
@@ -304,6 +305,7 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
 
     SECTION("cluster=128") {
         SKIP_IF(this->get_policy().is_cpu());
+        SKIP_IF(!this->get_policy().has_native_float64());
         bool init_centroids = true;
         auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(128,
                                                                       100000,
@@ -335,6 +337,7 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
 
     SECTION("cluster=32") {
         SKIP_IF(this->get_policy().is_cpu());
+        SKIP_IF(!this->get_policy().has_native_float64());
         bool init_centroids = false;
         auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(32,
                                                                       10000,
@@ -352,8 +355,8 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
                      "[kmeans][batch]",
                      kmeans_types_csr) {
     SKIP_IF(this->get_policy().is_cpu());
+    SKIP_IF(!this->get_policy().has_native_float64());
     SKIP_IF(!this->is_sparse_method());
-    SKIP_IF(this->not_float64_friendly());
     using Float = std::tuple_element_t<0, TestType>;
 
     // Check that algorithm does not crash on big number of rows

--- a/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
@@ -103,7 +103,6 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
     // This test is not stable on CPU
     // TODO: Remove the following `SKIP_IF` once stability problem is resolved
     SKIP_IF(this->get_policy().is_cpu());
-    SKIP_IF(!this->get_policy().has_native_float64());
     SKIP_IF(this->is_sparse_method());
     SKIP_IF(this->not_float64_friendly());
     this->check_on_large_data_with_one_cluster();
@@ -305,7 +304,6 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
 
     SECTION("cluster=128") {
         SKIP_IF(this->get_policy().is_cpu());
-        SKIP_IF(!this->get_policy().has_native_float64());
         bool init_centroids = true;
         auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(128,
                                                                       100000,
@@ -337,7 +335,6 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
 
     SECTION("cluster=32") {
         SKIP_IF(this->get_policy().is_cpu());
-        SKIP_IF(!this->get_policy().has_native_float64());
         bool init_centroids = false;
         auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(32,
                                                                       10000,
@@ -355,8 +352,8 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
                      "[kmeans][batch]",
                      kmeans_types_csr) {
     SKIP_IF(this->get_policy().is_cpu());
-    SKIP_IF(!this->get_policy().has_native_float64());
     SKIP_IF(!this->is_sparse_method());
+    SKIP_IF(this->not_float64_friendly());
     using Float = std::tuple_element_t<0, TestType>;
 
     // Check that algorithm does not crash on big number of rows

--- a/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/test/batch.cpp
@@ -273,47 +273,74 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
 TEMPLATE_LIST_TEST_M(kmeans_batch_test,
                      "KMmeans sparse default cases",
                      "[kmeans][batch]",
-                     kmeans_types) {
+                     kmeans_types_csr) {
     SKIP_IF(!this->is_sparse_method());
     SKIP_IF(this->not_float64_friendly());
 
     using Float = std::tuple_element_t<0, TestType>;
 
+    const float nnz_fraction = 0.05;
+    this->data_indexing_ = GENERATE(sparse_indexing::zero_based, sparse_indexing::one_based);
+
     SECTION("cluster=5") {
-        auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(5, 50, 20);
+        auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(5,
+                                                                      50,
+                                                                      20,
+                                                                      nnz_fraction,
+                                                                      this->data_indexing_);
         bool init_centroids = true;
         this->test_on_sparse_data(input, 10, 0.01, init_centroids);
     }
 
     SECTION("cluster=16") {
         bool init_centroids = true;
-        auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(16, 200, 100);
+        auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(16,
+                                                                      200,
+                                                                      100,
+                                                                      nnz_fraction,
+                                                                      this->data_indexing_);
         this->test_on_sparse_data(input, 10, 0.01, init_centroids);
     }
 
     SECTION("cluster=128") {
         SKIP_IF(this->get_policy().is_cpu());
         bool init_centroids = true;
-        auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(128, 100000, 200);
+        auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(128,
+                                                                      100000,
+                                                                      200,
+                                                                      nnz_fraction,
+                                                                      this->data_indexing_);
         this->test_on_sparse_data(input, 10, 0.01, init_centroids);
     }
 
     SECTION("cluster=5") {
-        auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(5, 50, 20);
+        auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(5,
+                                                                      50,
+                                                                      20,
+                                                                      nnz_fraction,
+                                                                      this->data_indexing_);
         bool init_centroids = false;
         this->test_on_sparse_data(input, 20, 0.01, init_centroids);
     }
 
     SECTION("cluster=16") {
         bool init_centroids = false;
-        auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(16, 200, 100);
+        auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(16,
+                                                                      200,
+                                                                      100,
+                                                                      nnz_fraction,
+                                                                      this->data_indexing_);
         this->test_on_sparse_data(input, 10, 0.01, init_centroids);
     }
 
     SECTION("cluster=32") {
         SKIP_IF(this->get_policy().is_cpu());
         bool init_centroids = false;
-        auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(32, 10000, 100);
+        auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(32,
+                                                                      10000,
+                                                                      100,
+                                                                      nnz_fraction,
+                                                                      this->data_indexing_);
         this->test_on_sparse_data(input, 30, 0.01, init_centroids);
     }
 }
@@ -323,7 +350,7 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
 TEMPLATE_LIST_TEST_M(kmeans_batch_test,
                      "KMmeans sparse cases on large number of rows",
                      "[kmeans][batch]",
-                     kmeans_types) {
+                     kmeans_types_csr) {
     SKIP_IF(this->get_policy().is_cpu());
     SKIP_IF(!this->is_sparse_method());
     SKIP_IF(this->not_float64_friendly());
@@ -337,7 +364,12 @@ TEMPLATE_LIST_TEST_M(kmeans_batch_test,
     if (device_name.find("Data Center GPU Max") != std::string::npos) {
         rows_count = 100 * 1000 * 1000;
     }
-    auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(cluster_count, rows_count, 20);
+    this->data_indexing_ = GENERATE(sparse_indexing::zero_based, sparse_indexing::one_based);
+    auto input = oneapi::dal::test::engine::csr_make_blobs<Float>(cluster_count,
+                                                                  rows_count,
+                                                                  20,
+                                                                  0.05,
+                                                                  this->data_indexing_);
 
     auto desc = this->get_descriptor(cluster_count, 10, 0.01);
     const table initial_centroids = input.get_initial_centroids();

--- a/cpp/oneapi/dal/algo/kmeans/test/fixture.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/test/fixture.hpp
@@ -38,9 +38,12 @@ namespace la = dal::test::engine::linalg;
 using kmeans_types = COMBINE_TYPES((float, double),
                                    (kmeans::method::lloyd_dense, kmeans::method::lloyd_csr));
 
+using kmeans_types_csr = COMBINE_TYPES((float, double), (kmeans::method::lloyd_csr));
+
 template <typename TestType, typename Derived>
 class kmeans_test : public te::crtp_algo_fixture<TestType, Derived> {
 public:
+    sparse_indexing data_indexing_; // for sparse data testing
     using base_t = te::crtp_algo_fixture<TestType, Derived>;
     using float_t = std::tuple_element_t<0, TestType>;
     using method_t = std::tuple_element_t<1, TestType>;

--- a/cpp/oneapi/dal/table/backend/interop/host_csr_table_adapter.cpp
+++ b/cpp/oneapi/dal/table/backend/interop/host_csr_table_adapter.cpp
@@ -134,7 +134,7 @@ host_csr_table_adapter<Data>::host_csr_table_adapter(const csr_table& table, sta
         return;
     }
 
-    const std::int64_t column_count = table.get_column_count();
+    const std::int64_t column_indices_count = table.get_non_zero_count();
     const std::int64_t row_count = table.get_row_count();
     size_t* column_indices =
         const_cast<std::size_t*>(reinterpret_cast<const std::size_t*>(table.get_column_indices()));
@@ -144,11 +144,11 @@ host_csr_table_adapter<Data>::host_csr_table_adapter(const csr_table& table, sta
     // Convert zero-based indices to one-based if needed.
     // Because DAAL tables support only one-based indexing
     if (table.get_indexing() == sparse_indexing::zero_based) {
-        one_based_column_indices_.reset(column_count);
+        one_based_column_indices_.reset(column_indices_count);
         one_based_row_offsets_.reset(row_count + 1);
         size_t* one_based_column_indices_ptr = one_based_column_indices_.get_mutable_data();
         size_t* one_based_row_offsets_ptr = one_based_row_offsets_.get_mutable_data();
-        for (std::int64_t i = 0; i < column_count; i++) {
+        for (std::int64_t i = 0; i < column_indices_count; i++) {
             one_based_column_indices_ptr[i] = column_indices[i] + 1;
         }
         column_indices = one_based_column_indices_ptr;

--- a/cpp/oneapi/dal/test/engine/csr_table_builder.hpp
+++ b/cpp/oneapi/dal/test/engine/csr_table_builder.hpp
@@ -457,7 +457,7 @@ struct csr_make_blobs {
         for (std::int32_t i = 0; i < row_count_; ++i) {
             response_ptr[i] = i % cluster_count_;
         }
-        return homogen_table::wrap(response_ptr, row_count_, 1);
+        return homogen_table::wrap(responses, row_count_, 1);
     }
 };
 


### PR DESCRIPTION
## Description

Fix insufficient memory allocation in case 0-based oneDAL csr_table to 1-based DAAL CSRNumericTable conversion.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
        New test configurations are failing on GPU. Investigation is in progress.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

not applicable.

</details>
