### PR TITLE
MAINT: Add missing declaration when building with debug macro

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
@@ -536,6 +536,10 @@ public:
         node.impurity = imp.var;
     }
 
+#ifdef DEBUG_CHECK_IMPURITY
+    void checkImpurityInternal(const IndexType * ptrIdx, size_t n, const ImpurityData & expected, bool bInternal) const;
+#endif
+
 private:
 #ifdef DEBUG_CHECK_IMPURITY
     algorithmFPType calcResponse(algorithmFPType & res, const IndexType * idx, size_t n) const;


### PR DESCRIPTION
## Description

The files for decision forests allow defining a debug macro `DEBUG_CHECK_IMPURITY`, but if adding such macro, it will fail to compile due to a missing method declaration in one of the classes. This PR adds the declaration so that it becomes possible to build with this debug macro.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
