### PR TITLE
[enhancement] add ability to set external `MPI_Comm` for sub-communicator support (sklearnex dask integration)

### DIFF
--- a/cpp/oneapi/dal/detail/mpi/communicator.hpp
+++ b/cpp/oneapi/dal/detail/mpi/communicator.hpp
@@ -395,7 +395,7 @@ public:
                   new mpi_communicator_impl<MemoryAccessKind>(queue, default_root)) {}
 
     template <typename T = MemoryAccessKind,
-            typename = spmd::enable_if_device_memory_accessible_t<T>>
+              typename = spmd::enable_if_device_memory_accessible_t<T>>
     explicit mpi_communicator(sycl::queue& queue, MPI_Comm comm, std::int64_t default_root = 0)
             : spmd::communicator<MemoryAccessKind>(
                   new mpi_communicator_impl<MemoryAccessKind>(queue, comm, default_root)) {}
@@ -404,10 +404,10 @@ public:
             : spmd::communicator<MemoryAccessKind>(
                   new mpi_communicator_impl<MemoryAccessKind>(default_root)) {}
 };
-  
-    explicit mpi_communicator(MPI_Comm comm, std::int64_t default_root = 0)
-            : spmd::communicator<MemoryAccessKind>(
-                  new mpi_communicator_impl<MemoryAccessKind>(comm, default_root)) {}
+
+explicit mpi_communicator(MPI_Comm comm, std::int64_t default_root = 0)
+        : spmd::communicator<MemoryAccessKind>(
+              new mpi_communicator_impl<MemoryAccessKind>(comm, default_root)) {}
 
 } // namespace v1
 

--- a/cpp/oneapi/dal/detail/mpi/communicator.hpp
+++ b/cpp/oneapi/dal/detail/mpi/communicator.hpp
@@ -403,11 +403,11 @@ public:
     explicit mpi_communicator(std::int64_t default_root = 0)
             : spmd::communicator<MemoryAccessKind>(
                   new mpi_communicator_impl<MemoryAccessKind>(default_root)) {}
-};
 
-explicit mpi_communicator(MPI_Comm comm, std::int64_t default_root = 0)
-        : spmd::communicator<MemoryAccessKind>(
-              new mpi_communicator_impl<MemoryAccessKind>(comm, default_root)) {}
+    explicit mpi_communicator(MPI_Comm comm, std::int64_t default_root = 0)
+            : spmd::communicator<MemoryAccessKind>(
+                  new mpi_communicator_impl<MemoryAccessKind>(comm, default_root)) {}
+};
 
 } // namespace v1
 

--- a/cpp/oneapi/dal/detail/mpi/communicator.hpp
+++ b/cpp/oneapi/dal/detail/mpi/communicator.hpp
@@ -120,9 +120,9 @@ public:
             : mpi_comm_(MPI_COMM_WORLD),
               default_root_(default_root) {}
 
-  explicit mpi_communicator_impl(MPI_Comm comm, std::int64_t default_root = 0)
-          : mpi_comm_(comm),
-            default_root_(default_root) {}
+    explicit mpi_communicator_impl(MPI_Comm comm, std::int64_t default_root = 0)
+            : mpi_comm_(comm),
+              default_root_(default_root) {}
 
 #ifdef ONEDAL_DATA_PARALLEL
     //    template<typename T = MemoryAccessKind, spmd::enable_if_device_memory_accessible_t<T>>

--- a/cpp/oneapi/dal/detail/mpi/communicator.hpp
+++ b/cpp/oneapi/dal/detail/mpi/communicator.hpp
@@ -120,11 +120,20 @@ public:
             : mpi_comm_(MPI_COMM_WORLD),
               default_root_(default_root) {}
 
+  explicit mpi_communicator_impl(MPI_Comm comm, std::int64_t default_root = 0)
+          : mpi_comm_(comm),
+            default_root_(default_root) {}
+
 #ifdef ONEDAL_DATA_PARALLEL
     //    template<typename T = MemoryAccessKind, spmd::enable_if_device_memory_accessible_t<T>>
     explicit mpi_communicator_impl(sycl::queue& queue, std::int64_t default_root = 0)
             : base_t(queue),
               mpi_comm_(MPI_COMM_WORLD),
+              default_root_(default_root) {}
+
+    explicit mpi_communicator_impl(sycl::queue& queue, MPI_Comm comm, std::int64_t default_root = 0)
+            : base_t(queue),
+              mpi_comm_(comm),
               default_root_(default_root) {}
 #endif
 

--- a/cpp/oneapi/dal/detail/mpi/communicator.hpp
+++ b/cpp/oneapi/dal/detail/mpi/communicator.hpp
@@ -393,11 +393,21 @@ public:
     explicit mpi_communicator(sycl::queue& queue, std::int64_t default_root = 0)
             : spmd::communicator<MemoryAccessKind>(
                   new mpi_communicator_impl<MemoryAccessKind>(queue, default_root)) {}
+
+    template <typename T = MemoryAccessKind,
+            typename = spmd::enable_if_device_memory_accessible_t<T>>
+    explicit mpi_communicator(sycl::queue& queue, MPI_Comm comm, std::int64_t default_root = 0)
+            : spmd::communicator<MemoryAccessKind>(
+                  new mpi_communicator_impl<MemoryAccessKind>(queue, comm, default_root)) {}
 #endif
     explicit mpi_communicator(std::int64_t default_root = 0)
             : spmd::communicator<MemoryAccessKind>(
                   new mpi_communicator_impl<MemoryAccessKind>(default_root)) {}
 };
+  
+    explicit mpi_communicator(MPI_Comm comm, std::int64_t default_root = 0)
+            : spmd::communicator<MemoryAccessKind>(
+                  new mpi_communicator_impl<MemoryAccessKind>(comm, default_root)) {}
 
 } // namespace v1
 

--- a/cpp/oneapi/dal/spmd/communicator.hpp
+++ b/cpp/oneapi/dal/spmd/communicator.hpp
@@ -545,6 +545,13 @@ communicator<device_memory_access::none> make_communicator() {
     throw communication_error(dal::detail::error_messages::unsupported_communicator_backend());
 }
 
+template <typename Backend>
+communicator<device_memory_access::none> make_communicator(std::int64_t comm_handle) {
+    static_assert(!std::is_same_v<Backend, Backend>, "Unsupported communicator backend");
+
+    throw communication_error(dal::detail::error_messages::unsupported_communicator_backend());
+}
+
 #ifdef ONEDAL_DATA_PARALLEL
 template <typename Backend>
 communicator<device_memory_access::usm> make_communicator(sycl::queue& queue) {
@@ -552,6 +559,14 @@ communicator<device_memory_access::usm> make_communicator(sycl::queue& queue) {
 
     throw communication_error(dal::detail::error_messages::unsupported_communicator_backend());
 }
+
+template <typename Backend>
+communicator<device_memory_access::usm> make_communicator(sycl::queue& queue,
+                                                            std::int64_t comm_handle) {
+    static_assert(!std::is_same_v<Backend, Backend>, "Unsupported communicator backend");
+
+    throw communication_error(dal::detail::error_messages::unsupported_communicator_backend());
+  }
 #endif
 
 } // namespace oneapi::dal::preview::spmd

--- a/cpp/oneapi/dal/spmd/communicator.hpp
+++ b/cpp/oneapi/dal/spmd/communicator.hpp
@@ -546,7 +546,7 @@ communicator<device_memory_access::none> make_communicator() {
 }
 
 template <typename Backend>
-communicator<device_memory_access::none> make_communicator(std::int64_t comm_handle) {
+communicator<device_memory_access::none> make_communicator(std::int64_t comm) {
     static_assert(!std::is_same_v<Backend, Backend>, "Unsupported communicator backend");
 
     throw communication_error(dal::detail::error_messages::unsupported_communicator_backend());
@@ -561,8 +561,7 @@ communicator<device_memory_access::usm> make_communicator(sycl::queue& queue) {
 }
 
 template <typename Backend>
-communicator<device_memory_access::usm> make_communicator(sycl::queue& queue,
-                                                          std::int64_t comm_handle) {
+communicator<device_memory_access::usm> make_communicator(sycl::queue& queue, std::int64_t comm) {
     static_assert(!std::is_same_v<Backend, Backend>, "Unsupported communicator backend");
 
     throw communication_error(dal::detail::error_messages::unsupported_communicator_backend());

--- a/cpp/oneapi/dal/spmd/communicator.hpp
+++ b/cpp/oneapi/dal/spmd/communicator.hpp
@@ -562,11 +562,11 @@ communicator<device_memory_access::usm> make_communicator(sycl::queue& queue) {
 
 template <typename Backend>
 communicator<device_memory_access::usm> make_communicator(sycl::queue& queue,
-                                                            std::int64_t comm_handle) {
+                                                          std::int64_t comm_handle) {
     static_assert(!std::is_same_v<Backend, Backend>, "Unsupported communicator backend");
 
     throw communication_error(dal::detail::error_messages::unsupported_communicator_backend());
-  }
+}
 #endif
 
 } // namespace oneapi::dal::preview::spmd

--- a/cpp/oneapi/dal/spmd/mpi/communicator.hpp
+++ b/cpp/oneapi/dal/spmd/mpi/communicator.hpp
@@ -29,10 +29,20 @@ inline communicator<device_memory_access::none> make_communicator<backend::mpi>(
     return dal::detail::mpi_communicator<device_memory_access::none>{};
 }
 
+template <>
+inline communicator<device_memory_access::none> make_communicator<backend::mpi>(MPI_Comm comm) {
+    return dal::detail::mpi_communicator<device_memory_access::none>{ comm };
+}
+
 #ifdef ONEDAL_DATA_PARALLEL
 template <>
 inline communicator<device_memory_access::usm> make_communicator<backend::mpi>(sycl::queue& queue) {
     return dal::detail::mpi_communicator<device_memory_access::usm>{ queue };
+}
+
+template <>
+inline communicator<device_memory_access::usm> make_communicator<backend::mpi>(sycl::queue& queue, MPI_Comm comm) {
+    return dal::detail::mpi_communicator<device_memory_access::usm>{ queue, comm };
 }
 #endif
 

--- a/cpp/oneapi/dal/spmd/mpi/communicator.hpp
+++ b/cpp/oneapi/dal/spmd/mpi/communicator.hpp
@@ -31,6 +31,9 @@ inline communicator<device_memory_access::none> make_communicator<backend::mpi>(
 
 template <>
 inline communicator<device_memory_access::none> make_communicator<backend::mpi>(std::int64_t comm) {
+    // make_communicator takes in a int64 representation of the MPI_comm raw pointer in order
+    // to be as general as possible (for all possible MPI comm sources: from other languages
+    // MPICH vs Intel MPI, generalized architecture support, etc.) by using MPI_Comm_f2c.
     MPI_Comm c = MPI_Comm_f2c(static_cast<MPI_Fint>(comm));
     return dal::detail::mpi_communicator<device_memory_access::none>{ c };
 }

--- a/cpp/oneapi/dal/spmd/mpi/communicator.hpp
+++ b/cpp/oneapi/dal/spmd/mpi/communicator.hpp
@@ -31,7 +31,7 @@ inline communicator<device_memory_access::none> make_communicator<backend::mpi>(
 
 template <>
 inline communicator<device_memory_access::none> make_communicator<backend::mpi>(std::int64_t comm) {
-    MPI_Comm c = MPI_Comm_f2c(static_cast<MPI_Fint>(comm_handle));
+    MPI_Comm c = MPI_Comm_f2c(static_cast<MPI_Fint>(comm));
     return dal::detail::mpi_communicator<device_memory_access::none>{ c };
 }
 

--- a/cpp/oneapi/dal/spmd/mpi/communicator.hpp
+++ b/cpp/oneapi/dal/spmd/mpi/communicator.hpp
@@ -30,8 +30,9 @@ inline communicator<device_memory_access::none> make_communicator<backend::mpi>(
 }
 
 template <>
-inline communicator<device_memory_access::none> make_communicator<backend::mpi>(MPI_Comm comm) {
-    return dal::detail::mpi_communicator<device_memory_access::none>{ comm };
+inline communicator<device_memory_access::none> make_communicator<backend::mpi>(std::int64_t comm) {
+    MPI_Comm c = MPI_Comm_f2c(static_cast<MPI_Fint>(comm_handle));
+    return dal::detail::mpi_communicator<device_memory_access::none>{ c };
 }
 
 #ifdef ONEDAL_DATA_PARALLEL
@@ -41,8 +42,9 @@ inline communicator<device_memory_access::usm> make_communicator<backend::mpi>(s
 }
 
 template <>
-inline communicator<device_memory_access::usm> make_communicator<backend::mpi>(sycl::queue& queue, MPI_Comm comm) {
-    return dal::detail::mpi_communicator<device_memory_access::usm>{ queue, comm };
+inline communicator<device_memory_access::usm> make_communicator<backend::mpi>(sycl::queue& queue, std::int64_t comm) {
+    MPI_Comm c = MPI_Comm_f2c(static_cast<MPI_Fint>(comm));
+    return dal::detail::mpi_communicator<device_memory_access::usm>{ queue, c };
 }
 #endif
 

--- a/cpp/oneapi/dal/spmd/mpi/communicator.hpp
+++ b/cpp/oneapi/dal/spmd/mpi/communicator.hpp
@@ -42,7 +42,8 @@ inline communicator<device_memory_access::usm> make_communicator<backend::mpi>(s
 }
 
 template <>
-inline communicator<device_memory_access::usm> make_communicator<backend::mpi>(sycl::queue& queue, std::int64_t comm) {
+inline communicator<device_memory_access::usm> make_communicator<backend::mpi>(sycl::queue& queue,
+                                                                               std::int64_t comm) {
     MPI_Comm c = MPI_Comm_f2c(static_cast<MPI_Fint>(comm));
     return dal::detail::mpi_communicator<device_memory_access::usm>{ queue, c };
 }

--- a/cpp/oneapi/dal/test/mpi_communicator.cpp
+++ b/cpp/oneapi/dal/test/mpi_communicator.cpp
@@ -14,8 +14,11 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include <mpi.h>
+
 #include "oneapi/dal/test/engine/mpi_global.hpp"
 #include "oneapi/dal/test/engine/fixtures.hpp"
+#include "oneapi/dal/spmd/mpi/communicator.hpp"
 
 namespace spmd = oneapi::dal::preview::spmd;
 
@@ -338,6 +341,35 @@ TEST_M(mpi_comm_test, "allgatherv") {
     for (std::int64_t i = 0; i < total_size; i++) {
         REQUIRE(recv_buffer[i] == final_buffer[i]);
     }
+}
+
+TEST_M(mpi_comm_test, "make_communicator from split MPI_Comm handle") {
+    int world_rank = 0;
+    int world_size = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+    SKIP_IF(world_size < 2);
+
+    const int color = (world_rank < world_size / 2) ? 0 : 1;
+    MPI_Comm split_comm = MPI_COMM_NULL;
+    REQUIRE(MPI_Comm_split(MPI_COMM_WORLD, color, world_rank, &split_comm) == MPI_SUCCESS);
+    const std::int64_t comm_handle = static_cast<std::int64_t>(MPI_Comm_c2f(split_comm));
+
+#ifdef ONEDAL_DATA_PARALLEL
+    auto ext_comm = spmd::make_communicator<spmd::backend::mpi>(get_queue(), comm_handle);
+#else
+    auto ext_comm = spmd::make_communicator<spmd::backend::mpi>(comm_handle);
+#endif
+
+    const int expected_size = (color == 0) ? (world_size / 2) : (world_size - world_size / 2);
+    REQUIRE(ext_comm.get_rank_count() == expected_size);
+
+    // Ensure the wrapped sub-communicator can drive a collective end-to-end.
+    float value = 1.0f;
+    ext_comm.allreduce(value, spmd::reduce_op::sum).wait();
+    REQUIRE(value == float(expected_size));
+
+    MPI_Comm_free(&split_comm);
 }
 
 TEST_M(mpi_comm_test, "sendrecv_replace") {

--- a/docs/source/api/spmd/communicator.rst
+++ b/docs/source/api/spmd/communicator.rst
@@ -80,3 +80,15 @@ The following reduction operations are supported:
 - Max
 - Min
 - Sum
+
+MPI Communicator
+----------------
+
+The MPI communicator will use the default MPI communicator (``MPI_COMM_WORLD``) in creating an MPI communicator object unless otherwise specified.
+The use of sub-communicators in oneDAL requires passing an integer (int64) representation of the raw ``MPI Comm`` object pointer to the MPI communicator constructor.
+The MPI library used for this process must be compatible with the MPI library used to compile oneDAL.
+
+CCL Communicator
+----------------
+
+This communicator uses the `Intel oneCCL <https://github.com/uxlfoundation/oneCCL>`_ library. It can only be used in conjunction with a dpc build of oneDAL.

--- a/samples/oneapi/dpc/mpi/sources/basic_statistics_split_comm_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/basic_statistics_split_comm_mpi.cpp
@@ -43,9 +43,8 @@ float run(sycl::queue& queue, MPI_Comm split_comm, int color) {
     // sub-communicator is performed by the compute() collective below. The two
     // groups run this section concurrently -- collectives on the
     // sub-communicator only synchronize the ranks within that group.
-    auto arr = (color == 0)
-                   ? dal::array<float>::zeros(queue, count, sycl::usm::alloc::device)
-                   : dal::array<float>::full(queue, count, 1.0f, sycl::usm::alloc::device);
+    auto arr = (color == 0) ? dal::array<float>::zeros(queue, count, sycl::usm::alloc::device)
+                            : dal::array<float>::full(queue, count, 1.0f, sycl::usm::alloc::device);
     const auto data = dal::homogen_table::wrap(arr, row_count, column_count);
 
     const auto bs_desc = dal::basic_statistics::descriptor{};
@@ -56,9 +55,8 @@ float run(sycl::queue& queue, MPI_Comm split_comm, int color) {
     // MPI communicator rather than defaulting to MPI_COMM_WORLD.
     const std::int64_t comm_handle = static_cast<std::int64_t>(MPI_Comm_c2f(split_comm));
 
-    auto comm = dal::preview::spmd::make_communicator<dal::preview::spmd::backend::mpi>(
-        queue,
-        comm_handle);
+    auto comm =
+        dal::preview::spmd::make_communicator<dal::preview::spmd::backend::mpi>(queue, comm_handle);
 
     const auto result = dal::preview::compute(comm, bs_desc, data);
 
@@ -116,13 +114,13 @@ int main(int argc, char const* argv[]) {
     // MPI_COMM_WORLD must participate in each MPI_Barrier, so the color guards
     // wrap only the std::cout call; both groups reach both barriers.
     if (color == 0 && sub_rank == 0) {
-        std::cout << "Group 0 (sub-communicator size = " << sub_size
-                  << ") mean: " << mean_value << std::endl;
+        std::cout << "Group 0 (sub-communicator size = " << sub_size << ") mean: " << mean_value
+                  << std::endl;
     }
     MPI_Barrier(MPI_COMM_WORLD);
     if (color == 1 && sub_rank == 0) {
-        std::cout << "Group 1 (sub-communicator size = " << sub_size
-                  << ") mean: " << mean_value << std::endl;
+        std::cout << "Group 1 (sub-communicator size = " << sub_size << ") mean: " << mean_value
+                  << std::endl;
     }
     MPI_Barrier(MPI_COMM_WORLD);
 

--- a/samples/oneapi/dpc/mpi/sources/basic_statistics_split_comm_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/basic_statistics_split_comm_mpi.cpp
@@ -47,7 +47,7 @@ dal::table make_filled_table(sycl::queue& queue,
 float run(sycl::queue& queue, MPI_Comm split_comm, int color) {
     const std::int64_t row_count = 1000;
     const std::int64_t column_count = 10;
-    const float fill_value = (color == 0) ? 0.0f : 1.0f;
+    const float fill_value = static_cast<float>(color);
 
     // Each rank produces its own local block of data (zeros for group 0,
     // ones for group 1). Aggregation across the ranks of each sub-communicator

--- a/samples/oneapi/dpc/mpi/sources/basic_statistics_split_comm_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/basic_statistics_split_comm_mpi.cpp
@@ -1,0 +1,152 @@
+/*******************************************************************************
+* Copyright contributors to the oneDAL project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <sycl/sycl.hpp>
+#include <iomanip>
+#include <iostream>
+#include <mpi.h>
+
+#ifndef ONEDAL_DATA_PARALLEL
+#define ONEDAL_DATA_PARALLEL
+#endif
+
+#include "oneapi/dal/algo/basic_statistics.hpp"
+#include "oneapi/dal/spmd/mpi/communicator.hpp"
+#include "oneapi/dal/table/homogen.hpp"
+#include "oneapi/dal/table/row_accessor.hpp"
+
+#include "utils.hpp"
+
+namespace dal = oneapi::dal;
+
+// Build a homogen table of shape (row_count, column_count) filled with `value`
+// on the SYCL device associated with `queue`.
+dal::table make_filled_table(sycl::queue& queue,
+                             std::int64_t row_count,
+                             std::int64_t column_count,
+                             float value) {
+    const std::int64_t count = row_count * column_count;
+    auto arr = dal::array<float>::empty(queue, count, sycl::usm::alloc::device);
+    queue.fill(arr.get_mutable_data(), value, count).wait_and_throw();
+    return dal::homogen_table::wrap(arr, row_count, column_count);
+}
+
+float run(sycl::queue& queue, MPI_Comm split_comm, int color) {
+    const std::int64_t row_count = 1000;
+    const std::int64_t column_count = 10;
+    const float fill_value = (color == 0) ? 0.0f : 1.0f;
+
+    // Each rank produces its own local block of data (zeros for group 0,
+    // ones for group 1). Aggregation across the ranks of each sub-communicator
+    // is performed by the compute() collective below. The two groups run this
+    // section concurrently -- collectives on the sub-communicator only
+    // synchronize the ranks within that group.
+    const auto data = make_filled_table(queue, row_count, column_count, fill_value);
+
+    const auto bs_desc = dal::basic_statistics::descriptor{};
+
+    // Convert the MPI_Comm handle into a portable int64 representation using
+    // MPI_Comm_c2f so it can be passed to make_communicator. This is what
+    // enables a oneDAL sub-communicator to be built from a user-provided
+    // MPI communicator rather than defaulting to MPI_COMM_WORLD.
+    const std::int64_t comm_handle = static_cast<std::int64_t>(MPI_Comm_c2f(split_comm));
+
+    auto comm = dal::preview::spmd::make_communicator<dal::preview::spmd::backend::mpi>(
+        queue,
+        comm_handle);
+
+    const auto result = dal::preview::compute(comm, bs_desc, data);
+
+    // Pull the mean row onto the host so we can return a scalar. basic_statistics
+    // returns a 1 x column_count table for each statistic; every column of our
+    // input is filled with the same value, so every entry of the mean row must
+    // equal `fill_value`.
+    const auto mean_arr = dal::row_accessor<const float>{ result.get_mean() }.pull(queue);
+    return mean_arr[0];
+}
+
+int main(int argc, char const* argv[]) {
+    int status = MPI_Init(nullptr, nullptr);
+    if (status != MPI_SUCCESS) {
+        throw std::runtime_error{ "Problem occurred during MPI init" };
+    }
+
+    int world_rank = 0;
+    int world_size = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+
+    if (world_size < 2) {
+        if (world_rank == 0) {
+            std::cerr << "This sample requires at least 2 MPI ranks so that MPI_COMM_WORLD "
+                         "can be split into two sub-communicators."
+                      << std::endl;
+        }
+        MPI_Finalize();
+        return 0;
+    }
+
+    // Split MPI_COMM_WORLD into two groups: the lower half (color = 0) computes
+    // basic statistics over a dataset of zeros, the upper half (color = 1) over
+    // a dataset of ones.
+    const int color = (world_rank < world_size / 2) ? 0 : 1;
+    MPI_Comm split_comm = MPI_COMM_NULL;
+    status = MPI_Comm_split(MPI_COMM_WORLD, color, world_rank, &split_comm);
+    if (status != MPI_SUCCESS) {
+        throw std::runtime_error{ "Problem occurred during MPI_Comm_split" };
+    }
+
+    auto device = sycl::device(sycl::gpu_selector_v);
+    sycl::queue q{ device };
+
+    const float mean_value = run(q, split_comm, color);
+
+    int sub_rank = 0;
+    int sub_size = 0;
+    MPI_Comm_rank(split_comm, &sub_rank);
+    MPI_Comm_size(split_comm, &sub_size);
+
+    // Serialize the printing across the two groups so their output does not
+    // interleave -- the compute above already ran concurrently. Every rank in
+    // MPI_COMM_WORLD must participate in each MPI_Barrier, so the color guards
+    // wrap only the std::cout call; both groups reach both barriers.
+    if (color == 0 && sub_rank == 0) {
+        std::cout << "Group 0 (sub-communicator size = " << sub_size
+                  << ") mean: " << mean_value << std::endl;
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (color == 1 && sub_rank == 0) {
+        std::cout << "Group 1 (sub-communicator size = " << sub_size
+                  << ") mean: " << mean_value << std::endl;
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Guarantee that the mean equals the color: 0.0 for group 0, 1.0 for group 1.
+    const float expected = static_cast<float>(color);
+    if (mean_value != expected) {
+        std::cerr << "Rank " << world_rank << " (color " << color << ") got mean " << mean_value
+                  << ", expected " << expected << std::endl;
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    MPI_Comm_free(&split_comm);
+
+    status = MPI_Finalize();
+    if (status != MPI_SUCCESS) {
+        throw std::runtime_error{ "Problem occurred during MPI finalize" };
+    }
+    return 0;
+}

--- a/samples/oneapi/dpc/mpi/sources/basic_statistics_split_comm_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/basic_statistics_split_comm_mpi.cpp
@@ -32,29 +32,21 @@
 
 namespace dal = oneapi::dal;
 
-// Build a homogen table of shape (row_count, column_count) filled with `value`
-// on the SYCL device associated with `queue`.
-dal::table make_filled_table(sycl::queue& queue,
-                             std::int64_t row_count,
-                             std::int64_t column_count,
-                             float value) {
-    const std::int64_t count = row_count * column_count;
-    auto arr = dal::array<float>::empty(queue, count, sycl::usm::alloc::device);
-    queue.fill(arr.get_mutable_data(), value, count).wait_and_throw();
-    return dal::homogen_table::wrap(arr, row_count, column_count);
-}
-
 float run(sycl::queue& queue, MPI_Comm split_comm, int color) {
     const std::int64_t row_count = 1000;
     const std::int64_t column_count = 10;
-    const float fill_value = static_cast<float>(color);
+    const std::int64_t count = row_count * column_count;
 
     // Each rank produces its own local block of data (zeros for group 0,
-    // ones for group 1). Aggregation across the ranks of each sub-communicator
-    // is performed by the compute() collective below. The two groups run this
-    // section concurrently -- collectives on the sub-communicator only
-    // synchronize the ranks within that group.
-    const auto data = make_filled_table(queue, row_count, column_count, fill_value);
+    // ones for group 1) using dal::array's built-in factories -- no manual
+    // sycl::queue::fill needed. Aggregation across the ranks of each
+    // sub-communicator is performed by the compute() collective below. The two
+    // groups run this section concurrently -- collectives on the
+    // sub-communicator only synchronize the ranks within that group.
+    auto arr = (color == 0)
+                   ? dal::array<float>::zeros(queue, count, sycl::usm::alloc::device)
+                   : dal::array<float>::full(queue, count, 1.0f, sycl::usm::alloc::device);
+    const auto data = dal::homogen_table::wrap(arr, row_count, column_count);
 
     const auto bs_desc = dal::basic_statistics::descriptor{};
 
@@ -73,7 +65,7 @@ float run(sycl::queue& queue, MPI_Comm split_comm, int color) {
     // Pull the mean row onto the host so we can return a scalar. basic_statistics
     // returns a 1 x column_count table for each statistic; every column of our
     // input is filled with the same value, so every entry of the mean row must
-    // equal `fill_value`.
+    // equal that value (0.0 for color 0, 1.0 for color 1).
     const auto mean_arr = dal::row_accessor<const float>{ result.get_mean() }.pull(queue);
     return mean_arr[0];
 }


### PR DESCRIPTION
## Description

Current implementation of MPI support in oneDAL assumes that all MPI nodes can be used for the computation. There are circumstances (e.g. dask) where some nodes should not be used.  This creates the necessary entry points into oneDAL to make this possible.  In order to limit changes in public interfaces needed for using the spmd capabilities from the oneDAL shared object (i.e. forcing the inclusion of the mpi.h and changing includes) it uses the fortran int64 interface.

Coming soon: PR which uses this capability on sklearnex side in order to enable dask support for spmd algos.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
