### PR TITLE
Fix failures in kmeans::test_batch_dpc

### DIFF
--- a/cpp/oneapi/dal/backend/interop/table_conversion.hpp
+++ b/cpp/oneapi/dal/backend/interop/table_conversion.hpp
@@ -233,8 +233,14 @@ inline daal::data_management::CSRNumericTablePtr wrap_by_host_csr_adapter(const 
 template <typename Float>
 inline daal::data_management::CSRNumericTablePtr convert_to_daal_table(const csr_table& table,
                                                                        bool need_copy = false) {
+    if (need_copy)
+        // Always copy the table, and do not try to wrap it, if need_copy is specified by the caller.
+        // Because the table's data can be allocated on device and it will lead to crash in wrap_by_host_csr_adapter
+        return copy_to_daal_csr_table<Float>(table);
+
     auto wrapper = wrap_by_host_csr_adapter(table);
-    return need_copy || !wrapper ? copy_to_daal_csr_table<Float>(table) : wrapper;
+    // copy the table if wrap failed
+    return !wrapper ? copy_to_daal_csr_table<Float>(table) : wrapper;
 }
 
 template <typename Data>


### PR DESCRIPTION
## Description

Fix the logic in `convert_to_daal_table(const csr_table & table, bool need_copy)`:
Always do copy the table if `need_copy == true`. Because otherwise it can lead to crash on GPU.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
The failures are not related to the changes in this PR.

**Performance**

not applicable.

</details>
