### PR TITLE
FIX: Remove vectorization pragma where data dependencies would give incorrect results

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
@@ -155,7 +155,6 @@ void OrderedRespHelperBest<algorithmFPType, cpu>::calcImpurity(const IndexType *
     imp.mean = this->_aResponse[aIdx[0]].val;
     if (noWeights)
     {
-        PRAGMA_VECTOR_ALWAYS
         for (size_t i = 1; i < n; ++i)
         {
             const double delta = this->_aResponse[aIdx[i]].val - imp.mean; //x[i] - mean
@@ -168,7 +167,6 @@ void OrderedRespHelperBest<algorithmFPType, cpu>::calcImpurity(const IndexType *
     else
     {
         totalWeights = this->_aWeights[aIdx[0]].val;
-        PRAGMA_VECTOR_ALWAYS
         for (size_t i = 1; i < n; ++i)
         {
             const double weights = this->_aWeights[aIdx[i]].val;
@@ -1054,7 +1052,6 @@ bool OrderedRespHelperRandom<algorithmFPType, cpu>::findBestSplitOrderedFeature(
     right.mean = this->_aResponse[aIdx[r]].val;
     if (noWeights)
     {
-        PRAGMA_VECTOR_ALWAYS
         for (size_t i = 1; i < r; ++i)
         {
             const double delta = this->_aResponse[aIdx[i]].val - left.mean; //x[i] - mean
@@ -1063,7 +1060,6 @@ bool OrderedRespHelperRandom<algorithmFPType, cpu>::findBestSplitOrderedFeature(
             DAAL_ASSERT(left.var >= 0);
         }
 
-        PRAGMA_VECTOR_ALWAYS
         for (size_t i = r + 1; i < n; ++i)
         {
             const double delta = this->_aResponse[aIdx[i]].val - right.mean; //x[i] - mean
@@ -1076,7 +1072,6 @@ bool OrderedRespHelperRandom<algorithmFPType, cpu>::findBestSplitOrderedFeature(
     else
     {
         leftWeights = this->_aWeights[aIdx[0]].val;
-        PRAGMA_VECTOR_ALWAYS
         for (size_t i = 1; i < r; ++i)
         {
             const double weights = this->_aWeights[aIdx[i]].val;
@@ -1088,7 +1083,6 @@ bool OrderedRespHelperRandom<algorithmFPType, cpu>::findBestSplitOrderedFeature(
         }
 
         algorithmFPType rightWeights = this->_aWeights[aIdx[r]].val;
-        PRAGMA_VECTOR_ALWAYS
         for (size_t i = r + 1; i < n; ++i)
         {
             const double weights = this->_aWeights[aIdx[i]].val;


### PR DESCRIPTION
## Description

There is an algorithm for fast calculation of mean and centered sum of squares that uses a vectorization pragma for an operation that has direct loop dependencies.

Currently, when using ICX, this compiler pragma doesn't end up doing anything, but if it were to be updated to vectorize the operations, it would produce incorrect results due to data dependencies.

The correct way to vectorize those loops would be to keep a vector of means/sum-squares updated in a vectorized fashion and then merging them at the end for the final numbers. This PR in the meantime just removes the pragmas.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
