### PR TITLE
Add kernel profiling macros into Decision Forest classification training

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
@@ -566,6 +566,7 @@ public:
                              const algorithmFPType accuracy, const ImpurityData & curImpurity, TSplitData & split,
                              const algorithmFPType minWeightLeaf, const algorithmFPType totalWeights) const
     {
+        DAAL_PROFILER_THREADING_TASK(DFClassifierTrain::RespHelperBase.findSplitForFeature);
         const bool noWeights = !this->_weights;
         if (noWeights)
         {
@@ -885,6 +886,7 @@ int RespHelperBase<algorithmFPType, cpu, crtp>::findSplitForFeatureSorted(algori
                                                                           TSplitData & split, const algorithmFPType minWeightLeaf,
                                                                           const algorithmFPType totalWeights, const BinIndexType * binIndex) const
 {
+    DAAL_PROFILER_THREADING_TASK(DFClassifierTrain::RespHelperBase.findSplitForFeatureSorted);
     const auto nDiffFeatMax = this->indexedFeatures().numIndices(iFeature);
     this->_samplesPerClassBuf.setValues(nClasses() * nDiffFeatMax, 0);
 
@@ -1049,6 +1051,7 @@ int UnorderedRespHelperRandom<algorithmFPType, cpu>::findSplitByHistDefault(int 
                                                                             const algorithmFPType minWeightLeaf, const algorithmFPType totalWeights,
                                                                             const IndexType iFeature) const
 {
+    DAAL_PROFILER_THREADING_TASK(UnorderedRespHelperRandom::findSplitByHistDefault);
     auto nFeatIdx         = this->_idxFeatureBuf.get();
     auto featWeights      = this->_weightsFeatureBuf.get();
     auto nSamplesPerClass = this->_samplesPerClassBuf.get();
@@ -1156,6 +1159,7 @@ int UnorderedRespHelperRandom<algorithmFPType, cpu>::findSplitFewClasses(int nDi
                                                                          const algorithmFPType minWeightLeaf, const algorithmFPType totalWeights,
                                                                          const IndexType iFeature) const
 {
+    DAAL_PROFILER_THREADING_TASK(UnorderedRespHelperRandom::findSplitFewClasses);
     auto nSamplesPerClass = this->_samplesPerClassBuf.get();
     auto nFeatIdx         = this->_idxFeatureBuf.get();
 

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -33,6 +33,7 @@
 #include "src/services/service_defines.h"
 #include "src/algorithms/distributions/uniform/uniform_kernel.h"
 #include "src/algorithms/dtrees/forest/df_hyperparameter_impl.h"
+#include "src/services/service_profiler.h"
 
 using namespace daal::algorithms::dtrees::training::internal;
 using namespace daal::algorithms::internal;
@@ -351,6 +352,7 @@ template <CpuType cpu, typename IndexType, typename BinIndexType>
 services::Status copyBinIndex(const size_t nRows, const size_t nCols, const IndexType * featureIndex,
                               TVector<BinIndexType, cpu, ScalableAllocator<cpu> > & binIndexVector, BinIndexType ** binIndex)
 {
+    DAAL_PROFILER_TASK(DFClassifierTrain::copyBinIndex);
     DAAL_OVERFLOW_CHECK_BY_MULTIPLICATION(size_t, nRows, nCols);
     binIndexVector.resize(nRows * nCols);
     DAAL_CHECK(binIndexVector.get(), ErrorMemoryAllocationFailed);
@@ -702,6 +704,7 @@ template <typename algorithmFPType, typename BinIndexType, typename DataHelper, 
 services::Status TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::run(
     engines::internal::BatchBaseImpl * engineImpl, dtrees::internal::Tree *& pTree, size_t & numElems)
 {
+    DAAL_PROFILER_THREADING_TASK(DFClassifierTrain::TrainBatchTaskBase.run);
     const size_t maxFeatures = nFeatures();
     _nConstFeature           = 0;
     _numElems                = &numElems;
@@ -817,6 +820,7 @@ template <typename algorithmFPType, typename BinIndexType, typename DataHelper, 
 typename DataHelper::NodeType::Leaf * TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::makeLeaf(
     const IndexType * idx, size_t n, typename DataHelper::ImpurityData & imp, size_t nClasses)
 {
+    DAAL_PROFILER_THREADING_TASK(DFClassifierTrain::TrainBatchTaskBase.makeLeaf);
     typename DataHelper::NodeType::Leaf * pNode = _tree.allocator().allocLeaf(_nClasses);
     _helper.setLeafData(*pNode, idx, n, imp);
     return pNode;
@@ -827,6 +831,7 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
     services::Status & s, size_t iStart, size_t n, size_t level, typename DataHelper::ImpurityData & curImpurity, bool & bUnorderedFeaturesUsed,
     size_t nClasses, algorithmFPType totalWeights)
 {
+    DAAL_PROFILER_THREADING_TASK(DFClassifierTrain::TrainBatchTaskBase.buildDepthFirst);
     const size_t maxFeatures = nFeatures();
     if (_hostApp.isCancelled(s, n)) return nullptr;
 
@@ -910,6 +915,7 @@ template <typename WorkItem>
 typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::buildNode(
     const size_t level, const size_t nClasses, size_t & remainingSplitNodes, WorkItem & item, typename DataHelper::ImpurityData & impurity)
 {
+    DAAL_PROFILER_THREADING_TASK(DFClassifierTrain::buildNode);
     typename DataHelper::TSplitData split;
     IndexType iFeature;
 
@@ -966,6 +972,7 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
     services::Status & s, size_t iStart, size_t n, size_t level, typename DataHelper::ImpurityData & curImpurity, bool & bUnorderedFeaturesUsed,
     size_t nClasses, algorithmFPType totalWeights)
 {
+    DAAL_PROFILER_THREADING_TASK(DFClassifierTrain::buildBestFirst);
     struct WorkItem
     {
         bool isLeaf;
@@ -1095,6 +1102,7 @@ template <typename algorithmFPType, typename BinIndexType, typename DataHelper, 
 NodeSplitResult TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::simpleSplit(
     size_t iStart, const typename DataHelper::ImpurityData & curImpurity, IndexType & iFeatureBest, typename DataHelper::TSplitData & split)
 {
+    DAAL_PROFILER_THREADING_TASK(DFClassifierTrain::TrainBatchTaskBase.simpleSplit);
     services::Status st;
     RNGsInst<IndexType, cpu> rng;
     algorithmFPType featBuf[2];
@@ -1144,6 +1152,7 @@ NodeSplitResult TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, Hy
     size_t level, size_t iStart, size_t n, const typename DataHelper::ImpurityData & curImpurity, IndexType & iBestFeature,
     typename DataHelper::TSplitData & bestSplit, algorithmFPType totalWeights)
 {
+    DAAL_PROFILER_THREADING_TASK(DFClassifierTrain::TrainBatchTaskBase.findBestSplitSerial);
     services::Status st;
 
     /* counter of the number of visited features, we visit _nFeaturesPerNode


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
