### PR TITLE
bazel: add Linux LeakSanitizer config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -201,6 +201,17 @@ build:asan-static \
     --config=dbg-symbols
 
 
+# Configuration: 'lsan'
+# LeakSanitizer build for supported Linux non-DPC++ targets.
+# Equivalent to Make: REQSAN=leak
+#   bazel test //cpp/oneapi/dal:tests --config=lsan
+build:lsan \
+    --copt=-fsanitize=leak \
+    --copt=-fno-omit-frame-pointer \
+    --linkopt=-fsanitize=leak \
+    --config=dbg-symbols
+
+
 # Configuration: 'tsan'
 # ThreadSanitizer build.
 # Equivalent to Make: REQSAN=thread

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -430,7 +430,7 @@ jobs:
   - script: |
       set -euo pipefail
 
-      for config in dbg dbg-symbols asan asan-static tsan ubsan msan type; do
+      for config in dbg dbg-symbols asan asan-static lsan tsan ubsan msan type; do
         echo "Checking Bazel config: ${config}"
         bazel build --nobuild :release --config="${config}"
       done

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -497,6 +497,16 @@ For static libasan linkage (equivalent to Make `REQSAN=static`):
 bazel test //cpp/oneapi/dal:tests --config=asan-static --config=dbg
 ```
 
+### LeakSanitizer (LSan)
+
+Equivalent to Make `REQSAN=leak`. This configuration is for Linux non-DPC++ targets
+with a compiler that supports LeakSanitizer. Do not use it for DPC++ targets;
+DPC++ device compilation does not support LSan. Windows ICX does not support it.
+
+```sh
+bazel test //cpp/oneapi/dal:tests --config=lsan
+```
+
 ### ThreadSanitizer (TSan)
 
 Equivalent to Make `REQSAN=thread`:
@@ -627,6 +637,7 @@ build --linkopt=-your-link-flag
 | `REQDBG=symbols`               | `--config=dbg-symbols`                                       | Debug symbols only                                                         |
 | `REQSAN=address`               | `--config=asan`                                              | AddressSanitizer                                                           |
 | `REQSAN=static`                | `--config=asan-static`                                       | ASan with static libasan                                                   |
+| `REQSAN=leak`                  | `--config=lsan`                                              | LeakSanitizer; Linux host builds only; compiler support required           |
 | `REQSAN=thread`                | `--config=tsan`                                              | ThreadSanitizer                                                            |
 | `REQSAN=undefined`             | `--config=ubsan`                                             | UBSan                                                                      |
 | `REQSAN=memory`                | `--config=msan`                                              | MemorySanitizer (Clang/LLVM + lld; instrumented dependencies recommended)  |


### PR DESCRIPTION
## Description

Add a named Bazel `--config=lsan` for Linux non-DPC++ targets, equivalent to Make `REQSAN=leak`.

This is a focused Make-to-Bazel option-parity improvement toward #3530. It does not claim LeakSanitizer support for DPC++ device compilation or Windows ICX, where the sanitizer is unsupported.

## What changed

- add `build:lsan` with:
  - `-fsanitize=leak` for compile and link actions
  - `-fno-omit-frame-pointer`
  - debug symbols through `--config=dbg-symbols`
- document usage, scope, and the Make-to-Bazel mapping
- add `lsan` to the existing bounded Linux Bazel config-smoke loop

## Validation

Validated on the Linux build system at exact commit `e2148797935805f727d490a19b42291b400a9c53`.

### Static and configuration checks

```bash
git diff --check
python3 -c 'import yaml; yaml.safe_load(open(".ci/pipeline/ci.yml")); print("PASS")'
/home/ubuntu/bin/bazelisk \
  --output_user_root=/tmp/issue3530-lsan-analysis \
  --nohome_rc build --nobuild :release --config=lsan
```

Results:

- diff check: passed
- CI YAML parse: passed
- Bazel analysis: passed; 5,114 targets configured

### Materialized action flags

Representative target:

```text
//examples/oneapi/cpp:column_accessor_homogen_host
```

Queries:

```bash
bazel aquery \
  'mnemonic("CppCompile", deps(//examples/oneapi/cpp:column_accessor_homogen_host))' \
  --config=lsan --output=textproto

bazel aquery \
  'mnemonic("CppLink", deps(//examples/oneapi/cpp:column_accessor_homogen_host))' \
  --config=lsan --output=textproto
```

Results:

- compile actions: 1,584/1,584 contain `-fsanitize=leak`
- compile actions: 1,584/1,584 contain `-fno-omit-frame-pointer`
- link actions: 55/55 contain `-fsanitize=leak`
- debug `-g` is inherited through `dbg-symbols`

### Compiler smoke

A bounded Bazel build/run smoke printed `LSan smoke: 42` with:

- GCC 15.2
- Intel ICX 2026.0

The exact configuration flags also passed direct compile/link/run probes with:

- GCC 15.2
- Clang 21.1.8
- ICPX 2026.0

### Known pre-existing limitation

Selecting the repository's Bazel Clang toolchain currently fails during toolchain analysis because its CPU flag lists are empty. This predates this change; direct Clang LeakSanitizer compile/link/run succeeds. The new config does not modify compiler selection.

## Review

Independent build/config review: approve-with-nits; no critical or should-fix code issue. The documentation wording was tightened from “host builds” to “non-DPC++ targets” after review, and exact proof commands/results are recorded above.

---

<details>
<summary>Checklist</summary>

**Completeness and readability**

- [x] The configuration follows neighboring sanitizer patterns.
- [x] Linux/non-DPC++ scope and unsupported Windows/DPC++ cases are documented.
- [x] The commit is signed off.

**Testing**

- [x] `git diff --check`
- [x] CI YAML parse
- [x] full release configuration analysis with `--config=lsan`
- [x] compile/link action inspection
- [x] GCC and ICX Bazel smoke
- [x] direct GCC, Clang, and ICPX probes

**Performance**

- [x] No algorithm or production runtime behavior changes unless users explicitly select `--config=lsan`.

</details>
