### PR TITLE
Add Bazel parameter library layout control

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,6 +18,7 @@ build --flag_alias=release_dpc=@config//:release_dpc
 build --flag_alias=device=@config//:device
 build --flag_alias=cpu=@config//:cpu
 build --flag_alias=enable_assert=@config//:enable_assert
+build --flag_alias=build_parameters_lib=@config//:build_parameters_lib
 
 # Always pass this env variable to test rules, because SYCL
 # OpenCL backend uses it to determine available devices

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -451,10 +451,18 @@ jobs:
 
   - script: |
       set -euo pipefail
-      # The CMake consumer resolves oneMKL/TBB through the same oneAPI
-      # environment as an installed package user.
-      source /opt/intel/oneapi/setvars.sh
+      # Build with the same environment as the other Bazel steps. `setvars.sh`
+      # exports `MKLROOT`, which `mkl_repo` declares in `environ`, so sourcing it
+      # before the build would repoint `@mkl` at the oneAPI installation and
+      # invalidate the dependency for this step only.
       bazel build :release --release_dpc=false --build_parameters_lib=no
+      # The CMake and pkg-config consumers resolve oneMKL/TBB through the same
+      # oneAPI environment as an installed package user. `setvars.sh` reads
+      # optional variables such as `OCL_ICD_FILENAMES` unguarded, so `nounset`
+      # has to be relaxed while it runs.
+      set +u
+      source /opt/intel/oneapi/setvars.sh
+      set -u
       DALROOT="$(pwd)/bazel-bin/release/daal/latest" \
         BAZEL=bazel dev/release_tests/parameters_layout_consumer_test.sh \
         "$(pwd)/bazel-bin/release/daal/latest" "$(pwd)"

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -389,6 +389,9 @@ jobs:
       .ci/env/apt.sh opencl
     displayName: 'install opencl'
   - script: |
+      .ci/env/apt.sh mkl
+    displayName: 'mkl installation'
+  - script: |
       # sourcing done to set bazel version value from script
       source .ci/env/bazelisk.sh
       echo "##vso[task.setvariable variable=BAZEL_VERSION]${BAZEL_VERSION}"

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -448,6 +448,9 @@ jobs:
 
   - script: |
       set -euo pipefail
+      # The CMake consumer resolves oneMKL/TBB through the same oneAPI
+      # environment as an installed package user.
+      source /opt/intel/oneapi/setvars.sh
       bazel build :release --release_dpc=false --build_parameters_lib=no
       DALROOT="$(pwd)/bazel-bin/release/daal/latest" \
         BAZEL=bazel dev/release_tests/parameters_layout_consumer_test.sh \

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -438,6 +438,21 @@ jobs:
       echo "Checking Bazel config: release-dpc"
       bazel build --nobuild :release --config=release-dpc --cpu=all
 
+      for parameters_lib in auto yes no; do
+        echo "Checking parameter library layout: ${parameters_lib}"
+        bazel build --nobuild :release --cpu=avx2 \
+          --build_parameters_lib="${parameters_lib}"
+      done
+
+      if bazel build @config//:validate_build_parameters_lib \
+          --platforms=@config//:windows_analysis_platform \
+          --build_parameters_lib=yes > windows_parameters_lib.log 2>&1; then
+        echo "Windows --build_parameters_lib=yes unexpectedly succeeded"
+        exit 1
+      fi
+      grep -F -- "--build_parameters_lib=yes is not supported on Windows" \
+        windows_parameters_lib.log
+
       echo "Checking Bazel config: dev"
       bazel build --nobuild //cpp/oneapi/dal:tests --config=dev
     displayName: 'Bazel config smoke checks'
@@ -671,6 +686,20 @@ jobs:
       echo ##vso[task.setvariable variable=BAZEL_SH]C:\Program Files\Git\bin\bash.exe
       echo ##vso[task.setvariable variable=BAZEL_JOBS]%NUMBER_OF_PROCESSORS%
     displayName: 'bazel-configure'
+  - script: |
+      call %TEMP%\oneapi\setvars.bat --force
+      "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" build //:release --nobuild --build_parameters_lib=yes > build_parameters_lib_yes.log 2>&1
+      if not errorlevel 1 (
+        type build_parameters_lib_yes.log
+        echo ERROR: Windows --build_parameters_lib=yes unexpectedly succeeded
+        exit /b 1
+      )
+      findstr /C:"--build_parameters_lib=yes is not supported on Windows" build_parameters_lib_yes.log >NUL || (
+        type build_parameters_lib_yes.log
+        echo ERROR: expected Windows parameter-library diagnostic was not found
+        exit /b 1
+      )
+    displayName: 'Reject separate parameter libraries on Windows'
   - script: |
       call %TEMP%\oneapi\setvars.bat --force
       "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" shutdown

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -438,24 +438,21 @@ jobs:
       echo "Checking Bazel config: release-dpc"
       bazel build --nobuild :release --config=release-dpc --cpu=all
 
-      for parameters_lib in auto yes no; do
-        echo "Checking parameter library layout: ${parameters_lib}"
-        bazel build --nobuild :release --cpu=avx2 \
-          --build_parameters_lib="${parameters_lib}"
-      done
-
-      if bazel build @config//:validate_build_parameters_lib \
-          --platforms=@config//:windows_analysis_platform \
-          --build_parameters_lib=yes > windows_parameters_lib.log 2>&1; then
-        echo "Windows --build_parameters_lib=yes unexpectedly succeeded"
-        exit 1
-      fi
-      grep -F -- "--build_parameters_lib=yes is not supported on Windows" \
-        windows_parameters_lib.log
+      # Analysis-only: validates configured release outputs, host/DPC dependency
+      # separation, folded-target rejection, and the Windows unsupported value.
+      BAZEL=bazel dev/bazel/tests/parameters_layout_test.sh
 
       echo "Checking Bazel config: dev"
       bazel build --nobuild //cpp/oneapi/dal:tests --config=dev
     displayName: 'Bazel config smoke checks'
+
+  - script: |
+      set -euo pipefail
+      bazel build :release --release_dpc=false --build_parameters_lib=no
+      DALROOT="$(pwd)/bazel-bin/release/daal/latest" \
+        BAZEL=bazel dev/release_tests/parameters_layout_consumer_test.sh \
+        "$(pwd)/bazel-bin/release/daal/latest" "$(pwd)"
+    displayName: 'Folded parameter-layout packaged consumer smoke'
 
   - script: |
       bazel build :release --release_dpc=false
@@ -688,7 +685,7 @@ jobs:
     displayName: 'bazel-configure'
   - script: |
       call %TEMP%\oneapi\setvars.bat --force
-      "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" build //:release --nobuild --build_parameters_lib=yes > build_parameters_lib_yes.log 2>&1
+      "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" build @config//:validate_build_parameters_lib --build_parameters_lib=yes > build_parameters_lib_yes.log 2>&1
       if not errorlevel 1 (
         type build_parameters_lib_yes.log
         echo ERROR: Windows --build_parameters_lib=yes unexpectedly succeeded

--- a/.ci/scripts/build.bat
+++ b/.ci/scripts/build.bat
@@ -44,5 +44,5 @@ IF "%VS_VER%"=="2017_build_tools" (
 echo make %1 -j%NUMBER_OF_PROCESSORS% COMPILER=%2 PLAT=win32e REQCPU=%3
 make %1 -j%NUMBER_OF_PROCESSORS% COMPILER=%2 PLAT=win32e REQCPU=%3 || set errorcode=1
 
-cmake -DINSTALL_DIR=__release_win_vc\daal\latest\lib\cmake\oneDAL -DARCH_DIR=intel64 -P cmake\scripts\generate_config.cmake || set errorcode=1
+cmake -DINSTALL_DIR=__release_win_vc\daal\latest\lib\cmake\oneDAL -DARCH_DIR=intel64 -DONEDAL_USE_PARAMETERS_LIBRARY=no -P cmake\scripts\generate_config.cmake || set errorcode=1
 EXIT /B %errorcode%

--- a/BUILD
+++ b/BUILD
@@ -3,6 +3,10 @@ load("@onedal//dev/bazel:release.bzl",
     "release_include",
     "release_extra_file",
 )
+load("@onedal//dev/bazel/config:selects.bzl",
+    "parameters_lib_enabled",
+    "release_dpc_parameters_lib_enabled",
+)
 load("@onedal//dev/bazel:scripts.bzl",
     "generate_cmake_config",
     "generate_modulefile",
@@ -151,22 +155,20 @@ release(
         "@onedal//cpp/daal:thread_dynamic",
         "@onedal//cpp/oneapi/dal:static",
         "@onedal//cpp/oneapi/dal:dynamic",
-    ] + select({
-        ":windows": [],
-        "//conditions:default": [
-            "@onedal//cpp/oneapi/dal:static_parameters",
-            "@onedal//cpp/oneapi/dal:dynamic_parameters",
-        ],
-    }) + select({
+    ] + parameters_lib_enabled([
+        "@onedal//cpp/oneapi/dal:static_parameters",
+        "@onedal//cpp/oneapi/dal:dynamic_parameters",
+    ]) + select({
         ":release_dpc_windows": [
             "@onedal//cpp/oneapi/dal:dynamic_dpc",
         ],
         "@config//:release_dpc_enabled": [
             "@onedal//cpp/oneapi/dal:dynamic_dpc",
-            "@onedal//cpp/oneapi/dal:dynamic_parameters_dpc",
         ],
         "//conditions:default": [],
-    }),
+    }) + release_dpc_parameters_lib_enabled([
+        "@onedal//cpp/oneapi/dal:dynamic_parameters_dpc",
+    ]),
     data = [
         "//data:datasets",
         ":release_package_files",

--- a/BUILD
+++ b/BUILD
@@ -5,6 +5,7 @@ load("@onedal//dev/bazel:release.bzl",
 )
 load("@onedal//dev/bazel/config:selects.bzl",
     "parameters_lib_enabled",
+    "parameters_lib_separate_value",
     "release_dpc_parameters_lib_enabled",
 )
 load("@onedal//dev/bazel:scripts.bzl",
@@ -40,17 +41,20 @@ generate_modulefile(
 generate_pkgconfig(
     name = "release_pkgconfig",
     out = "lib/pkgconfig/onedal.pc",
+    parameters_lib = parameters_lib_separate_value(),
 )
 
 generate_pkgconfig(
     name = "release_pkgconfig_dynamic_threading_host",
     out = "lib/pkgconfig/dal-dynamic-threading-host.pc",
+    parameters_lib = parameters_lib_separate_value(),
 )
 
 generate_pkgconfig(
     name = "release_pkgconfig_static_threading_host",
     out = "lib/pkgconfig/dal-static-threading-host.pc",
     static = True,
+    parameters_lib = parameters_lib_separate_value(),
 )
 
 filegroup(
@@ -62,6 +66,7 @@ generate_cmake_config(
     name = "release_cmake_config",
     template = "cmake/templates/oneDALConfig.cmake.in",
     out = "lib/cmake/oneDAL/oneDALConfig.cmake",
+    parameters_lib = parameters_lib_separate_value(),
 )
 
 generate_cmake_config(
@@ -170,6 +175,7 @@ release(
         "@onedal//cpp/oneapi/dal:dynamic_parameters_dpc",
     ]),
     data = [
+        "@config//:validate_build_parameters_lib",
         "//data:datasets",
         ":release_package_files",
         "//examples/daal/cpp:release_files",

--- a/cmake/templates/oneDALConfig.cmake.in
+++ b/cmake/templates/oneDALConfig.cmake.in
@@ -40,11 +40,9 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type not specified, defaulting to Release" FORCE)
 endif()
 
-if(WIN32)
-    message(STATUS "Optimization library is not enabled on Windows")
-    set(ONEDAL_USE_PARAMETERS_LIBRARY no)
-else()
-    set(ONEDAL_USE_PARAMETERS_LIBRARY yes)
+set(ONEDAL_USE_PARAMETERS_LIBRARY "@ONEDAL_USE_PARAMETERS_LIBRARY@")
+if(WIN32 AND ONEDAL_USE_PARAMETERS_LIBRARY STREQUAL "yes")
+    message(FATAL_ERROR "This package advertises unsupported separate parameter libraries on Windows")
 endif()
 
 #Backward compatibility section to be removed with next major version
@@ -80,7 +78,9 @@ elseif (NOT "${ONEDAL_USE_DPCPP}" STREQUAL "yes" AND NOT "${ONEDAL_USE_DPCPP}" S
 endif()
 if ("${ONEDAL_LINK}" STREQUAL "" OR "${ONEDAL_LINK}" STREQUAL "dynamic")
     set(ONEDAL_LINK "dynamic")
-    if ("${ONEDAL_USE_DPCPP}" STREQUAL "yes")
+    if ("${ONEDAL_USE_DPCPP}" STREQUAL "yes" OR
+        "${ONEDAL_USE_PARAMETERS_LIBRARY}" STREQUAL "no")
+        # Folded parameter objects reference MKL from the main host library.
         set(MKL_DEPENDENCY "yes")
     endif()
 elseif ("${ONEDAL_LINK}" STREQUAL "static")
@@ -181,6 +181,9 @@ if(MKL_DEPENDENCY STREQUAL "yes")
                 MKL::mkl_core
                 MKL::mkl_intel_lp64
                 MKL::mkl_gnu_thread${DAL_DEBUG_SUFFIX})
+            if(ONEDAL_USE_PARAMETERS_LIBRARY STREQUAL "no")
+                list(APPEND oneDAL_IMPORTED_TARGETS -lgomp)
+            endif()
         endif()
     endif()
 

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -9,6 +9,23 @@ load("@onedal//dev/bazel:dal.bzl",
     "dal_collect_test_suites",
     "dal_generate_cpu_dispatcher",
 )
+load("@onedal//dev/bazel/config:selects.bzl",
+    "parameters_lib_disabled",
+    "parameters_lib_enabled",
+)
+
+_PARAMETER_MODULES = [
+    "@onedal//cpp/oneapi/dal/algo:parameters",
+    "@onedal//cpp/oneapi/dal/detail/parameters",
+]
+
+_PARAMETER_MODULES_DPC = [
+    "@onedal//cpp/oneapi/dal/algo:parameters_dpc",
+    "@onedal//cpp/oneapi/dal/detail/parameters:parameters_dpc",
+]
+
+_DAL_LIB_TAGS = ["dal"] + parameters_lib_disabled(["parameters"])
+
 
 dal_generate_cpu_dispatcher(
     name = "cpu_dispatcher",
@@ -73,10 +90,13 @@ dal_public_includes(
 dal_static_lib(
     name = "static",
     lib_name = "onedal",
+    lib_tags = _DAL_LIB_TAGS,
     dal_deps = [
         ":core",
         ":optional",
     ],
+    host_deps = parameters_lib_disabled(_PARAMETER_MODULES),
+    dpc_deps = parameters_lib_disabled(_PARAMETER_MODULES_DPC),
 )
 
 dal_static_lib(
@@ -101,29 +121,22 @@ dal_dynamic_lib(
     lib_tags = select({
         "@platforms//os:windows": ["dal", "daal", "mkl_embed"],
         "//conditions:default": ["dal"],
-    }),
-    dpc_lib_tags = ["dal", "daal", "mkl_embed"],
+    }) + parameters_lib_disabled(["parameters"]),
+    dpc_lib_tags = ["dal", "daal", "mkl_embed"] + parameters_lib_disabled(["parameters"]),
     dal_deps = [
         ":core",
         ":optional",
     ],
-    dpc_deps = select({
+    dpc_deps = parameters_lib_disabled(_PARAMETER_MODULES_DPC) + select({
         "@platforms//os:windows": [
             "@onedal//cpp/daal:core_dynamic",
-            ":static_parameters_dpc",
         ],
         "//conditions:default": [],
     }),
-    # On Windows, onedal.dll must resolve all externals at link time:
-    #   - static_parameters: parameter symbols not part of any other dep tree.
-    #   - services_win_dll_shim: delay-load stubs for threading entry points
-    #     (e.g. `_threaded_scalable_*`, `_daal_static_threader_reduce`) that
-    #     the embedded DAAL kernel objects reference. The real TBB-backed
-    #     symbols live in onedal_thread.dll. Mirrors onedal_core.dll above
-    #     and the original Make build.
-    host_deps = select({
+    # On Windows, services_win_dll_shim provides delay-load stubs for
+    # threading entry points referenced by the embedded DAAL kernel objects.
+    host_deps = parameters_lib_disabled(_PARAMETER_MODULES) + select({
         "@platforms//os:windows": [
-            ":static_parameters",
             "@onedal//cpp/daal:services_win_dll_shim",
         ],
         "//conditions:default": [],
@@ -168,9 +181,10 @@ filegroup(
     srcs = [
         ":static",
         ":static_dpc",
+    ] + parameters_lib_enabled([
         ":static_parameters",
         ":static_parameters_dpc",
-    ],
+    ]),
 )
 
 filegroup(
@@ -178,9 +192,10 @@ filegroup(
     srcs = [
         ":dynamic",
         ":dynamic_dpc",
+    ] + parameters_lib_enabled([
         ":dynamic_parameters",
         ":dynamic_parameters_dpc",
-    ],
+    ]),
 )
 
 dal_test_suite(

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -12,6 +12,7 @@ load("@onedal//dev/bazel:dal.bzl",
 load("@onedal//dev/bazel/config:selects.bzl",
     "parameters_lib_disabled",
     "parameters_lib_enabled",
+    "parameters_lib_target_compatible_with",
 )
 
 _PARAMETER_MODULES = [
@@ -107,6 +108,7 @@ dal_static_lib(
         "@onedal//cpp/oneapi/dal/algo:parameters",
         "@onedal//cpp/oneapi/dal/detail/parameters",
     ],
+    target_compatible_with = parameters_lib_target_compatible_with(),
 )
 
 dal_dynamic_lib(
@@ -136,6 +138,12 @@ dal_dynamic_lib(
     # On Windows, services_win_dll_shim provides delay-load stubs for
     # threading entry points referenced by the embedded DAAL kernel objects.
     host_deps = parameters_lib_disabled(_PARAMETER_MODULES) + select({
+        "@platforms//os:windows": [
+            "@onedal//cpp/daal:services_win_dll_shim",
+        ],
+        "//conditions:default": [],
+    }),
+    dpc_host_deps = select({
         "@platforms//os:windows": [
             "@onedal//cpp/daal:services_win_dll_shim",
         ],
@@ -174,6 +182,11 @@ dal_dynamic_lib(
         "@platforms//os:windows": ["@onedal//cpp/daal:services_win_dll_shim"],
         "//conditions:default": [],
     }),
+    dpc_host_deps = select({
+        "@platforms//os:windows": ["@onedal//cpp/daal:services_win_dll_shim"],
+        "//conditions:default": [],
+    }),
+    target_compatible_with = parameters_lib_target_compatible_with(),
 )
 
 filegroup(

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -625,10 +625,10 @@ Bazel mirrors Make's `BUILD_PARAMETERS_LIB` switch with the typed
 `--build_parameters_lib=auto|yes|no` setting:
 
 - `auto` (default) builds separate `libonedal_parameters` and
-  `libonedal_parameters_dpc` libraries on Linux, and folds those objects into
-  `onedal`/`onedal_dpc` on Windows.
-- `yes` selects the separate host and DPC parameter libraries on Linux. It is
-  unsupported on Windows and fails during analysis with a diagnostic.
+  `libonedal_parameters_dpc` libraries on non-Windows targets, and folds those
+  objects into `onedal`/`onedal_dpc` on Windows.
+- `yes` selects the separate host and DPC parameter libraries on non-Windows
+  targets. It is unsupported on Windows and fails during analysis with a diagnostic.
 - `no` folds the host and DPC parameter modules into the corresponding main
   libraries and omits separate parameter libraries from `//:release`.
 
@@ -638,11 +638,18 @@ For example:
 bazel build //:release --build_parameters_lib=no
 ```
 
+CI uses `dev/bazel/tests/parameters_layout_test.sh` for analysis-only checks of
+configured release outputs, host/DPC dependency separation, folded-target
+rejection, and Windows value validation. It does not build DPC binaries.
+`dev/release_tests/parameters_layout_consumer_test.sh` separately builds and
+runs host static and dynamic consumers through packaged CMake, pkg-config, and
+Bazel metadata for the folded layout.
+
 ## Make → Bazel Flag Reference
 
 | Make option                    | Bazel equivalent                                             | Notes                                                                      |
 |--------------------------------|--------------------------------------------------------------|----------------------------------------------------------------------------|
-| `BUILD_PARAMETERS_LIB=yes|no` | `--build_parameters_lib=yes|no`                              | `auto` preserves Linux `yes` / Windows `no` defaults; Windows `yes` is unsupported |
+| `BUILD_PARAMETERS_LIB=yes|no` | `--build_parameters_lib=yes|no`                              | `auto` preserves non-Windows `yes` / Windows `no` defaults; Windows `yes` is unsupported |
 | `REQDBG=yes`                   | `--config=dbg`                                               | Debug symbols + assertions                                                 |
 | `REQDBG=symbols`               | `--config=dbg-symbols`                                       | Debug symbols only                                                         |
 | `REQSAN=address`               | `--config=asan`                                              | AddressSanitizer                                                           |

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -619,10 +619,30 @@ build --linkopt=-your-link-flag
 
 ---
 
+## Parameter library layout
+
+Bazel mirrors Make's `BUILD_PARAMETERS_LIB` switch with the typed
+`--build_parameters_lib=auto|yes|no` setting:
+
+- `auto` (default) builds separate `libonedal_parameters` and
+  `libonedal_parameters_dpc` libraries on Linux, and folds those objects into
+  `onedal`/`onedal_dpc` on Windows.
+- `yes` selects the separate host and DPC parameter libraries on Linux. It is
+  unsupported on Windows and fails during analysis with a diagnostic.
+- `no` folds the host and DPC parameter modules into the corresponding main
+  libraries and omits separate parameter libraries from `//:release`.
+
+For example:
+
+```
+bazel build //:release --build_parameters_lib=no
+```
+
 ## Make → Bazel Flag Reference
 
 | Make option                    | Bazel equivalent                                             | Notes                                                                      |
 |--------------------------------|--------------------------------------------------------------|----------------------------------------------------------------------------|
+| `BUILD_PARAMETERS_LIB=yes|no` | `--build_parameters_lib=yes|no`                              | `auto` preserves Linux `yes` / Windows `no` defaults; Windows `yes` is unsupported |
 | `REQDBG=yes`                   | `--config=dbg`                                               | Debug symbols + assertions                                                 |
 | `REQDBG=symbols`               | `--config=dbg-symbols`                                       | Debug symbols only                                                         |
 | `REQSAN=address`               | `--config=asan`                                              | AddressSanitizer                                                           |

--- a/dev/bazel/cc.bzl
+++ b/dev/bazel/cc.bzl
@@ -23,7 +23,9 @@ load("@onedal//dev/bazel:utils.bzl",
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@onedal//dev/bazel/config:config.bzl",
     "CpuInfo",
+    "ConfigFlagInfo",
     "VersionInfo",
+    "validate_build_parameters_lib",
 )
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
@@ -185,7 +187,16 @@ def cc_module(name, hdrs=[], deps=[], **kwargs):
     )
 
 
+def _validate_build_parameters_lib(ctx):
+    value = ctx.attr._build_parameters_lib[ConfigFlagInfo].flag
+    is_windows = ctx.target_platform_has_constraint(
+        ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
+    )
+    validate_build_parameters_lib(value, is_windows)
+
+
 def _cc_static_lib_impl(ctx):
+    _validate_build_parameters_lib(ctx)
     toolchain, feature_config = _init_cc_rule(ctx)
     compilation_context = onedal_cc_common.collect_and_merge_compilation_contexts(ctx.attr.deps)
     linking_contexts = onedal_cc_common.collect_and_filter_linking_contexts(
@@ -219,6 +230,10 @@ cc_static_lib = rule(
         "deps": attr.label_list(mandatory=True),
         "_windows_constraint": attr.label(
             default = "@platforms//os:windows",
+        ),
+        "_build_parameters_lib": attr.label(
+            default = "@config//:build_parameters_lib",
+            providers = [ConfigFlagInfo],
         ),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
@@ -255,6 +270,7 @@ def _copy_dynamic_release_file(ctx, src, out_name, is_windows = False, extra_inp
 
 
 def _cc_dynamic_lib_impl(ctx):
+    _validate_build_parameters_lib(ctx)
     toolchain, feature_config = _init_cc_rule(ctx, features=[
         # Keep produced shared libraries free of dynamic Bazel deps on Linux.
         # Release-dynamic tests provide standalone oneDAL libs through
@@ -341,6 +357,10 @@ cc_dynamic_lib = rule(
         "_version_info": attr.label(
             default = "@config//:version",
             providers = [VersionInfo],
+        ),
+        "_build_parameters_lib": attr.label(
+            default = "@config//:build_parameters_lib",
+            providers = [ConfigFlagInfo],
         ),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],

--- a/dev/bazel/config/config.bzl
+++ b/dev/bazel/config/config.bzl
@@ -70,6 +70,33 @@ config_bool_flag = rule(
     build_setting = config.bool(flag = True),
 )
 
+
+def validate_build_parameters_lib(value, is_windows):
+    if is_windows and value == "yes":
+        fail("--build_parameters_lib=yes is not supported on Windows; use auto or no")
+
+
+def _build_parameters_lib_validation_impl(ctx):
+    value = ctx.attr.flag[ConfigFlagInfo].flag
+    is_windows = ctx.target_platform_has_constraint(
+        ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
+    )
+    validate_build_parameters_lib(value, is_windows)
+    return []
+
+build_parameters_lib_validation = rule(
+    implementation = _build_parameters_lib_validation_impl,
+    attrs = {
+        "flag": attr.label(
+            mandatory = True,
+            providers = [ConfigFlagInfo],
+        ),
+        "_windows_constraint": attr.label(
+            default = "@platforms//os:windows",
+        ),
+    },
+)
+
 CpuInfo = provider(
     fields = [
         "enabled",

--- a/dev/bazel/config/config.tpl.BUILD
+++ b/dev/bazel/config/config.tpl.BUILD
@@ -4,6 +4,7 @@ load("@onedal//dev/bazel/config:config.bzl",
     "version_info",
     "config_flag",
     "config_bool_flag",
+    "build_parameters_lib_validation",
     "dump_config_info",
 )
 
@@ -49,6 +50,74 @@ config_setting(
     },
     constraint_values = [
         "@platforms//os:linux",
+    ],
+)
+
+# Make BUILD_PARAMETERS_LIB parity. "auto" follows the supported platform
+# defaults: separate parameter libraries on Linux, folded libraries on Windows.
+config_flag(
+    name = "build_parameters_lib",
+    build_setting_default = "auto",
+    allowed_build_setting_values = [
+        "auto",
+        "yes",
+        "no",
+    ],
+)
+
+config_setting(
+    name = "build_parameters_lib_auto_linux",
+    flag_values = {
+        ":build_parameters_lib": "auto",
+    },
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "build_parameters_lib_yes_linux",
+    flag_values = {
+        ":build_parameters_lib": "yes",
+    },
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "release_dpc_build_parameters_lib_auto_linux",
+    flag_values = {
+        ":build_parameters_lib": "auto",
+        ":release_dpc": "True",
+    },
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "release_dpc_build_parameters_lib_yes_linux",
+    flag_values = {
+        ":build_parameters_lib": "yes",
+        ":release_dpc": "True",
+    },
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+build_parameters_lib_validation(
+    name = "validate_build_parameters_lib",
+    flag = ":build_parameters_lib",
+)
+
+# Toolchain-free target platform used by the analysis-only rejection smoke test.
+platform(
+    name = "windows_analysis_platform",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
     ],
 )
 
@@ -157,6 +226,7 @@ dump_config_info(
     cpu_info = ":cpu",
     version_info = ":version",
     flags = [
+        ":build_parameters_lib",
         ":test_link_mode",
         ":test_thread_mode",
     ],

--- a/dev/bazel/config/config.tpl.BUILD
+++ b/dev/bazel/config/config.tpl.BUILD
@@ -53,8 +53,8 @@ config_setting(
     ],
 )
 
-# Make BUILD_PARAMETERS_LIB parity. "auto" follows the supported platform
-# defaults: separate parameter libraries on Linux, folded libraries on Windows.
+# Make BUILD_PARAMETERS_LIB parity. "auto" means yes on every non-Windows
+# target and no on Windows. Explicit yes is rejected on Windows.
 config_flag(
     name = "build_parameters_lib",
     build_setting_default = "auto",
@@ -66,45 +66,20 @@ config_flag(
 )
 
 config_setting(
-    name = "build_parameters_lib_auto_linux",
-    flag_values = {
-        ":build_parameters_lib": "auto",
-    },
-    constraint_values = [
-        "@platforms//os:linux",
-    ],
+    name = "build_parameters_lib_auto_windows",
+    flag_values = {":build_parameters_lib": "auto"},
+    constraint_values = ["@platforms//os:windows"],
 )
 
 config_setting(
-    name = "build_parameters_lib_yes_linux",
-    flag_values = {
-        ":build_parameters_lib": "yes",
-    },
-    constraint_values = [
-        "@platforms//os:linux",
-    ],
+    name = "build_parameters_lib_yes_windows",
+    flag_values = {":build_parameters_lib": "yes"},
+    constraint_values = ["@platforms//os:windows"],
 )
 
 config_setting(
-    name = "release_dpc_build_parameters_lib_auto_linux",
-    flag_values = {
-        ":build_parameters_lib": "auto",
-        ":release_dpc": "True",
-    },
-    constraint_values = [
-        "@platforms//os:linux",
-    ],
-)
-
-config_setting(
-    name = "release_dpc_build_parameters_lib_yes_linux",
-    flag_values = {
-        ":build_parameters_lib": "yes",
-        ":release_dpc": "True",
-    },
-    constraint_values = [
-        "@platforms//os:linux",
-    ],
+    name = "release_dpc_disabled",
+    flag_values = {":release_dpc": "False"},
 )
 
 build_parameters_lib_validation(
@@ -112,7 +87,7 @@ build_parameters_lib_validation(
     flag = ":build_parameters_lib",
 )
 
-# Toolchain-free target platform used by the analysis-only rejection smoke test.
+# Toolchain-free target platform used by cross-platform analysis smoke tests.
 platform(
     name = "windows_analysis_platform",
     constraint_values = [

--- a/dev/bazel/config/selects.bzl
+++ b/dev/bazel/config/selects.bzl
@@ -1,0 +1,38 @@
+#===============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#===============================================================================
+
+"""Central selects for the BUILD_PARAMETERS_LIB layout."""
+
+
+def parameters_lib_enabled(values):
+    """Returns values when parameter libraries use the separate layout."""
+    return select({
+        "@config//:build_parameters_lib_auto_linux": values,
+        "@config//:build_parameters_lib_yes_linux": values,
+        "//conditions:default": [],
+    })
+
+
+def parameters_lib_disabled(values):
+    """Returns values when parameter objects must be folded into main libs."""
+    return select({
+        "@config//:build_parameters_lib_auto_linux": [],
+        "@config//:build_parameters_lib_yes_linux": [],
+        "//conditions:default": values,
+    })
+
+
+def release_dpc_parameters_lib_enabled(values):
+    """Returns values when both DPC release and separate parameters are enabled."""
+    return select({
+        "@config//:release_dpc_build_parameters_lib_auto_linux": values,
+        "@config//:release_dpc_build_parameters_lib_yes_linux": values,
+        "//conditions:default": [],
+    })

--- a/dev/bazel/config/selects.bzl
+++ b/dev/bazel/config/selects.bzl
@@ -6,6 +6,12 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #===============================================================================
 
 """Central selects for the BUILD_PARAMETERS_LIB layout."""

--- a/dev/bazel/config/selects.bzl
+++ b/dev/bazel/config/selects.bzl
@@ -10,29 +10,39 @@
 
 """Central selects for the BUILD_PARAMETERS_LIB layout."""
 
+_FOLDED = [
+    "@config//:build_parameters_lib_auto_windows",
+    "@config//:build_parameters_lib_yes_windows",
+    "@config//:build_parameters_lib_no",
+]
 
 def parameters_lib_enabled(values):
-    """Returns values when parameter libraries use the separate layout."""
-    return select({
-        "@config//:build_parameters_lib_auto_linux": values,
-        "@config//:build_parameters_lib_yes_linux": values,
-        "//conditions:default": [],
-    })
-
+    """Values for separate layout: auto on non-Windows, or explicit yes."""
+    choices = {setting: [] for setting in _FOLDED}
+    choices["//conditions:default"] = values
+    return select(choices)
 
 def parameters_lib_disabled(values):
-    """Returns values when parameter objects must be folded into main libs."""
-    return select({
-        "@config//:build_parameters_lib_auto_linux": [],
-        "@config//:build_parameters_lib_yes_linux": [],
-        "//conditions:default": values,
-    })
+    """Values for folded layout: no, and auto/unsupported yes on Windows."""
+    choices = {setting: values for setting in _FOLDED}
+    choices["//conditions:default"] = []
+    return select(choices)
 
+def parameters_lib_target_compatible_with():
+    """Reject public parameter-library targets when the layout is folded."""
+    choices = {setting: ["@platforms//:incompatible"] for setting in _FOLDED}
+    choices["//conditions:default"] = []
+    return select(choices)
+
+def parameters_lib_separate_value():
+    """Boolean metadata value for the selected release layout."""
+    choices = {setting: False for setting in _FOLDED}
+    choices["//conditions:default"] = True
+    return select(choices)
 
 def release_dpc_parameters_lib_enabled(values):
-    """Returns values when both DPC release and separate parameters are enabled."""
-    return select({
-        "@config//:release_dpc_build_parameters_lib_auto_linux": values,
-        "@config//:release_dpc_build_parameters_lib_yes_linux": values,
-        "//conditions:default": [],
-    })
+    """Values when DPC release and separate parameters are both enabled."""
+    choices = {setting: [] for setting in _FOLDED}
+    choices["@config//:release_dpc_disabled"] = []
+    choices["//conditions:default"] = values
+    return select(choices)

--- a/dev/bazel/dal.bzl
+++ b/dev/bazel/dal.bzl
@@ -144,7 +144,7 @@ def dal_static_lib(name, lib_name, dal_deps=[], host_deps=[],
     )
 
 def dal_dynamic_lib(name, lib_name, dal_deps=[], host_deps=[],
-                    dpc_deps=[], extra_deps=[], lib_tags=["dal"],
+                    dpc_deps=[], dpc_host_deps=[], extra_deps=[], lib_tags=["dal"],
                     dpc_lib_tags=None, features=[], **kwargs):
     cc_dynamic_lib(
         name = name,
@@ -158,9 +158,10 @@ def dal_dynamic_lib(name, lib_name, dal_deps=[], host_deps=[],
         features = features + [ "dpc++" ],
         lib_name = lib_name + "_dpc",
         lib_tags = dpc_lib_tags if dpc_lib_tags != None else lib_tags,
-        # Some dynamic DPC libraries also need host-only objects, e.g. the
-        # Windows delay-load shim for DAAL threading symbols.
-        deps = _get_dpc_deps(dal_deps) + extra_deps + dpc_deps + host_deps,
+        # dpc_host_deps is reserved for platform glue compiled as host code
+        # into a DPC library. Never forward ordinary host_deps here: doing so
+        # folds host parameter objects into the DPC library as duplicates.
+        deps = _get_dpc_deps(dal_deps) + extra_deps + dpc_deps + dpc_host_deps,
         **kwargs
     )
 

--- a/dev/bazel/deps/onedal.bzl
+++ b/dev/bazel/deps/onedal.bzl
@@ -25,7 +25,6 @@ onedal_repo = repos.prebuilt_libs_repo_rule(
         "lib/intel64/libonedal_core.a",
         "lib/intel64/libonedal_thread.a",
         "lib/intel64/libonedal.a",
-        "lib/intel64/libonedal_parameters.a",
 
         # Dynamic
         "lib/intel64/libonedal_core.so",
@@ -40,6 +39,9 @@ onedal_repo = repos.prebuilt_libs_repo_rule(
         "lib/intel64/libonedal_dpc.so",
         "lib/intel64/libonedal_dpc.so.%{version_binary_major}",
         "lib/intel64/libonedal_dpc.so.%{version_binary_major}.%{version_binary_minor}",
+    ],
+    optional_libs = [
+        "lib/intel64/libonedal_parameters.a",
         "lib/intel64/libonedal_parameters.so",
         "lib/intel64/libonedal_parameters.so.%{version_binary_major}",
         "lib/intel64/libonedal_parameters.so.%{version_binary_major}.%{version_binary_minor}",

--- a/dev/bazel/deps/onedal.tpl.BUILD
+++ b/dev/bazel/deps/onedal.tpl.BUILD
@@ -46,17 +46,8 @@ cc_library(
     ],
 )
 
-cc_library(
-    name = "onedal_static_dpc",
-    srcs = [
-        "lib/intel64/libonedal_dpc.a",
-%{parameters_dpc_static_src}
-    ],
-    deps = [
-        ":headers",
-        "@mkl//:mkl_dpc",
-    ],
-)
+# Packaged oneDAL releases expose DPC libraries only in dynamic form, so no
+# static-DPC consumer target is declared here.
 
 cc_library(
     name = "core_dynamic",

--- a/dev/bazel/deps/onedal.tpl.BUILD
+++ b/dev/bazel/deps/onedal.tpl.BUILD
@@ -39,7 +39,7 @@ cc_library(
     name = "onedal_static",
     srcs = [
         "lib/intel64/libonedal.a",
-        "lib/intel64/libonedal_parameters.a",
+%{parameters_static_src}
     ],
     deps = [
         ":headers",
@@ -50,7 +50,7 @@ cc_library(
     name = "onedal_static_dpc",
     srcs = [
         "lib/intel64/libonedal_dpc.a",
-        "lib/intel64/libonedal_parameters_dpc.a",
+%{parameters_dpc_static_src}
     ],
     deps = [
         ":headers",
@@ -103,7 +103,7 @@ cc_library(
         # Link through the SONAME symlinks. Bazel's _solib runfiles then expose
         # names like libonedal.so.4, matching DT_NEEDED in test executables.
         "lib/intel64/libonedal.so.%{version_binary_major}",
-        "lib/intel64/libonedal_parameters.so.%{version_binary_major}",
+%{parameters_dynamic_src}
     ]),
     deps = [
         ":headers",
@@ -123,8 +123,8 @@ cc_library(
     name = "onedal_dynamic_dpc",
     srcs = glob([
         "lib/intel64/libonedal_dpc.so.%{version_binary_major}",
-        # Link through the SONAME symlink for the same _solib/runfiles reason.
-        "lib/intel64/libonedal_parameters_dpc.so.%{version_binary_major}",
+%{parameters_dpc_dynamic_src}
+        # The optional parameter SONAME follows generated package metadata.
     ], allow_empty=True),
     deps = [
         ":headers",

--- a/dev/bazel/repos.bzl
+++ b/dev/bazel/repos.bzl
@@ -200,7 +200,6 @@ def _prebuilt_libs_repo_impl(repo_ctx):
         parameters_lib = "yes"
     substitutions["%{parameters_static_src}"] = ("        \"lib/intel64/libonedal_parameters.a\"," if parameters_lib == "yes" else "")
     substitutions["%{parameters_dynamic_src}"] = ("        \"lib/intel64/libonedal_parameters.so.{}\",".format(_BINARY_MAJOR) if parameters_lib == "yes" else "")
-    substitutions["%{parameters_dpc_static_src}"] = ("        \"lib/intel64/libonedal_parameters_dpc.a\"," if parameters_lib == "yes" else "")
     substitutions["%{parameters_dpc_dynamic_src}"] = ("        \"lib/intel64/libonedal_parameters_dpc.so.{}\",".format(_BINARY_MAJOR) if parameters_lib == "yes" else "")
 
     _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "includes", os_id), substitutions, mapping)

--- a/dev/bazel/repos.bzl
+++ b/dev/bazel/repos.bzl
@@ -188,9 +188,25 @@ def _prebuilt_libs_repo_impl(repo_ctx):
     }
     substitutions["%{version_binary_major}"] = _BINARY_MAJOR
     substitutions["%{version_binary_minor}"] = _BINARY_MINOR
+    cmake_config = repo_ctx.path(paths.join(root, "lib/cmake/oneDAL/oneDALConfig.cmake"))
+    cmake_config_text = repo_ctx.read(cmake_config) if cmake_config.exists else ""
+    if 'set(ONEDAL_USE_PARAMETERS_LIBRARY "no")' in cmake_config_text:
+        parameters_lib = "no"
+    elif 'set(ONEDAL_USE_PARAMETERS_LIBRARY "yes")' in cmake_config_text:
+        parameters_lib = "yes"
+    else:
+        # Legacy packages predate explicit layout metadata and always used the
+        # separate non-Windows layout consumed by this template.
+        parameters_lib = "yes"
+    substitutions["%{parameters_static_src}"] = ("        \"lib/intel64/libonedal_parameters.a\"," if parameters_lib == "yes" else "")
+    substitutions["%{parameters_dynamic_src}"] = ("        \"lib/intel64/libonedal_parameters.so.{}\",".format(_BINARY_MAJOR) if parameters_lib == "yes" else "")
+    substitutions["%{parameters_dpc_static_src}"] = ("        \"lib/intel64/libonedal_parameters_dpc.a\"," if parameters_lib == "yes" else "")
+    substitutions["%{parameters_dpc_dynamic_src}"] = ("        \"lib/intel64/libonedal_parameters_dpc.so.{}\",".format(_BINARY_MAJOR) if parameters_lib == "yes" else "")
 
     _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "includes", os_id), substitutions, mapping)
     _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "libs", os_id), substitutions, mapping)
+    if parameters_lib == "yes":
+        _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "optional_libs", os_id), substitutions, mapping)
     _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "bins", os_id), substitutions, mapping)
     repo_ctx.template(
         "BUILD",
@@ -198,7 +214,7 @@ def _prebuilt_libs_repo_impl(repo_ctx):
         substitutions = substitutions,
     )
 
-def _prebuilt_libs_repo_rule(includes, libs, build_template, bins=[],
+def _prebuilt_libs_repo_rule(includes, libs, build_template, bins=[], optional_libs=[],
                              root_env_var="", fallback_root="",
                              url="", sha256="", strip_prefix="",
                              local_mapping={}, download_mapping={},
@@ -223,6 +239,7 @@ def _prebuilt_libs_repo_rule(includes, libs, build_template, bins=[],
             "strip_prefixes": attr.string_list(default=[]),
             "includes": attr.string_list(default=includes),
             "libs": attr.string_list(default=libs),
+            "optional_libs": attr.string_list(default=optional_libs),
             "bins": attr.string_list(default=bins),
             "build_template": attr.label(allow_files=True,
                                          default=Label(build_template)),

--- a/dev/bazel/scripts.bzl
+++ b/dev/bazel/scripts.bzl
@@ -164,7 +164,8 @@ Cflags: /std:c++17 /MD /wd4996 /EHsc -I${{includedir}}
     else:
         suffix = "a" if ctx.attr.static else "so"
         if ctx.attr.parameters_lib:
-            onedal_libs = "${{libdir}}/libonedal.{0} ${{libdir}}/libonedal_core.{0} ${{libdir}}/libonedal_thread.{0} ${{libdir}}/libonedal_parameters.{0} -lmkl_core -lmkl_intel_lp64 -lmkl_tbb_thread -ltbb -ltbbmalloc -lpthread -ldl".format(suffix)
+            mkl_interface = "intel_ilp64" if ctx.attr.static else "intel_lp64"
+            onedal_libs = "${{libdir}}/libonedal.{0} ${{libdir}}/libonedal_core.{0} ${{libdir}}/libonedal_thread.{0} ${{libdir}}/libonedal_parameters.{0} -lmkl_core -lmkl_{1} -lmkl_tbb_thread -ltbb -ltbbmalloc -lpthread -ldl".format(suffix, mkl_interface)
         else:
             mkl_interface = "intel_ilp64" if ctx.attr.static else "intel_lp64"
             openmp = " -lgomp" if not ctx.attr.static else ""

--- a/dev/bazel/scripts.bzl
+++ b/dev/bazel/scripts.bzl
@@ -138,7 +138,7 @@ def _generate_pkgconfig_impl(ctx):
         onedal_libs = (
             "${libdir}/onedal.lib ${libdir}/onedal_core.lib ${libdir}/onedal_thread.lib"
             if ctx.attr.static else
-            "${libdir}/onedal_dll.lib{} ${libdir}/onedal_core_dll.lib".format(
+            "${{libdir}}/onedal_dll.lib{} ${{libdir}}/onedal_core_dll.lib".format(
                 " ${libdir}/onedal_parameters_dll.lib" if ctx.attr.parameters_lib else "",
             )
         )

--- a/dev/bazel/scripts.bzl
+++ b/dev/bazel/scripts.bzl
@@ -96,6 +96,7 @@ def _generate_cmake_config_impl(ctx):
             "@DLL_REL_PATH@": "redist",
             "@INC_REL_PATH@": "include",
             "@oneDAL_VERSION@": "",
+            "@ONEDAL_USE_PARAMETERS_LIBRARY@": "yes" if ctx.attr.parameters_lib else "no",
         },
     )
     return [DefaultInfo(files = depset([out]))]
@@ -108,6 +109,7 @@ _generate_cmake_config = rule(
             mandatory = True,
         ),
         "out": attr.string(mandatory = True),
+        "parameters_lib": attr.bool(default = True),
         "_version_info": attr.label(
             default = "@config//:version",
             providers = [VersionInfo],
@@ -136,7 +138,9 @@ def _generate_pkgconfig_impl(ctx):
         onedal_libs = (
             "${libdir}/onedal.lib ${libdir}/onedal_core.lib ${libdir}/onedal_thread.lib"
             if ctx.attr.static else
-            "${libdir}/onedal_dll.lib ${libdir}/onedal_parameters_dll.lib ${libdir}/onedal_core_dll.lib"
+            "${libdir}/onedal_dll.lib{} ${libdir}/onedal_core_dll.lib".format(
+                " ${libdir}/onedal_parameters_dll.lib" if ctx.attr.parameters_lib else "",
+            )
         )
         ctx.actions.write(
             output = out,
@@ -159,6 +163,12 @@ Cflags: /std:c++17 /MD /wd4996 /EHsc -I${{includedir}}
         )
     else:
         suffix = "a" if ctx.attr.static else "so"
+        if ctx.attr.parameters_lib:
+            onedal_libs = "${{libdir}}/libonedal.{0} ${{libdir}}/libonedal_core.{0} ${{libdir}}/libonedal_thread.{0} ${{libdir}}/libonedal_parameters.{0} -lmkl_core -lmkl_intel_lp64 -lmkl_tbb_thread -ltbb -ltbbmalloc -lpthread -ldl".format(suffix)
+        else:
+            mkl_interface = "intel_ilp64" if ctx.attr.static else "intel_lp64"
+            openmp = " -lgomp" if not ctx.attr.static else ""
+            onedal_libs = "-Wl,--start-group ${{libdir}}/libonedal.{0} ${{libdir}}/libonedal_core.{0} ${{libdir}}/libonedal_thread.{0} -lmkl_{1} -lmkl_tbb_thread -lmkl_core -Wl,--end-group -ltbb -ltbbmalloc -lpthread{2} -ldl".format(suffix, mkl_interface, openmp)
         ctx.actions.write(
             output = out,
             content = """#===============================================================================
@@ -185,12 +195,13 @@ Name: oneDAL
 Description: oneAPI Data Analytics Library
 Version: {major}.{minor}
 URL: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onedal.html
-Libs: ${{libdir}}/libonedal.{suffix} ${{libdir}}/libonedal_core.{suffix} ${{libdir}}/libonedal_thread.{suffix} ${{libdir}}/libonedal_parameters.{suffix} -lmkl_core -lmkl_intel_lp64 -lmkl_tbb_thread -ltbb -ltbbmalloc -lpthread -ldl
+Libs: {onedal_libs}
 Cflags: -std=c++17 -Wno-deprecated-declarations -I${{includedir}}
 """.format(
                 major = vi.major,
                 minor = vi.minor,
                 suffix = suffix,
+                onedal_libs = onedal_libs,
             ),
         )
     return [DefaultInfo(files = depset([out]))]
@@ -211,6 +222,7 @@ _generate_pkgconfig = rule(
             default = False,
             doc = "Generate a static-library pkg-config file.",
         ),
+        "parameters_lib": attr.bool(default = True),
         "_version_info": attr.label(
             default = "@config//:version",
             providers = [VersionInfo],

--- a/dev/bazel/tests/BUILD
+++ b/dev/bazel/tests/BUILD
@@ -4,4 +4,5 @@ exports_files([
     "release_structure_test.sh",
     "isa_coverage_test.sh",
     "mkl_linkage_test.sh",
+    "parameters_layout_test.sh",
 ])

--- a/dev/bazel/tests/parameters_layout_test.sh
+++ b/dev/bazel/tests/parameters_layout_test.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+#===============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
 # Cheap configured-graph validation for BUILD_PARAMETERS_LIB layouts.
 set -euo pipefail
 

--- a/dev/bazel/tests/parameters_layout_test.sh
+++ b/dev/bazel/tests/parameters_layout_test.sh
@@ -18,15 +18,29 @@ if grep -E ':(static|dynamic)_parameters(_dpc)?$' "${work}/no"; then
     echo "folded release still exposes parameter-library artifacts" >&2
     exit 1
 fi
+host_parameter_modules=(
+    //cpp/oneapi/dal/algo:parameters
+    //cpp/oneapi/dal/detail/parameters
+)
+dpc_parameter_modules=(
+    //cpp/oneapi/dal/algo:parameters_dpc
+    //cpp/oneapi/dal/detail/parameters:parameters_dpc
+)
 for label in //cpp/oneapi/dal:static //cpp/oneapi/dal:dynamic; do
-    query "somepath(${label}, //cpp/oneapi/dal/algo:parameters)" --build_parameters_lib=no | grep -q .
+    for module in "${host_parameter_modules[@]}"; do
+        query "somepath(${label}, ${module})" --build_parameters_lib=no | grep -q .
+    done
 done
 for label in //cpp/oneapi/dal:static_dpc //cpp/oneapi/dal:dynamic_dpc; do
-    if query "somepath(${label}, //cpp/oneapi/dal/algo:parameters)" --build_parameters_lib=no | grep -q .; then
-        echo "${label} depends on host parameter modules" >&2
-        exit 1
-    fi
-    query "somepath(${label}, //cpp/oneapi/dal/algo:parameters_dpc)" --build_parameters_lib=no | grep -q .
+    for module in "${host_parameter_modules[@]}"; do
+        if query "somepath(${label}, ${module})" --build_parameters_lib=no | grep -q .; then
+            echo "${label} depends on host parameter module ${module}" >&2
+            exit 1
+        fi
+    done
+    for module in "${dpc_parameter_modules[@]}"; do
+        query "somepath(${label}, ${module})" --build_parameters_lib=no | grep -q .
+    done
 done
 
 for label in static_parameters static_parameters_dpc dynamic_parameters dynamic_parameters_dpc; do

--- a/dev/bazel/tests/parameters_layout_test.sh
+++ b/dev/bazel/tests/parameters_layout_test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Cheap configured-graph validation for BUILD_PARAMETERS_LIB layouts.
+set -euo pipefail
+
+bazel_cmd="${BAZEL:-bazel}"
+common=(--noshow_progress --cpu=avx2)
+query() { "${bazel_cmd}" cquery "$1" "${common[@]}" "${@:2}" --output=label 2>/dev/null | awk '{print $1}' | sort -u; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+query 'labels(lib, //:release)' --build_parameters_lib=auto >"${work}/auto"
+query 'labels(lib, //:release)' --build_parameters_lib=yes >"${work}/yes"
+cmp "${work}/auto" "${work}/yes"
+
+query 'labels(lib, //:release)' --build_parameters_lib=no >"${work}/no"
+if grep -E ':(static|dynamic)_parameters(_dpc)?$' "${work}/no"; then
+    echo "folded release still exposes parameter-library artifacts" >&2
+    exit 1
+fi
+for label in //cpp/oneapi/dal:static //cpp/oneapi/dal:dynamic; do
+    query "somepath(${label}, //cpp/oneapi/dal/algo:parameters)" --build_parameters_lib=no | grep -q .
+done
+for label in //cpp/oneapi/dal:static_dpc //cpp/oneapi/dal:dynamic_dpc; do
+    if query "somepath(${label}, //cpp/oneapi/dal/algo:parameters)" --build_parameters_lib=no | grep -q .; then
+        echo "${label} depends on host parameter modules" >&2
+        exit 1
+    fi
+    query "somepath(${label}, //cpp/oneapi/dal/algo:parameters_dpc)" --build_parameters_lib=no | grep -q .
+done
+
+for label in static_parameters static_parameters_dpc dynamic_parameters dynamic_parameters_dpc; do
+    if "${bazel_cmd}" build "//cpp/oneapi/dal:${label}" "${common[@]}" --nobuild \
+        --build_parameters_lib=no >"${work}/${label}.log" 2>&1; then
+        echo "folded layout unexpectedly permits direct target ${label}" >&2
+        exit 1
+    fi
+    grep -qi 'incompatible' "${work}/${label}.log"
+done
+
+if "${bazel_cmd}" cquery @config//:validate_build_parameters_lib \
+    --platforms=@config//:windows_analysis_platform --build_parameters_lib=yes \
+    --noshow_progress >"${work}/windows.log" 2>&1; then
+    echo "Windows --build_parameters_lib=yes unexpectedly passed validation" >&2
+    exit 1
+fi
+grep -Fq -- '--build_parameters_lib=yes is not supported on Windows' "${work}/windows.log"
+
+echo "BUILD_PARAMETERS_LIB configured-graph checks passed"

--- a/dev/release_tests/BUILD
+++ b/dev/release_tests/BUILD
@@ -2,4 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "package_metadata_test.sh",
+    "parameters_layout_consumer_test.sh",
 ])

--- a/dev/release_tests/parameters_layout_consumer_test.sh
+++ b/dev/release_tests/parameters_layout_consumer_test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Linux packaged-consumer smoke for a folded (BUILD_PARAMETERS_LIB=no) release.
+set -euo pipefail
+
+DALROOT="$(cd "${1:?usage: parameters_layout_consumer_test.sh DALROOT [source-root]}" && pwd)"
+SOURCE_ROOT="$(cd "${2:-$(dirname "$0")/../..}" && pwd)"
+BAZEL_CMD="${BAZEL:-bazel}"
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+! find "${DALROOT}/lib" -type f -o -type l | grep -q 'onedal_parameters'
+grep -Fq 'set(ONEDAL_USE_PARAMETERS_LIBRARY "no")' "${DALROOT}/lib/cmake/oneDAL/oneDALConfig.cmake"
+! grep -q 'onedal_parameters' "${DALROOT}/lib/pkgconfig/"*.pc
+
+cat >"${work}/smoke.cpp" <<'CPP'
+#include <cstdint>
+#include "oneapi/dal/table/homogen.hpp"
+int main() {
+    float data[] = { 1.0f, 2.0f };
+    const auto table = oneapi::dal::homogen_table::wrap(data, 1, 2);
+    return table.get_row_count() == 1 && table.get_column_count() == 2 ? 0 : 1;
+}
+CPP
+
+cat >"${work}/CMakeLists.txt" <<'CMAKE'
+cmake_minimum_required(VERSION 3.16)
+project(onedal_folded_consumer LANGUAGES CXX)
+find_package(oneDAL REQUIRED CONFIG)
+add_executable(smoke smoke.cpp)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(smoke PRIVATE -Wl,--start-group ${oneDAL_IMPORTED_TARGETS} -Wl,--end-group)
+else()
+    target_link_libraries(smoke PRIVATE ${oneDAL_IMPORTED_TARGETS})
+endif()
+CMAKE
+cmake_dependency_args=()
+if [[ -n "${TBBROOT:-}" && -f "${TBBROOT}/lib/cmake/tbb/TBBConfig.cmake" ]]; then
+    cmake_dependency_args+=("-DTBB_DIR=${TBBROOT}/lib/cmake/tbb")
+fi
+for mode in static dynamic; do
+    cmake -S "${work}" -B "${work}/cmake-${mode}" \
+        -DoneDAL_DIR="${DALROOT}/lib/cmake/oneDAL" \
+        -DONEDAL_LINK="${mode}" -DONEDAL_USE_DPCPP=no -DONEDAL_INTERFACE=yes \
+        "${cmake_dependency_args[@]}"
+    cmake --build "${work}/cmake-${mode}" --parallel 2
+    LD_LIBRARY_PATH="${DALROOT}/lib/intel64:${LD_LIBRARY_PATH:-}" "${work}/cmake-${mode}/smoke"
+done
+
+export PKG_CONFIG_PATH="${DALROOT}/lib/pkgconfig"
+if [[ -n "${MKLROOT:-}" ]]; then
+    export LIBRARY_PATH="${MKLROOT}/lib:${LIBRARY_PATH:-}"
+fi
+if [[ -n "${TBBROOT:-}" ]]; then
+    export LIBRARY_PATH="${TBBROOT}/lib:${LIBRARY_PATH:-}"
+fi
+for pc in dal-dynamic-threading-host dal-static-threading-host; do
+    c++ "${work}/smoke.cpp" -o "${work}/pkg-${pc}" $(pkg-config --cflags --libs "${pc}")
+    LD_LIBRARY_PATH="${DALROOT}/lib/intel64:${LD_LIBRARY_PATH:-}" "${work}/pkg-${pc}"
+done
+
+cat >"${work}/MODULE.bazel" <<EOF
+module(name = "onedal_folded_consumer")
+bazel_dep(name = "onedal", version = "0.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+local_path_override(module_name = "onedal", path = "${SOURCE_ROOT}")
+tbb_repo = use_repo_rule("@onedal//dev/bazel/deps:tbb.bzl", "tbb_repo")
+tbb_repo(name = "tbb", root_env_var = "TBBROOT")
+mkl_repo = use_repo_rule("@onedal//dev/bazel/deps:mkl.bzl", "mkl_repo")
+mkl_repo(name = "mkl", root_env_var = "MKLROOT")
+onedal_repo = use_repo_rule("@onedal//dev/bazel/deps:onedal.bzl", "onedal_repo")
+onedal_repo(name = "onedal_release", root_env_var = "DALROOT")
+EOF
+cat >"${work}/BUILD" <<'BUILD'
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+cc_binary(
+    name = "static",
+    srcs = ["smoke.cpp"],
+    deps = [
+        "@onedal_release//:onedal_static",
+        "@onedal_release//:core_static",
+        "@onedal_release//:thread_static",
+    ],
+)
+cc_binary(
+    name = "dynamic",
+    srcs = ["smoke.cpp"],
+    deps = [
+        "@onedal_release//:onedal_dynamic",
+        "@onedal_release//:core_dynamic",
+        "@onedal_release//:thread_dynamic",
+    ],
+)
+BUILD
+(
+    cd "${work}"
+    DALROOT="${DALROOT}" "${BAZEL_CMD}" build //:static //:dynamic --noshow_progress --show_result=0
+    DALROOT="${DALROOT}" "${BAZEL_CMD}" run //:static --noshow_progress --show_result=0
+    DALROOT="${DALROOT}" "${BAZEL_CMD}" run //:dynamic --noshow_progress --show_result=0
+)
+
+echo "Folded packaged CMake, pkg-config, and Bazel consumers passed"

--- a/dev/release_tests/parameters_layout_consumer_test.sh
+++ b/dev/release_tests/parameters_layout_consumer_test.sh
@@ -13,12 +13,18 @@ grep -Fq 'set(ONEDAL_USE_PARAMETERS_LIBRARY "no")' "${DALROOT}/lib/cmake/oneDAL/
 ! grep -q 'onedal_parameters' "${DALROOT}/lib/pkgconfig/"*.pc
 
 cat >"${work}/smoke.cpp" <<'CPP'
-#include <cstdint>
+#include "oneapi/dal/algo/covariance.hpp"
 #include "oneapi/dal/table/homogen.hpp"
+
 int main() {
-    float data[] = { 1.0f, 2.0f };
-    const auto table = oneapi::dal::homogen_table::wrap(data, 1, 2);
-    return table.get_row_count() == 1 && table.get_column_count() == 2 ? 0 : 1;
+    namespace dal = oneapi::dal;
+    float data[] = { 1.0f, 2.0f, 3.0f, 4.0f };
+    const auto input = dal::homogen_table::wrap(data, 2, 2);
+    const auto descriptor = dal::covariance::descriptor<float>{}.set_result_options(
+        dal::covariance::result_options::cov_matrix);
+    const auto result = dal::compute(descriptor, input);
+    const auto& covariance = result.get_cov_matrix();
+    return covariance.get_row_count() == 2 && covariance.get_column_count() == 2 ? 0 : 1;
 }
 CPP
 

--- a/dev/release_tests/parameters_layout_consumer_test.sh
+++ b/dev/release_tests/parameters_layout_consumer_test.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+#===============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
 # Linux packaged-consumer smoke for a folded (BUILD_PARAMETERS_LIB=no) release.
 set -euo pipefail
 

--- a/makefile
+++ b/makefile
@@ -1100,7 +1100,7 @@ $(foreach t,$(releasetbb.LIBS_A),$(eval $(call .release.t,$t,$(RELEASEDIR.tbb.li
 #----- cmake configs generation
 
 _release_cmake_configs:
-	$(if $(shell bash -c "command -v cmake"),cmake -DINSTALL_DIR=$(RELEASEDIR.lib)/cmake/oneDAL -DARCH_DIR_ONEDAL=$(ARCH_DIR_ONEDAL) -P cmake/scripts/generate_config.cmake,echo 'cmake configs generation skipped')
+	$(if $(shell bash -c "command -v cmake"),cmake -DINSTALL_DIR=$(RELEASEDIR.lib)/cmake/oneDAL -DARCH_DIR_ONEDAL=$(ARCH_DIR_ONEDAL) -DONEDAL_USE_PARAMETERS_LIBRARY=$(BUILD_PARAMETERS_LIB) -P cmake/scripts/generate_config.cmake,echo 'cmake configs generation skipped')
 
 #----- nuspecs generation
 _release_common: _release_nuspec


### PR DESCRIPTION
## Description

Adds Bazel control for the parameter-library layout to match the existing Make `BUILD_PARAMETERS_LIB` behavior.

- adds `--build_parameters_lib=auto|yes|no`;
- preserves platform defaults (`auto`: separate libraries on non-Windows, folded into the main libraries on Windows);
- rejects `yes` on Windows during analysis;
- keeps host and DPC parameter objects separated;
- makes release CMake, pkg-config, and Bazel consumer metadata match the selected layout;
- disables conflicting direct parameter-library targets in folded mode;
- removes the unsupported prebuilt static-DPC consumer target (release packages provide dynamic DPC libraries).

Part of #3530.

## Validation

- configured graph checks for host/DPC and `auto|yes|no` layouts;
- Windows `yes` analysis rejection;
- host static and dynamic consumers;
- folded release package consumers via CMake static/dynamic, pkg-config, and Bazel;
- real DPC++ builds for separate and folded layouts;
- symbol placement proof:
  - separate: `system_parameters::dump` absent from `libonedal_dpc.so`, present in `libonedal_parameters_dpc.so`;
  - folded: symbol present in `libonedal_dpc.so`;
- shell/YAML checks, `git diff --check`, clean worktree;
- independent architecture/build-system review: APPROVE.
