### PR TITLE
FIX: Fix divisions by zero when there are weights of zero in forests

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
@@ -197,7 +197,7 @@ int UnorderedRespHelperBest<algorithmFPType, cpu>::findSplitByHistDefault(int nD
             PRAGMA_VECTOR_ALWAYS
             for (size_t iClass = 0; iClass < _nClasses; ++iClass) histLeft[iClass] += nSamplesPerClass[i * _nClasses + iClass];
         }
-        if ((nLeft < nMinSplitPart) || leftWeights < minWeightLeaf) continue;
+        if ((nLeft < nMinSplitPart) || leftWeights < minWeightLeaf || !leftWeights) continue;
 
         if (split.featureUnordered)
         {
@@ -299,7 +299,7 @@ int UnorderedRespHelperBest<algorithmFPType, cpu>::findSplitFewClasses(int nDiff
         {
             for (size_t iClass = 0; iClass < K; ++iClass) histLeft[iClass] += nSamplesPerClass[i * K + iClass];
         }
-        if ((nLeft < nMinSplitPart) || leftWeights < minWeightLeaf) continue;
+        if ((nLeft < nMinSplitPart) || leftWeights < minWeightLeaf || !leftWeights) continue;
 
         if (split.featureUnordered)
         {
@@ -483,7 +483,7 @@ bool UnorderedRespHelperBest<algorithmFPType, cpu>::findSplitCategoricalFeature(
             _impLeft.hist[xi] += weights;
         }
         if ((count < nMinSplitPart) || ((n - count) < nMinSplitPart) || (leftWeights < minWeightLeaf)
-            || ((totalWeights - leftWeights) < minWeightLeaf))
+            || ((totalWeights - leftWeights) < minWeightLeaf) || !leftWeights)
             continue;
         PRAGMA_FORCE_SIMD
         PRAGMA_VECTOR_ALWAYS
@@ -1114,8 +1114,8 @@ int UnorderedRespHelperRandom<algorithmFPType, cpu>::findSplitByHistDefault(int 
         }
     }
 
-    if (!(((n - nLeft) < nMinSplitPart) || ((totalWeights - leftWeights) < minWeightLeaf) || (nLeft < nMinSplitPart)
-          || (leftWeights < minWeightLeaf)))
+    if (!(((n - nLeft) < nMinSplitPart) || ((totalWeights - leftWeights) < minWeightLeaf) || (nLeft < nMinSplitPart) || (leftWeights < minWeightLeaf))
+        && leftWeights)
     {
         auto histTotal           = curImpurity.hist.get();
         algorithmFPType sumLeft  = 0;
@@ -1327,8 +1327,8 @@ int UnorderedRespHelperRandom<algorithmFPType, cpu>::findSplitFewClasses(int nDi
         for (size_t iClass = 0; iClass < K; ++iClass) leftWeights += histLeft[iClass];
     }
 
-    if (!(((n - nLeft) < nMinSplitPart) || ((totalWeights - leftWeights) < minWeightLeaf) || (nLeft < nMinSplitPart)
-          || (leftWeights < minWeightLeaf)))
+    if (!(((n - nLeft) < nMinSplitPart) || ((totalWeights - leftWeights) < minWeightLeaf) || (nLeft < nMinSplitPart) || (leftWeights < minWeightLeaf))
+        && leftWeights)
     {
         auto histTotal           = curImpurity.hist.get();
         algorithmFPType sumLeft  = 0;
@@ -1446,7 +1446,8 @@ bool UnorderedRespHelperRandom<algorithmFPType, cpu>::findSplitOrderedFeature(co
     checkImpurity(aIdx + i - 1, totalWeights - leftWeights, this->_impRight);
 #endif
 
-    if ((leftWeights >= minWeightLeaf) && ((totalWeights - leftWeights) >= minWeightLeaf)) //it is a valid split with enought leaf weights
+    if ((leftWeights >= minWeightLeaf) && ((totalWeights - leftWeights) >= minWeightLeaf)
+        && leftWeights) //it is a valid split with enought leaf weights
     {
         //check if bFound condition below
         if (!isPositive<algorithmFPType, cpu>(this->_impLeft.var)) this->_impLeft.var = 0;   //set left impurity to 0 if negative
@@ -1548,7 +1549,7 @@ bool UnorderedRespHelperRandom<algorithmFPType, cpu>::findSplitCategoricalFeatur
             this->_impLeft.hist[xi] += weights;
         }
         if ((count < nMinSplitPart) || ((n - count) < nMinSplitPart) || (leftWeights < minWeightLeaf)
-            || ((totalWeights - leftWeights) < minWeightLeaf))
+            || ((totalWeights - leftWeights) < minWeightLeaf) || !leftWeights)
             continue;
         PRAGMA_FORCE_SIMD
         PRAGMA_VECTOR_ALWAYS

--- a/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
@@ -158,10 +158,11 @@ template <typename algorithmFPType, CpuType cpu>
 template <bool noWeights>
 void OrderedRespHelperBest<algorithmFPType, cpu>::calcImpurity(const IndexType * aIdx, size_t n, ImpurityData & imp, double & totalWeights) const
 {
-    imp.var  = 0;
-    imp.mean = this->_aResponse[aIdx[0]].val;
     if (noWeights)
     {
+        imp.var  = 0;
+        imp.mean = this->_aResponse[aIdx[0]].val;
+
         PRAGMA_VECTOR_ALWAYS
         for (size_t i = 1; i < n; ++i)
         {
@@ -174,18 +175,28 @@ void OrderedRespHelperBest<algorithmFPType, cpu>::calcImpurity(const IndexType *
     }
     else
     {
-        totalWeights = this->_aWeights[aIdx[0]].val;
-        PRAGMA_VECTOR_ALWAYS
-        for (size_t i = 1; i < n; ++i)
+        imp.mean     = 0;
+        imp.var      = 0;
+        totalWeights = 0;
+
+        // Note: weights can be exactly zero, in which case they'd break the division.
+        // Since zero-weight observations have no impact on the results, this tries to
+        // look for the first non-zero weight.
+        size_t i_start;
+        for (i_start = 0; i_start < n; i_start++)
+        {
+            if (this->_aWeights[aIdx[i_start]].val) break;
+        }
+
+        for (size_t i = i_start; i < n; ++i)
         {
             const double weights = this->_aWeights[aIdx[i]].val;
             const double delta   = this->_aResponse[aIdx[i]].val - imp.mean; //x[i] - mean
             totalWeights += weights;
-            DAAL_ASSERT(!(isZero<double, cpu>(totalWeights)));
-            imp.mean += weights * delta / totalWeights;
+            imp.mean += delta * (weights / totalWeights);
             imp.var += weights * delta * (this->_aResponse[aIdx[i]].val - imp.mean);
         }
-        imp.var /= totalWeights; //impurity is MSE
+        if (totalWeights) imp.var /= totalWeights; //impurity is MSE
     }
 
 // Note: the debug checks throughout this file are always done in float64 precision regardless
@@ -234,7 +245,7 @@ int OrderedRespHelperBest<algorithmFPType, cpu>::findBestSplitByHist(size_t nDif
             || ((n - nLeft) < nMinSplitPart) || ((totalWeights - leftWeights) < minWeightLeaf))
             break;
         sumLeft = (featureUnordered ? buf[i] : sumLeft + buf[i]);
-        if ((nLeft < nMinSplitPart) || (leftWeights < minWeightLeaf)) continue;
+        if ((nLeft < nMinSplitPart) || (leftWeights < minWeightLeaf) || !leftWeights) continue;
         intermSummFPType sumRight = sumTotal - sumLeft;
         //the part of the impurity decrease dependent on split itself
         const intermSummFPType impDecreasePart = sumLeft * sumLeft / leftWeights + sumRight * sumRight / (totalWeights - leftWeights);
@@ -323,7 +334,8 @@ bool OrderedRespHelperBest<algorithmFPType, cpu>::findBestSplitOrderedFeature(co
             weights = aWeights[aIdx[i]].val;
             const bool bSameFeaturePrev(featureVal[i] <= featureVal[i - 1] + accuracy);
 
-            if (!(bSameFeaturePrev || (i < nMinSplitPart) || (leftWeights < minWeightLeaf) || ((totalWeights - leftWeights) < minWeightLeaf)))
+            if (!(bSameFeaturePrev || (i < nMinSplitPart) || (leftWeights < minWeightLeaf) || ((totalWeights - leftWeights) < minWeightLeaf))
+                && leftWeights)
             {
                 //can make a split
                 //nLeft == i, nRight == n - i
@@ -393,7 +405,7 @@ bool OrderedRespHelperBest<algorithmFPType, cpu>::findBestSplitCategoricalFeatur
             leftWeights += aWeights[aIdx[i]].val;
         }
         if ((count < nMinSplitPart) || ((n - count) < nMinSplitPart) || (leftWeights < minWeightLeaf)
-            || ((totalWeights - leftWeights) < minWeightLeaf))
+            || ((totalWeights - leftWeights) < minWeightLeaf) || !leftWeights)
             continue;
 
         if ((i == n) && (nDiffFeatureValues == 2) && bFound) break; //only 2 feature values, one possible split, already found
@@ -993,7 +1005,9 @@ int OrderedRespHelperRandom<algorithmFPType, cpu>::findBestSplitByHist(size_t nD
     {
         intermSummFPType sumRight = sumTotal - sumLeft;
         //the part of the impurity decrease dependent on split itself
-        const intermSummFPType impDecreasePart = sumLeft * sumLeft / leftWeights + sumRight * sumRight / (totalWeights - leftWeights);
+        const intermSummFPType rightWeights = totalWeights - leftWeights;
+        const intermSummFPType impDecreasePart =
+            (leftWeights ? (sumLeft * sumLeft / leftWeights) : 0) + (rightWeights ? (sumRight * sumRight / rightWeights) : 0);
 
         if (impDecreasePart > bestImpDecreasePart)
         {
@@ -1026,9 +1040,10 @@ bool OrderedRespHelperRandom<algorithmFPType, cpu>::findBestSplitOrderedFeature(
     ImpurityData right;
     IndexType iBest = -1;
     algorithmFPType vBest;
-    algorithmFPType leftWeights = 0.;
-    auto aResponse              = this->_aResponse.get();
-    auto aWeights               = this->_aWeights.get();
+    double leftWeights  = 0.;
+    double rightWeights = 0.;
+    auto aResponse      = this->_aResponse.get();
+    auto aWeights       = this->_aWeights.get();
     algorithmFPType idx;
     vBest = split.impurityDecrease < 0 ? daal::services::internal::MaxVal<algorithmFPType>::get() :
                                          (curImpurity.var - split.impurityDecrease) * totalWeights;
@@ -1063,59 +1078,10 @@ bool OrderedRespHelperRandom<algorithmFPType, cpu>::findBestSplitOrderedFeature(
         }
     }
 
-    left.var   = 0;
-    left.mean  = this->_aResponse[aIdx[0]].val;
-    right.var  = 0;
-    right.mean = this->_aResponse[aIdx[r]].val;
-    if (noWeights)
-    {
-        PRAGMA_VECTOR_ALWAYS
-        for (size_t i = 1; i < r; ++i)
-        {
-            const double delta = this->_aResponse[aIdx[i]].val - left.mean; //x[i] - mean
-            left.mean += delta / double(i + 1);
-            left.var += delta * (this->_aResponse[aIdx[i]].val - left.mean);
-            DAAL_ASSERT(left.var >= 0);
-        }
+    this->template calcImpurity<noWeights>(aIdx, r, left, leftWeights);
+    this->template calcImpurity<noWeights>(aIdx + r, n - r, right, rightWeights);
 
-        PRAGMA_VECTOR_ALWAYS
-        for (size_t i = r + 1; i < n; ++i)
-        {
-            const double delta = this->_aResponse[aIdx[i]].val - right.mean; //x[i] - mean
-            right.mean += delta / double(i + 1 - r);
-            right.var += delta * (this->_aResponse[aIdx[i]].val - right.mean);
-        }
-
-        leftWeights = r;
-    }
-    else
-    {
-        leftWeights = this->_aWeights[aIdx[0]].val;
-        PRAGMA_VECTOR_ALWAYS
-        for (size_t i = 1; i < r; ++i)
-        {
-            const double weights = this->_aWeights[aIdx[i]].val;
-            const double delta   = this->_aResponse[aIdx[i]].val - left.mean; //x[i] - mean
-            leftWeights += weights;
-            DAAL_ASSERT(!(isZero<double, cpu>(leftWeights)));
-            left.mean += weights * delta / leftWeights;
-            left.var += weights * delta * (this->_aResponse[aIdx[i]].val - left.mean);
-        }
-
-        algorithmFPType rightWeights = this->_aWeights[aIdx[r]].val;
-        PRAGMA_VECTOR_ALWAYS
-        for (size_t i = r + 1; i < n; ++i)
-        {
-            const double weights = this->_aWeights[aIdx[i]].val;
-            const double delta   = this->_aResponse[aIdx[i]].val - right.mean; //x[i] - mean
-            rightWeights += weights;
-            DAAL_ASSERT(!(isZero<double, cpu>(rightWeights)));
-            right.mean += weights * delta / rightWeights;
-            right.var += weights * delta * (this->_aResponse[aIdx[i]].val - right.mean);
-        }
-    }
-
-    if (!((leftWeights < minWeightLeaf) || ((totalWeights - leftWeights) < minWeightLeaf)))
+    if (!((leftWeights < minWeightLeaf) || ((totalWeights - leftWeights) < minWeightLeaf)) && leftWeights)
     {
         const algorithmFPType v = left.var + right.var;
         if (v < vBest)
@@ -1194,7 +1160,7 @@ bool OrderedRespHelperRandom<algorithmFPType, cpu>::findBestSplitCategoricalFeat
             leftWeights += aWeights[aIdx[i]].val;
         }
         if ((count < nMinSplitPart) || ((n - count) < nMinSplitPart) || (leftWeights < minWeightLeaf)
-            || ((totalWeights - leftWeights) < minWeightLeaf))
+            || ((totalWeights - leftWeights) < minWeightLeaf) || !leftWeights)
             continue;
 
         //if ((i == n) && (nDiffFeatureValues == 2) && bFound) break; //only 2 feature values, one possible split, already found


### PR DESCRIPTION
## Description

This PR fixes an issue in decision forests in which observations with weight of zero can potentially generate NaNs in end results due to divisions by zero.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
