### PR TITLE
ci: pin MPI fabric to shm on Azure runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,13 +123,23 @@ jobs:
       - name: daal/cpp/mpi samples
         run: |
             source /opt/intel/oneapi/setvars.sh
-            # Azure GHA runners expose a MANA paravirtualized NIC (mana_0) that
-            # Intel MPI's OFI autoselect probes as a verbs/PSM3 device; the UD QP
-            # open fails with EINVAL and MPI_Init aborts before the sample runs.
-            # All ranks are on a single VM, so pin the fabric to shared memory
-            # and force libfabric off the verbs/PSM3 providers.
-            export I_MPI_FABRICS=shm
-            export FI_PROVIDER=tcp
+            # Azure GHA runners expose a MANA paravirtualized NIC that Intel
+            # MPI's OFI autoselect probes as a verbs/PSM3 device; the UD QP
+            # open fails with EINVAL and MPI_Init aborts before the sample
+            # runs. Probe libfabric directly: if the verbs provider cannot
+            # enumerate a usable endpoint on this host, pin the fabric to
+            # shared memory and force libfabric onto tcp so autoselect never
+            # touches verbs/PSM3. On real IB / OPA hardware fi_info succeeds
+            # and the override is skipped, preserving the native fabric.
+            if command -v fi_info > /dev/null 2>&1; then
+                if ! fi_info -p verbs > /dev/null 2>&1; then
+                    echo "libfabric verbs provider unavailable; pinning MPI fabric to shm/tcp"
+                    export I_MPI_FABRICS=shm
+                    export FI_PROVIDER=tcp
+                fi
+            else
+                echo "warning: fi_info not on PATH after setvars.sh; cannot probe verbs provider" >&2
+            fi
             .ci/scripts/test.sh --test-kind samples --build-dir __release_lnx --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build-system cmake
 
   LinuxABICheck:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
             # shared memory and force libfabric onto tcp so autoselect never
             # touches verbs/PSM3. On real IB / OPA hardware fi_info succeeds
             # and the override is skipped, preserving the native fabric.
-            if command -v fi_info > /dev/null 2>&1; then
+            if [ ! -z "$(command -v fi_info)" ]; then
                 if ! fi_info -p verbs > /dev/null 2>&1; then
                     echo "libfabric verbs provider unavailable; pinning MPI fabric to shm/tcp"
                     export I_MPI_FABRICS=shm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,13 @@ jobs:
       - name: daal/cpp/mpi samples
         run: |
             source /opt/intel/oneapi/setvars.sh
+            # Azure GHA runners expose a MANA paravirtualized NIC (mana_0) that
+            # Intel MPI's OFI autoselect probes as a verbs/PSM3 device; the UD QP
+            # open fails with EINVAL and MPI_Init aborts before the sample runs.
+            # All ranks are on a single VM, so pin the fabric to shared memory
+            # and force libfabric off the verbs/PSM3 providers.
+            export I_MPI_FABRICS=shm
+            export FI_PROVIDER=tcp
             .ci/scripts/test.sh --test-kind samples --build-dir __release_lnx --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build-system cmake
 
   LinuxABICheck:


### PR DESCRIPTION
The Azure-hosted ubuntu-24.04 runner exposes a MANA paravirtualized NIC at /sys/class/infiniband/mana_0. Intel MPI's OFI autoselect probes this as a verbs/PSM3 device, the UD QP open fails with EINVAL, and MPI_Init aborts before any MPI sample runs. Pin I_MPI_FABRICS=shm and FI_PROVIDER=tcp for the daal/cpp/mpi samples step so libfabric skips verbs/PSM3 entirely.

## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
