### PR TITLE
Fix ONEDAL_ASSERT failure triggered by empty table serialization

### DIFF
--- a/cpp/daal/include/data_management/data/data_archive.h
+++ b/cpp/daal/include/data_management/data/data_archive.h
@@ -593,7 +593,10 @@ public:
     template <typename T>
     void set(T * ptr, size_t size)
     {
-        _arch->write((byte *)ptr, size * sizeof(T));
+        if (size)
+        {
+            _arch->write((byte *)ptr, size * sizeof(T));
+        }
     }
 
     /**
@@ -873,7 +876,10 @@ public:
     template <typename T>
     void set(T * ptr, size_t size) const
     {
-        _arch->read((byte *)ptr, size * sizeof(T));
+        if (size)
+        {
+            _arch->read((byte *)ptr, size * sizeof(T));
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

If RF Regressor model is serialized we cause serialization of empty table https://github.com/uxlfoundation/oneDAL/blob/8ef5a1fb16de947fa9ee80803f0daab28599835a/cpp/daal/src/algorithms/dtrees/dtrees_model_impl.h#L535 from here.

If asserts are enable this assert is failing https://github.com/uxlfoundation/oneDAL/blob/773af9612efe34b5eabf1b7492c44981fabc9c17/cpp/oneapi/dal/detail/serialization.hpp#L193

void oneapi::dal::detail::output_archive::range(const T *, const T *) [T = unsigned char]: Assertion `begin' failed.

To fix the issue we only need to write/read bytes if size is not zero

---
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
