### PR TITLE
Bazel: align compiler and Windows toolchain behavior with Make

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -149,7 +149,13 @@ jobs:
         run: .\.ci\env\bazelisk.ps1
       - name: Bazel release
         shell: cmd
+        env:
+          BAZEL_SH: 'C:\Program Files\Git\bin\bash.exe'
         run: |
+          if not exist "%BAZEL_SH%" (
+            echo ERROR: Required Bazel shell not found: %BAZEL_SH%
+            exit /b 1
+          )
           set PATH=C:\msys64\usr\bin;%PATH%
           call .\oneapi\setvars.bat
           call "%ONEAPI_ROOT%\setvars-vcvarsall.bat" %VS_VER%

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -59,8 +59,8 @@ validation.
    bazelisk.exe version
    ```
 
-3. For `bazel test` on Windows, set `BAZEL_SH` to a Bash executable. Git for
-   Windows is sufficient.
+3. Before running Bazel build, test, or analysis commands on Windows, set
+   `BAZEL_SH` to a Bash executable. Git for Windows is sufficient.
    ```bat
    set BAZEL_SH=C:\Program Files\Git\bin\bash.exe
    ```

--- a/dev/bazel/cc/compile.bzl
+++ b/dev/bazel/cc/compile.bzl
@@ -39,6 +39,23 @@ _CPU_SUFFIX_TO_ISA_BACK_MAP = {
 _CPU_SUFFIXES = _CPU_SUFFIX_TO_ISA_MAP.keys()
 _CPU_ISA_IDS = _CPU_SUFFIX_TO_ISA_MAP.values()
 
+_MSVC_CPU_FLAGS = {
+    "sse2": [],
+    "avx2": ["/arch:AVX2"],
+    # Match dev/make/compiler_definitions/vc.mkl.32e.mk: MSVC's skx
+    # objects use the AVX2 code-generation target.
+    "avx512": ["/arch:AVX2"],
+}
+
+def _get_cpu_compile_kwargs(toolchain, cpu, kwargs):
+    if toolchain.compiler != "msvc-cl":
+        return kwargs
+    cpu_kwargs = dict(kwargs)
+    cpu_kwargs["user_compile_flags"] = (
+        kwargs.get("user_compile_flags", []) + _MSVC_CPU_FLAGS[cpu]
+    )
+    return cpu_kwargs
+
 def _categorize_sources(source_files, cpu_files_supported = True,
                                       fpt_files_supported = True):
     fpt_cpu_files_supported = cpu_files_supported and fpt_files_supported
@@ -217,7 +234,7 @@ def _compile(name, ctx, toolchain, feature_config, compilation_contexts=[],
                         sources_by_category.cpu_files),
                 local_defines = local_defines + cpu_defines[cpu],
                 compilation_contexts = dep_compilation_contexts,
-                **kwargs,
+                **_get_cpu_compile_kwargs(toolchain, cpu, kwargs),
             )
             compilation_contexts.append(compilation_context)
             compilation_outputs.append(compulation_output)
@@ -231,7 +248,7 @@ def _compile(name, ctx, toolchain, feature_config, compilation_contexts=[],
                     srcs = sources_by_category.fpt_cpu_files,
                     local_defines = local_defines + cpu_defines[cpu] + fpt_defines[fpt],
                     compilation_contexts = dep_compilation_contexts,
-                    **kwargs,
+                    **_get_cpu_compile_kwargs(toolchain, cpu, kwargs),
                 )
                 compilation_contexts.append(compilation_context)
                 compilation_outputs.append(compulation_output)

--- a/dev/bazel/config/config.bzl
+++ b/dev/bazel/config/config.bzl
@@ -200,12 +200,12 @@ def _detect_cpu_extension(repo_ctx):
     repo_ctx.report_progress("Compile cpu-detector")
     if is_windows:
         compile_command = [
-            "cl", "/nologo", "/EHsc", "/std:c++14",
+            "cl", "/nologo", "/EHsc", "/std:c++17",
             cpudetect_src, "/Fe:{}".format(cpudetect_exe),
         ]
     else:
         compile_command = [
-            "g++", "-pedantic", "-Wall", "-std=c++11",
+            "g++", "-pedantic", "-Wall", "-std=c++17",
             cpudetect_src, "-o{}".format(cpudetect_exe),
         ]
     compile_result = repo_ctx.execute(compile_command)

--- a/dev/bazel/config/config.bzl
+++ b/dev/bazel/config/config.bzl
@@ -195,12 +195,20 @@ dump_config_info = rule(
 
 def _detect_cpu_extension(repo_ctx):
     cpudetect_src = repo_ctx.path(repo_ctx.attr._cpudetect_src)
-    cpudetect_exe = repo_ctx.path("cpudetect")
+    is_windows = "windows" in repo_ctx.os.name
+    cpudetect_exe = repo_ctx.path("cpudetect.exe" if is_windows else "cpudetect")
     repo_ctx.report_progress("Compile cpu-detector")
-    compile_result = repo_ctx.execute([
-        "g++", "-pedantic", "-Wall", "-std=c++11",
-        cpudetect_src, "-o{}".format(cpudetect_exe),
-    ])
+    if is_windows:
+        compile_command = [
+            "cl", "/nologo", "/EHsc", "/std:c++14",
+            cpudetect_src, "/Fe:{}".format(cpudetect_exe),
+        ]
+    else:
+        compile_command = [
+            "g++", "-pedantic", "-Wall", "-std=c++11",
+            cpudetect_src, "-o{}".format(cpudetect_exe),
+        ]
+    compile_result = repo_ctx.execute(compile_command)
     if compile_result.return_code != 0:
         utils.warn("Cannot compile cpu-detector:\n" +
                    compile_result.stderr + "\n" +

--- a/dev/bazel/flags.bzl
+++ b/dev/bazel/flags.bzl
@@ -123,6 +123,10 @@ def get_cpu_flags(arch_id, os_id, compiler_id):
         sse2 = ["-march=nocona"]
         avx2 = ["-march=haswell"]
         avx512 = ["-march=skylake-avx512"]
+    elif compiler_id == "clang":
+        sse2 = ["-march=nocona"]
+        avx2 = ["-march=haswell"]
+        avx512 = ["-march=skylake-avx512"]
     elif compiler_id in ["icx", "icpx"]:
         # icx on Windows accepts -march like its Linux counterpart.
         sse2 = ["-march=nocona"]

--- a/dev/bazel/flags.bzl
+++ b/dev/bazel/flags.bzl
@@ -46,7 +46,6 @@ lnx_cc_flags = {
 # use MSVC-style spellings. Mirrors dev/make/compiler_definitions/{icx,dpcpp}.mkl.32e.mk
 # (COMPILER.win.icx / COMPILER.win.dpcpp).
 win_icx_common_flags = [
-    "-MD",
     "-nologo",
     "-WX",
     "-Qopenmp-simd",

--- a/dev/bazel/flags.bzl
+++ b/dev/bazel/flags.bzl
@@ -122,7 +122,7 @@ def get_cpu_flags(arch_id, os_id, compiler_id):
     if compiler_id == "gcc":
         sse2 = ["-march=nocona"]
         avx2 = ["-march=haswell"]
-        avx512 = ["-march=haswell"]
+        avx512 = ["-march=skylake-avx512"]
     elif compiler_id in ["icx", "icpx"]:
         # icx on Windows accepts -march like its Linux counterpart.
         sse2 = ["-march=nocona"]

--- a/dev/bazel/toolchains/cc_toolchain_config_win.bzl
+++ b/dev/bazel/toolchains/cc_toolchain_config_win.bzl
@@ -195,6 +195,22 @@ def _impl(ctx):
     pedantic_feature = feature(name = "pedantic")
     dbg_feature = feature(name = "dbg")
     opt_feature = feature(name = "opt")
+    runtime_library_feature = feature(
+        name = "runtime_library",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [flag_group(flags = ["-MDd"])],
+                with_features = [with_feature_set(features = ["dbg"])],
+            ),
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [flag_group(flags = ["-MD"])],
+                with_features = [with_feature_set(not_features = ["dbg"])],
+            ),
+        ],
+    )
     # Windows PE/COFF objects have no PIC/non-PIC distinction, so we do not
     # register a `supports_pic` feature. Matches rules_cc's MSVC auto-config
     # and keeps `cc_common.compile` from emitting both variants (which the
@@ -712,6 +728,7 @@ def _impl(ctx):
         pedantic_feature,
         dbg_feature,
         opt_feature,
+        runtime_library_feature,
         supports_dynamic_linker_feature,
         do_not_link_dynamic_dependencies_feature,
         default_compile_flags_feature,

--- a/dev/bazel/toolchains/cc_toolchain_lnx.bzl
+++ b/dev/bazel/toolchains/cc_toolchain_lnx.bzl
@@ -90,9 +90,12 @@ def _find_tools(repo_ctx, reqs):
     cc_link_path = _create_dynamic_link_wrapper(repo_ctx, "cc", cc_path)
     dpcc_link_path = _create_dynamic_link_wrapper(repo_ctx, "dpc", dpcc_path)
     if dpcpp_found:
-        #The llvm-ar tool is used because bazel prepended directory names with +
-        #which caused issues with the default gnu ar tool on REHL. Since icx is clang based we can use the llvm-ar tool.
-        ar_path = cc_path[:-3] + "compiler/llvm-ar"
+        # The llvm-ar tool is used because Bazel prepends directory names with +,
+        # which caused issues with GNU ar on RHEL. Derive it from the DPC++
+        # compiler, not from the unrelated host C/C++ compiler.
+        ar_path = paths.join(paths.dirname(dpcc_path), "compiler", "llvm-ar")
+        if not repo_ctx.path(ar_path).exists:
+            auto_configure_fail("Cannot find DPC++ archiver at {}".format(ar_path))
 
     ar_merge_path = _create_ar_merge_tool(repo_ctx, ar_path)
 

--- a/dev/make/compiler_definitions/gnu.32e.mk
+++ b/dev/make/compiler_definitions/gnu.32e.mk
@@ -61,4 +61,4 @@ link.dynamic.mac.gnu = $(link.dynamic.all.gnu)
 p4_OPT.gnu   = $(-Q)march=nocona
 mc3_OPT.gnu  = $(-Q)march=corei7
 avx2_OPT.gnu = $(-Q)march=haswell
-skx_OPT.gnu  = $(-Q)march=skylake
+skx_OPT.gnu  = $(-Q)march=skylake-avx512


### PR DESCRIPTION
## Description

This PR closes seven reproducible compiler/toolchain parity gaps found while auditing the Bazel path against the existing Make behavior for issue #3530.

The changes are intentionally kept as seven focused commits. Together they align x86-64 ISA selection across GCC, Clang, ICX, and the MSVC fallback; fix Windows CPU detection and CRT selection; derive the DPC++ archiver from the selected compiler; and make the Windows nightly `BAZEL_SH` requirement explicit and fail-fast.

This is progress toward #3530, but it does **not** claim that every Make-only platform or feature is ready for deprecation.

## What changed

### ISA parity

- Use `-march=skylake-avx512` for GCC SKX objects in both Make and Bazel.
- Define the missing Clang CPU matrix:
  - SSE2: `-march=nocona`
  - AVX2: `-march=haswell`
  - AVX-512: `-march=skylake-avx512`
- Propagate ISA flags to materialized MSVC fallback actions while retaining Make parity:
  - SSE2: no `/arch` option
  - AVX2: `/arch:AVX2`
  - SKX/AVX-512 dispatch objects: `/arch:AVX2`

### Toolchain/runtime behavior

- Derive `llvm-ar` from the selected DPC++ compiler path instead of slicing the unrelated host compiler path; fail configuration when the companion archiver is absent.
- Build the Windows CPU detector with MSVC and use the `.exe` output name expected by Windows.
- Select the Windows CRT through a toolchain feature:
  - optimized/non-debug actions: `/MD`
  - debug actions: `/MDd`
- Remove the former unconditional `-MD` from the shared Windows ICX flags.

### Windows nightly reproducibility

- Set step-scoped `BAZEL_SH` to Git for Windows Bash.
- Fail before Bazel with a clear diagnostic if that executable is missing.
- Document that Windows Bazel build, test, and analysis commands require `BAZEL_SH`.

## Commit structure

1. `build: enable AVX-512 for GCC skx targets`
2. `bazel: define Clang CPU ISA flags`
3. `bazel: derive DPC++ archiver from compiler path`
4. `bazel: compile CPU detector with MSVC on Windows`
5. `bazel: select Windows CRT by build mode`
6. `bazel: add MSVC CPU ISA flags`
7. `ci: require Bazel shell on Windows nightly`

The CRT removal/addition is atomic in commit 5; the workflow and documentation change are paired in commit 7.

## Validation

### Linux — exact clean PR head

Validated on clean head `f7ab546fb85dd1c41098f4132c01060ecd7fbced` with Bazel 9.2.0.

- GCC 15.2, Clang 21.1.8, and ICX 2026.0 ISA action matrices passed.
- SSE2/AVX2/AVX-512 actions materialized the expected compiler options.
- GCC, ICX, and ICPX archive actions selected:
  - `/opt/intel/oneapi/compiler/2026.0/bin/compiler/llvm-ar`
- Full host release:

```bash
PATH=/opt/intel/oneapi/compiler/2026.0/bin:$PATH \
CC=icx bazelisk \
  --output_base=<isolated-output-base> \
  build //:release --release_dpc=false --cpu=all --jobs=2
```

Result: rc 0, 3,188 actions, 17m50s.

Produced-release gates also passed:

- ISA coverage: 592 dispatch symbols for each SSE2/AVX2/AVX-512 tier
- release structure and SONAME checks
- package metadata: 9 passed, 0 failed
- MKL linkage probe: no bundled MKL archive objects or exported `mkl_` symbols

### Windows — cumulative source-equivalent patch

Validated on Windows Server 2025 with:

- MSVC `19.44.35227`
- Intel oneAPI DPC++/C++ Compiler `2026.0.0`
- Bazel 9.2.0
- Git for Windows Bash 5.3.9

Source integrity checks passed for the exact eight-file cumulative diff: `git diff --check`, reverse patch application, file inventory, and SHA-256 preservation.

Materialized MSVC parameters:

| Dispatch tier | params | expected `/arch` | violations |
|---|---:|---|---:|
| SSE2 | 390 | none | 0 |
| AVX2 | 390 | `/arch:AVX2` | 0 |
| SKX/AVX-512 | 390 | `/arch:AVX2` | 0 |

Materialized CRT parameters:

| mode | `/MD` | `/MDd` |
|---|---:|---:|
| opt | 1,533 | 0 |
| dbg | 0 | 1,533 |

Additional Windows gates:

- generated CPU detector compiled and executed successfully; output: `avx512`
- valid `BAZEL_SH` guard: rc 0
- deliberately missing `BAZEL_SH` guard: rc 1 with the expected diagnostic
- broad MSVC host build of `//examples/daal/cpp:library_version_info_host`: rc 0, 1,933 actions
- full ICX/DPC release:

```text
bazelisk --output_user_root=<isolated-root> build //:release \
  --config=release-dpc --cpu=avx2 --jobs=2 \
  --disk_cache= --remote_upload_local_results=false --verbose_failures
```

Result: rc 0, 3,294 actions, 49m43s.

Earlier Windows `LNK1180`/server-reset attempts were traced to a user-level `C:\b-cache` upload duplicating the multi-gigabyte `onedal_core.lib` archive until the disk reached zero free bytes. The same source passed after removing only that disposable cache and explicitly disabling cache upload. No compiler/linker source failure remained.

### Current `main` applicability

All seven commits were cherry-picked, in order and without conflicts, onto `main@9d920262384e681331fca9c3c4ed481e477ae81b` in a disposable checkout.

- clean status
- unchanged cumulative diff: 8 files, 69 insertions, 15 deletions
- workflow YAML assertions passed
- `//:release --release_dpc=false --cpu=all --nobuild` passed with ICX/Bazel 9.2.0: rc 0, 4,641 configured targets

### Independent review

Two independent passes reviewed the cumulative diff:

- compiler/toolchain semantics: approve-with-nits; critical 0, should-fix 0
- CI/integration: approve-with-nits for opening one PR; no code-level blocker

The recommendation was to keep this as one PR with the seven logical commits rather than squash or split it.

## Draft / merge gates

This PR intentionally starts as a draft.

Before marking ready/merging:

- [x] Run and inspect the actual GitHub-hosted Windows Bazel workflow for this pushed head.
- [x] Confirm all required CI checks are green.
- [x] Resolve commit sign-off/DCO requirements if reported by CI (no DCO failure was reported).
- Optional follow-up: an additional exact-head Windows opt/debug runtime smoke was not rerun manually after the validation VM account lock; exact-head hosted Windows CI passed.

## Scope boundary

This series does not by itself complete global Make deprecation. Remaining broader items include non-x86 platforms, macOS, OpenRNG and other Make-only switches, real DPC CPU/GPU execution coverage, sanitizer execution, downstream-consumer gates, ABI/release-comparison hardening, performance/build-time/hermeticity gates, and Bazel-backed nupkg/documentation deliverables.

---

<details>
<summary>Checklist</summary>

**Completeness and readability**

- [x] Hard-to-understand behavior is commented, including the intentional MSVC SKX-to-`/arch:AVX2` mapping.
- [x] Windows Bazel setup documentation is updated.
- [x] No commit sign-off/DCO failure was reported by CI.
- [x] The series applies to the current base without conflicts.

**Testing**

- [x] The changes were tested extensively on Linux and Windows as described above.
- [x] Required hosted CI passed on the exact PR head.
- [x] Validation covers materialized compiler parameters, full host/release builds, CPU detection, workflow guards, package structure, and metadata.

**Performance**

- [x] No algorithm, numerical path, or dispatch policy is changed; this PR corrects compiler/toolchain selection for existing dispatch tiers. Runtime benchmark changes are not expected.
- [x] No new measurable algorithm functionality is introduced, so no benchmark-suite extension is required.

</details>

