### PR TITLE
bazel: add Linux standard allocator option

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,6 +18,7 @@ build --flag_alias=release_dpc=@config//:release_dpc
 build --flag_alias=device=@config//:device
 build --flag_alias=cpu=@config//:cpu
 build --flag_alias=enable_assert=@config//:enable_assert
+build --flag_alias=stdalloc=@config//:stdalloc
 
 # Always pass this env variable to test rules, because SYCL
 # OpenCL backend uses it to determine available devices

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -438,6 +438,9 @@ jobs:
       echo "Checking Bazel config: release-dpc"
       bazel build --nobuild :release --config=release-dpc --cpu=all
 
+      echo "Checking Bazel config: stdalloc"
+      bazel build --nobuild :release --stdalloc=true --release_dpc=false
+
       echo "Checking Bazel config: dev"
       bazel build --nobuild //cpp/oneapi/dal:tests --config=dev
     displayName: 'Bazel config smoke checks'

--- a/cpp/daal/BUILD
+++ b/cpp/daal/BUILD
@@ -156,6 +156,9 @@ daal_module(
 daal_module(
     name = "threading_tbb",
     srcs = glob(["src/threading/**/*.cpp"]),
+    # Match Make STDALLOC=yes: separately built threading objects keep TBB
+    # scalable allocation while core objects switch away from MKL allocation.
+    stdalloc = False,
     visibility_hidden = False,
     local_defines = [
         "__TBB_NO_IMPLICIT_LINKAGE",

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -263,6 +263,14 @@ The most used Bazel commands are `build`, `test` and `run`.
   bazel test --test_disable_fp64 //cpp/oneapi/dal/algo/pca:tests
   ```
 
+- `--stdalloc` Selects standard-library aligned allocation for DAAL core
+  objects. Disabled by default and supported only for Linux targets.
+
+  Example:
+  ```sh
+  bazel build //cpp/daal:core_static --stdalloc=true
+  ```
+
 ## Build recipes for oneDAL
 ### Build release artifacts
 - To build the Bazel release artifacts, run:
@@ -448,6 +456,26 @@ dal_test_suite(
 ## What is missing in this guide
 - How to get make-like release structure
 
+## Standard-library allocator
+
+Equivalent to Make `STDALLOC=yes` for Linux core objects:
+
+```sh
+bazel build //:release --stdalloc=true
+```
+
+The option is disabled by default. When enabled, Bazel defines
+`USE_STD_ALLOC` only while compiling DAAL core objects, switching the MKL
+allocation wrappers to `std::aligned_alloc` and `std::free`. It intentionally
+does not define the macro for the separately built `threading_tbb` objects;
+this matches the current Make target-specific flag scope, so the threading
+library continues to use TBB scalable allocation.
+
+The setting rejects Windows targets because the MSVC standard library used by
+oneDAL's Windows builds does not provide `std::aligned_alloc`. Unlike the Make
+ICX configuration, the Bazel setting does not force static GNU C++ standard
+library linkage; it controls allocator selection only.
+
 ## Debug and Sanitizer Builds
 
 ### Debug build with assertions
@@ -631,6 +659,7 @@ build --linkopt=-your-link-flag
 | `REQSAN=undefined`             | `--config=ubsan`                                             | UBSan                                                                      |
 | `REQSAN=memory`                | `--config=msan`                                              | MemorySanitizer (Clang/LLVM + lld; instrumented dependencies recommended)  |
 | `REQSAN=type`                  | `--config=type`                                              | TypeSanitizer; Clang-only; GCC/ICPX unsupported                            |
+| `STDALLOC=yes`                  | `--stdalloc=true`                                            | Standard allocator for Linux DAAL core objects; threading objects unchanged |
 | `COMPILER=gnu`                 | `CC=gcc bazel build ...`                                     | Override compiler via `CC` env                                             |
 | `OPTFLAG=O2`                   | `--copt=-O2`                                                 | Override optimization level                                                |
 | `COPT=-flag`                   | `--copt=-flag` (C+C++) / `--cxxopt=-flag` (C++ only)         | Arbitrary compiler flag                                                    |

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -458,7 +458,8 @@ dal_test_suite(
 
 ## Standard-library allocator
 
-Equivalent to Make `STDALLOC=yes` for Linux core objects:
+For Linux DAAL core objects, this is equivalent to the allocator-selection
+part of Make `STDALLOC=yes`:
 
 ```sh
 bazel build //:release --stdalloc=true
@@ -471,10 +472,10 @@ does not define the macro for the separately built `threading_tbb` objects;
 this matches the current Make target-specific flag scope, so the threading
 library continues to use TBB scalable allocation.
 
-The setting rejects Windows targets because the MSVC standard library used by
-oneDAL's Windows builds does not provide `std::aligned_alloc`. Unlike the Make
-ICX configuration, the Bazel setting does not force static GNU C++ standard
-library linkage; it controls allocator selection only.
+The setting rejects every non-Linux target because this allocator path is
+currently supported only on Linux. It controls allocator selection only. Make
+builds with `COMPILER=icx STDALLOC=yes` additionally pass
+`-static-libstdc++`; `--stdalloc=true` does not change Bazel link options.
 
 ## Debug and Sanitizer Builds
 
@@ -659,7 +660,7 @@ build --linkopt=-your-link-flag
 | `REQSAN=undefined`             | `--config=ubsan`                                             | UBSan                                                                      |
 | `REQSAN=memory`                | `--config=msan`                                              | MemorySanitizer (Clang/LLVM + lld; instrumented dependencies recommended)  |
 | `REQSAN=type`                  | `--config=type`                                              | TypeSanitizer; Clang-only; GCC/ICPX unsupported                            |
-| `STDALLOC=yes`                  | `--stdalloc=true`                                            | Standard allocator for Linux DAAL core objects; threading objects unchanged |
+| `STDALLOC=yes`                  | `--stdalloc=true`                                            | Allocator-selection equivalent for Linux DAAL core objects; threading objects unchanged. Make ICX also adds `-static-libstdc++` |
 | `COMPILER=gnu`                 | `CC=gcc bazel build ...`                                     | Override compiler via `CC` env                                             |
 | `OPTFLAG=O2`                   | `--copt=-O2`                                                 | Override optimization level                                                |
 | `COPT=-flag`                   | `--copt=-flag` (C+C++) / `--cxxopt=-flag` (C++ only)         | Arbitrary compiler flag                                                    |

--- a/dev/bazel/config/config.bzl
+++ b/dev/bazel/config/config.bzl
@@ -70,6 +70,16 @@ config_bool_flag = rule(
     build_setting = config.bool(flag = True),
 )
 
+def _unsupported_config_impl(ctx):
+    fail(ctx.attr.message)
+
+unsupported_config = rule(
+    implementation = _unsupported_config_impl,
+    attrs = {
+        "message": attr.string(mandatory = True),
+    },
+)
+
 CpuInfo = provider(
     fields = [
         "enabled",

--- a/dev/bazel/config/config.tpl.BUILD
+++ b/dev/bazel/config/config.tpl.BUILD
@@ -5,6 +5,7 @@ load("@onedal//dev/bazel/config:config.bzl",
     "config_flag",
     "config_bool_flag",
     "dump_config_info",
+    "unsupported_config",
 )
 
 cpu_info(
@@ -136,6 +137,46 @@ config_bool_flag(
 config_bool_flag(
     name = "enable_assert",
     build_setting_default = False,
+)
+
+config_bool_flag(
+    name = "stdalloc",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "stdalloc_enabled",
+    flag_values = {
+        ":stdalloc": "True",
+    },
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "stdalloc_windows",
+    flag_values = {
+        ":stdalloc": "True",
+    },
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)
+
+config_setting(
+    name = "stdalloc_macos",
+    flag_values = {
+        ":stdalloc": "True",
+    },
+    constraint_values = [
+        "@platforms//os:macos",
+    ],
+)
+
+unsupported_config(
+    name = "stdalloc_linux_only_error",
+    message = "--stdalloc is supported only for Linux targets",
 )
 
 config_setting(

--- a/dev/bazel/config/config.tpl.BUILD
+++ b/dev/bazel/config/config.tpl.BUILD
@@ -155,28 +155,15 @@ config_setting(
 )
 
 config_setting(
-    name = "stdalloc_windows",
+    name = "stdalloc_disabled",
     flag_values = {
-        ":stdalloc": "True",
+        ":stdalloc": "False",
     },
-    constraint_values = [
-        "@platforms//os:windows",
-    ],
-)
-
-config_setting(
-    name = "stdalloc_macos",
-    flag_values = {
-        ":stdalloc": "True",
-    },
-    constraint_values = [
-        "@platforms//os:macos",
-    ],
 )
 
 unsupported_config(
-    name = "stdalloc_linux_only_error",
-    message = "--stdalloc is supported only for Linux targets",
+    name = "stdalloc_non_linux_error",
+    message = "--stdalloc=true is supported only when targeting Linux",
 )
 
 config_setting(

--- a/dev/bazel/daal.bzl
+++ b/dev/bazel/daal.bzl
@@ -30,13 +30,19 @@ load("@onedal//dev/bazel/config:config.bzl",
 
 def daal_module(name, features=[], lib_tag="daal",
                 hdrs=[], srcs=[], auto=False,
-                local_defines=[], copts=[], visibility_hidden=True, **kwargs):
+                local_defines=[], copts=[], visibility_hidden=True,
+                stdalloc=True, **kwargs):
     if auto:
         auto_hdrs = native.glob(["**/*.h", "**/*.i"], allow_empty=True,)
         auto_srcs = native.glob(["**/*.cpp"], allow_empty=True,)
     else:
         auto_hdrs = []
         auto_srcs = []
+    deps = kwargs.pop("deps", []) + select({
+        "@config//:stdalloc_macos": ["@config//:stdalloc_linux_only_error"],
+        "@config//:stdalloc_windows": ["@config//:stdalloc_linux_only_error"],
+        "//conditions:default": [],
+    })
     cc_module(
         name = name,
         lib_tag = lib_tag,
@@ -52,6 +58,7 @@ def daal_module(name, features=[], lib_tag="daal",
         },
         hdrs = auto_hdrs + hdrs,
         srcs = auto_srcs + srcs,
+        deps = deps,
         copts = copts + (select({
             "@platforms//os:windows": ["/utf-8"],
             "//conditions:default": ["-fvisibility=hidden", "-fvisibility-inlines-hidden"],
@@ -62,7 +69,10 @@ def daal_module(name, features=[], lib_tag="daal",
         local_defines = select({
             "@config//:assert_enabled": local_defines + ["__DAAL_IMPLEMENTATION", "DEBUG_ASSERT=1"],
             "//conditions:default": local_defines + ["__DAAL_IMPLEMENTATION"],
-        }) + select({
+        }) + (select({
+            "@config//:stdalloc_enabled": ["USE_STD_ALLOC"],
+            "//conditions:default": [],
+        }) if stdalloc else []) + select({
             "@config//:backend_ref": [
                 "DAAL_REF",
             ],

--- a/dev/bazel/daal.bzl
+++ b/dev/bazel/daal.bzl
@@ -39,9 +39,9 @@ def daal_module(name, features=[], lib_tag="daal",
         auto_hdrs = []
         auto_srcs = []
     deps = kwargs.pop("deps", []) + select({
-        "@config//:stdalloc_macos": ["@config//:stdalloc_linux_only_error"],
-        "@config//:stdalloc_windows": ["@config//:stdalloc_linux_only_error"],
-        "//conditions:default": [],
+        "@config//:stdalloc_enabled": [],
+        "@config//:stdalloc_disabled": [],
+        "//conditions:default": ["@config//:stdalloc_non_linux_error"],
     })
     cc_module(
         name = name,


### PR DESCRIPTION
## Description

Add a typed Bazel `--stdalloc=true` option for the allocator-selection part of Make `STDALLOC=yes` on Linux DAAL core builds.

This is a focused Make-to-Bazel option-parity improvement toward #3530. The option is disabled by default.

## What changed

- add the typed boolean `--stdalloc=true` interface
- define `USE_STD_ALLOC` only for DAAL core compilation actions
- keep separately built threading objects on TBB scalable allocation, matching Make target scope
- reject non-Linux DAAL configurations clearly
- document the difference from Make+ICX, which also adds `-static-libstdc++`
- add a bounded Bazel configuration-analysis smoke to CI

## Validation

Validated on Linux at exact branch head `8ce584627c78d90ca5d18eb709adff9c85dd1c71`.

### Exact-head GCC build/test

```bash
CC=gcc bazelisk build \
  //cpp/daal:core_static //cpp/daal:core_dynamic \
  //cpp/daal:thread_static //cpp/daal:thread_dynamic \
  --stdalloc=true --cpu=sse2 --jobs=2

CC=gcc bazelisk test \
  //cpp/daal/src/algorithms/dtrees/gbt/regression:test_gbt_regression_model_builder_unit_host \
  --stdalloc=true --cpu=sse2 --jobs=2 --test_output=errors
```

Results: build passed (1,151 actions); 1/1 test passed. CI YAML parse and `git diff --check` also passed.

### ICX proof

Validated with ICX/ICPX 2026.0 and Bazel 9.2:

- enabled core actions: 1,140/1,140 contain `USE_STD_ALLOC`
- enabled threading actions: 0/2 contain `USE_STD_ALLOC`
- default core actions: 0/1,140 contain `USE_STD_ALLOC`
- static/dynamic core and threading build passed
- representative tests passed
- runtime allocation/free probe passed with 64-byte alignment
- core resolves to `aligned_alloc/free`; threading retains TBB scalable allocation

## Scope notes

This option controls allocator selection only. Make builds with `COMPILER=icx STDALLOC=yes` additionally pass `-static-libstdc++`; Bazel link options are intentionally unchanged.

---

**Checklist**

- [x] Changes reviewed locally
- [x] Documentation updated
- [x] Commits include Signed-off-by
- [x] Focused build/test validation completed
- [x] No default behavior changes
- [x] No performance change unless the option is explicitly enabled
