### PR TITLE
[enhancement] expose original fast DAAL interface for self data distances in the oneDAL `cosine_distances` algo

### DIFF
--- a/cpp/oneapi/dal/algo/cosine_distance/backend/cpu/compute_kernel_dense.cpp
+++ b/cpp/oneapi/dal/algo/cosine_distance/backend/cpu/compute_kernel_dense.cpp
@@ -70,9 +70,7 @@ static result_t call_daal_kernel(const context_cpu& ctx,
 }
 
 template <typename Float>
-static result_t call_daal_kernel(const context_cpu& ctx,
-                                 const descriptor_t& desc,
-                                 const table& x) {
+static result_t call_daal_kernel(const context_cpu& ctx, const descriptor_t& desc, const table& x) {
     const std::int64_t row_count_x = x.get_row_count();
 
     dal::detail::check_mul_overflow(row_count_x, row_count_x);

--- a/cpp/oneapi/dal/algo/cosine_distance/backend/cpu/compute_kernel_dense.cpp
+++ b/cpp/oneapi/dal/algo/cosine_distance/backend/cpu/compute_kernel_dense.cpp
@@ -70,7 +70,38 @@ static result_t call_daal_kernel(const context_cpu& ctx,
 }
 
 template <typename Float>
+static result_t call_daal_kernel(const context_cpu& ctx,
+                                 const descriptor_t& desc,
+                                 const table& x) {
+    const std::int64_t row_count_x = x.get_row_count();
+
+    dal::detail::check_mul_overflow(row_count_x, row_count_x);
+    auto arr_values = array<Float>::empty(row_count_x * row_count_x);
+
+    const auto daal_x = interop::convert_to_daal_table<Float>(x);
+    const auto daal_values =
+        interop::convert_to_daal_homogen_table(arr_values, row_count_x, row_count_x);
+
+    daal::algorithms::Parameter param;
+    const daal::data_management::NumericTable* daal_input_tables[1] = { daal_x.get() };
+    daal::data_management::NumericTable* daal_result_table[1] = { daal_values.get() };
+
+    interop::status_to_exception(interop::call_daal_kernel<Float, daal_cosine_t>(ctx,
+                                                                                 1,
+                                                                                 daal_input_tables,
+                                                                                 1,
+                                                                                 daal_result_table,
+                                                                                 &param));
+
+    return result_t().set_values(
+        dal::detail::homogen_table_builder{}.reset(arr_values, row_count_x, row_count_x).build());
+}
+
+template <typename Float>
 static result_t compute(const context_cpu& ctx, const descriptor_t& desc, const input_t& input) {
+    if (!input.get_y().has_data()) {
+        return call_daal_kernel<Float>(ctx, desc, input.get_x());
+    }
     return call_daal_kernel<Float>(ctx, desc, input.get_x(), input.get_y());
 }
 

--- a/cpp/oneapi/dal/algo/cosine_distance/backend/gpu/compute_kernel_dense_dpc.cpp
+++ b/cpp/oneapi/dal/algo/cosine_distance/backend/gpu/compute_kernel_dense_dpc.cpp
@@ -37,7 +37,7 @@ static result_t compute(const context_gpu& ctx, const descriptor_t& desc, const 
 
     auto& queue = ctx.get_queue();
     const auto x = input.get_x();
-    const auto y = input.get_y();
+    const auto y = input.get_y().has_data() ? input.get_y() : input.get_x();
 
     const std::int64_t x_row_count = x.get_row_count();
     const std::int64_t y_row_count = y.get_row_count();

--- a/cpp/oneapi/dal/algo/cosine_distance/compute_types.cpp
+++ b/cpp/oneapi/dal/algo/cosine_distance/compute_types.cpp
@@ -23,6 +23,7 @@ template <typename Task>
 class detail::v1::compute_input_impl : public base {
 public:
     compute_input_impl(const table& x, const table& y) : x(x), y(y) {}
+    compute_input_impl(const table& x) : x(x) {}
     table x;
     table y;
 };
@@ -41,6 +42,9 @@ namespace v1 {
 template <typename Task>
 compute_input<Task>::compute_input(const table& x, const table& y)
         : impl_(new compute_input_impl<Task>(x, y)) {}
+
+template <typename Task>
+compute_input<Task>::compute_input(const table& x) : impl_(new compute_input_impl<Task>(x)) {}
 
 template <typename Task>
 const table& compute_input<Task>::get_x() const {

--- a/cpp/oneapi/dal/algo/cosine_distance/compute_types.hpp
+++ b/cpp/oneapi/dal/algo/cosine_distance/compute_types.hpp
@@ -48,6 +48,10 @@ public:
     /// Creates a new instance of the class with the given :literal:`x` and :literal:`y`.
     compute_input(const table& x, const table& y);
 
+    /// Creates a new instance of the class with the given :literal:`x` and a
+    /// default-constructed (empty) :literal:`y`.
+    compute_input(const table& x);
+
     /// An $n \\times p$ table with the data x, where each row
     /// stores one feature vector.
     /// @remark default = table{}

--- a/cpp/oneapi/dal/algo/cosine_distance/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/cosine_distance/detail/compute_ops.hpp
@@ -52,10 +52,8 @@ struct compute_ops {
         if (!input.get_x().has_data()) {
             throw domain_error(msg::input_x_is_empty());
         }
-        if (!input.get_y().has_data()) {
-            throw domain_error(msg::input_y_is_empty());
-        }
-        if (input.get_x().get_column_count() != input.get_y().get_column_count()) {
+        if (input.get_y().has_data() &&
+            input.get_x().get_column_count() != input.get_y().get_column_count()) {
             throw invalid_argument(msg::input_x_cc_neq_y_cc());
         }
     }
@@ -65,7 +63,9 @@ struct compute_ops {
                               const result_t& result) const {
         ONEDAL_ASSERT(result.get_values().has_data());
         ONEDAL_ASSERT(input.get_x().get_row_count() == result.get_values().get_row_count());
-        ONEDAL_ASSERT(input.get_y().get_row_count() == result.get_values().get_column_count());
+        if (input.get_y().has_data()) {
+            ONEDAL_ASSERT(input.get_y().get_row_count() == result.get_values().get_column_count());
+        }
     }
 
     template <typename Context>

--- a/cpp/oneapi/dal/algo/cosine_distance/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/cosine_distance/test/batch.cpp
@@ -89,6 +89,26 @@ public:
         }
     }
 
+    void check_tables_equal(const table& lhs, const table& rhs) {
+        REQUIRE(lhs.get_row_count() == rhs.get_row_count());
+        REQUIRE(lhs.get_column_count() == rhs.get_column_count());
+        row_accessor<const Float> lhs_acc{ lhs };
+        row_accessor<const Float> rhs_acc{ rhs };
+        for (std::int64_t row = 0; row < lhs.get_row_count(); ++row) {
+            auto lhs_row = lhs_acc.pull({ row, row + 1 });
+            auto rhs_row = rhs_acc.pull({ row, row + 1 });
+            for (std::int64_t col = 0; col < lhs.get_column_count(); ++col) {
+                const Float l = lhs_row[col];
+                const Float r = rhs_row[col];
+                const auto rerr =
+                    std::abs(l - r) / std::max<double>({ double(1), std::abs(l), std::abs(r) });
+                CAPTURE(row, col, l, r, rerr);
+                if (rerr > 1e-4)
+                    FAIL();
+            }
+        }
+    }
+
     la::matrix<double> compute_reference(const table& x_data, const table& y_data) {
         const auto x_data_matrix = la::matrix<double>::wrap(x_data);
         const auto y_data_matrix = la::matrix<double>::wrap(y_data);
@@ -170,6 +190,29 @@ TEMPLATE_LIST_TEST_M(cosine_distance_batch_test,
     const auto y_data_table_id = this->get_homogen_table_id();
 
     this->general_checks(x_data, y_data, x_data_table_id, y_data_table_id);
+}
+
+TEMPLATE_LIST_TEST_M(cosine_distance_batch_test,
+                     "cosine_distance self equals x-vs-x and empty-y",
+                     "[cosine_distance][integration][batch]",
+                     cosine_distance_types) {
+    SKIP_IF(this->not_float64_friendly());
+
+    const te::dataframe x_data =
+        GENERATE_DATAFRAME(te::dataframe_builder{ 8, 4 }.fill_normal(0, 1, 7777));
+    const auto x_data_table_id = this->get_homogen_table_id();
+    const table x = x_data.get_table(this->get_policy(), x_data_table_id);
+
+    const auto desc = this->get_descriptor();
+
+    const auto res_xx = this->compute(desc, x, x).get_values();
+    const auto res_x = this->compute(desc, x).get_values();
+    const auto res_empty_y = this->compute(desc, x, table{}).get_values();
+
+    INFO("compute(desc, x) matches compute(desc, x, x)");
+    this->check_tables_equal(res_x, res_xx);
+    INFO("compute(desc, x, table{}) matches compute(desc, x, x)");
+    this->check_tables_equal(res_empty_y, res_xx);
 }
 
 } // namespace oneapi::dal::cosine_distance::test


### PR DESCRIPTION
## Description

Questions have been raised as to the new cosine distances implementation for speed and optimization.  In order to speed changes in sklearnex (uxlfoundation/scikit-learn-intelex#2657) we need to open up the original optimized code path for cpu data. The optimization of two input distances can then be improved at a later input. The goal would be to add changes in sklearnex side to limit oneDAL offloading to single input data to match the daal4py implementation. These changes are needed in oneDAL to add the necessary interfaces.

It does it by removing y.has_data() errors and instead piping them to the proper pathways. Note that this means we are still using a somewhat unoptimized GPU path.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
