### PR TITLE
Add Bazel parameter library layout control

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,6 +19,7 @@ build --flag_alias=device=@config//:device
 build --flag_alias=cpu=@config//:cpu
 build --flag_alias=enable_assert=@config//:enable_assert
 build --flag_alias=stdalloc=@config//:stdalloc
+build --flag_alias=build_parameters_lib=@config//:build_parameters_lib
 
 # Always pass this env variable to test rules, because SYCL
 # OpenCL backend uses it to determine available devices

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -389,6 +389,9 @@ jobs:
       .ci/env/apt.sh opencl
     displayName: 'install opencl'
   - script: |
+      .ci/env/apt.sh mkl
+    displayName: 'mkl installation'
+  - script: |
       # sourcing done to set bazel version value from script
       source .ci/env/bazelisk.sh
       echo "##vso[task.setvariable variable=BAZEL_VERSION]${BAZEL_VERSION}"

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -441,6 +441,21 @@ jobs:
       echo "Checking Bazel config: stdalloc"
       bazel build --nobuild :release --stdalloc=true --release_dpc=false
 
+      for parameters_lib in auto yes no; do
+        echo "Checking parameter library layout: ${parameters_lib}"
+        bazel build --nobuild :release --cpu=avx2 \
+          --build_parameters_lib="${parameters_lib}"
+      done
+
+      if bazel build @config//:validate_build_parameters_lib \
+          --platforms=@config//:windows_analysis_platform \
+          --build_parameters_lib=yes > windows_parameters_lib.log 2>&1; then
+        echo "Windows --build_parameters_lib=yes unexpectedly succeeded"
+        exit 1
+      fi
+      grep -F -- "--build_parameters_lib=yes is not supported on Windows" \
+        windows_parameters_lib.log
+
       echo "Checking Bazel config: dev"
       bazel build --nobuild //cpp/oneapi/dal:tests --config=dev
     displayName: 'Bazel config smoke checks'
@@ -674,6 +689,20 @@ jobs:
       echo ##vso[task.setvariable variable=BAZEL_SH]C:\Program Files\Git\bin\bash.exe
       echo ##vso[task.setvariable variable=BAZEL_JOBS]%NUMBER_OF_PROCESSORS%
     displayName: 'bazel-configure'
+  - script: |
+      call %TEMP%\oneapi\setvars.bat --force
+      "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" build //:release --nobuild --build_parameters_lib=yes > build_parameters_lib_yes.log 2>&1
+      if not errorlevel 1 (
+        type build_parameters_lib_yes.log
+        echo ERROR: Windows --build_parameters_lib=yes unexpectedly succeeded
+        exit /b 1
+      )
+      findstr /C:"--build_parameters_lib=yes is not supported on Windows" build_parameters_lib_yes.log >NUL || (
+        type build_parameters_lib_yes.log
+        echo ERROR: expected Windows parameter-library diagnostic was not found
+        exit /b 1
+      )
+    displayName: 'Reject separate parameter libraries on Windows'
   - script: |
       call %TEMP%\oneapi\setvars.bat --force
       "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" shutdown

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -454,6 +454,15 @@ jobs:
 
   - script: |
       set -euo pipefail
+      # This step is the largest consumer of disk in the job -- a second full
+      # release under a different configuration, plus a packaged consumer that
+      # builds through CMake, pkg-config and Bazel. The agent starts at over 95%
+      # of / in use, and a link that runs out of space reports nothing but
+      # `collect2: error: ld returned 1 exit status`, so account for the space
+      # here rather than diagnosing it several steps later.
+      echo "Disk before the folded consumer smoke:"
+      df -h / "${HOME}"
+      du -sh "${HOME}/.cache/bazel" 2>/dev/null || true
       # Build with the same environment as the other Bazel steps. `setvars.sh`
       # exports `MKLROOT`, which `mkl_repo` declares in `environ`, so sourcing it
       # before the build would repoint `@mkl` at the oneAPI installation and
@@ -469,6 +478,9 @@ jobs:
       DALROOT="$(pwd)/bazel-bin/release/daal/latest" \
         BAZEL=bazel dev/release_tests/parameters_layout_consumer_test.sh \
         "$(pwd)/bazel-bin/release/daal/latest" "$(pwd)"
+      echo "Disk after the folded consumer smoke:"
+      df -h / "${HOME}"
+      du -sh "${HOME}/.cache/bazel" 2>/dev/null || true
     displayName: 'Folded parameter-layout packaged consumer smoke'
 
   - script: |

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -460,14 +460,32 @@ jobs:
       # of / in use, and a link that runs out of space reports nothing but
       # `collect2: error: ld returned 1 exit status`, so account for the space
       # here rather than diagnosing it several steps later.
-      echo "Disk before the folded consumer smoke:"
-      df -h / "${HOME}"
-      du -sh "${HOME}/.cache/bazel" 2>/dev/null || true
+      report_disk() {
+        echo "Disk ${1} the folded consumer smoke:"
+        df -h /
+        # Both of these matter and only one is reclaimed between steps. The
+        # output base under ~/.cache/bazel goes away at the next `Clean Bazel
+        # cache (expunge)`; the --disk_cache directory does not -- `clean` has
+        # no effect on it and `bazel-cache-limit` only trims it, at 4Gb, once
+        # the whole job is over.
+        du -sh "${HOME}/.cache/bazel" 2>/dev/null || true
+        du -sh "${BAZEL_CACHE_DIR:-}" 2>/dev/null || true
+      }
+      report_disk before
       # Build with the same environment as the other Bazel steps. `setvars.sh`
       # exports `MKLROOT`, which `mkl_repo` declares in `environ`, so sourcing it
       # before the build would repoint `@mkl` at the oneAPI installation and
       # invalidate the dependency for this step only.
-      bazel build :release --release_dpc=false --build_parameters_lib=no
+      #
+      # `--disk_cache=` disables the shared cache that `~/.bazelrc` points at
+      # (written in the `bazel-configure` step above) for this build alone.
+      # Nothing will ever reuse these artifacts: this is a one-off validation
+      # under a configuration no other step builds, so the entries share nothing
+      # with the default configuration and only occupy the cache for the rest of
+      # the job. `bazel clean --expunge` cannot reclaim them -- it clears the
+      # output base, not a disk cache -- which is what left `cpp-tests-thread-dev`
+      # linking at 97% of / in use.
+      bazel build :release --release_dpc=false --build_parameters_lib=no --disk_cache=
       # The CMake and pkg-config consumers resolve oneMKL/TBB through the same
       # oneAPI environment as an installed package user. `setvars.sh` reads
       # optional variables such as `OCL_ICD_FILENAMES` unguarded, so `nounset`
@@ -478,9 +496,7 @@ jobs:
       DALROOT="$(pwd)/bazel-bin/release/daal/latest" \
         BAZEL=bazel dev/release_tests/parameters_layout_consumer_test.sh \
         "$(pwd)/bazel-bin/release/daal/latest" "$(pwd)"
-      echo "Disk after the folded consumer smoke:"
-      df -h / "${HOME}"
-      du -sh "${HOME}/.cache/bazel" 2>/dev/null || true
+      report_disk after
     displayName: 'Folded parameter-layout packaged consumer smoke'
 
   - script: |
@@ -610,6 +626,13 @@ jobs:
     displayName: 'Clean Bazel cache (expunge)'
 
   - script: |
+      # These links are the largest of the job and the first thing to fail when
+      # the agent runs out of space, with no diagnostic of its own -- GNU ld
+      # reports only `collect2: error: ld returned 1 exit status`, and the target
+      # it happens to die on moves from run to run. Record the space so a red
+      # here says whether that was the reason.
+      df -h /
+      du -sh "${BAZEL_CACHE_DIR:-}" 2>/dev/null || true
       bazel test //cpp/oneapi/dal:tests \
                  --config=host \
                  --test_link_mode=dev \

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -482,9 +482,10 @@ jobs:
       # Nothing will ever reuse these artifacts: this is a one-off validation
       # under a configuration no other step builds, so the entries share nothing
       # with the default configuration and only occupy the cache for the rest of
-      # the job. `bazel clean --expunge` cannot reclaim them -- it clears the
-      # output base, not a disk cache -- which is what left `cpp-tests-thread-dev`
-      # linking at 97% of / in use.
+      # the job -- `bazel clean --expunge` cannot reclaim them, since it clears
+      # the output base and not a disk cache. Worth keeping on its own terms; it
+      # is not, as first assumed, the cause of the `cpp-tests-thread-dev` link
+      # failures, which persist with 4.6Gb free.
       bazel build :release --release_dpc=false --build_parameters_lib=no --disk_cache=
       # The CMake and pkg-config consumers resolve oneMKL/TBB through the same
       # oneAPI environment as an installed package user. `setvars.sh` reads
@@ -626,18 +627,38 @@ jobs:
     displayName: 'Clean Bazel cache (expunge)'
 
   - script: |
-      # These links are the largest of the job and the first thing to fail when
-      # the agent runs out of space, with no diagnostic of its own -- GNU ld
-      # reports only `collect2: error: ld returned 1 exit status`, and the target
-      # it happens to die on moves from run to run. Record the space so a red
-      # here says whether that was the reason.
+      # These links are the largest in the job and they fail here without saying
+      # why: GNU ld reports only `collect2: error: ld returned 1 exit status`,
+      # and the target it dies on moves between runs -- correlation_distance,
+      # covariance, linear_regression, pca across four builds, always exactly one
+      # of 112. Disk has been measured and is not the cause (4.6Gb free at this
+      # point), so record memory too, and keep the sandbox and the failing
+      # command so ld's own stderr survives into the log.
+      free -m
       df -h /
       du -sh "${BAZEL_CACHE_DIR:-}" 2>/dev/null || true
       bazel test //cpp/oneapi/dal:tests \
                  --config=host \
                  --test_link_mode=dev \
-                 --test_thread_mode=par
+                 --test_thread_mode=par \
+                 --verbose_failures \
+                 --sandbox_debug
     displayName: 'cpp-tests-thread-dev'
+
+  - script: |
+      # Only reached when a step above failed. Two concurrent link actions of
+      # debug-mode test binaries on an 8Gb agent is the current hypothesis for
+      # the failure described in the previous step, and an OOM-killed `ld` exits
+      # without printing anything itself -- the evidence is in the kernel log.
+      echo '=== memory ==='
+      free -m
+      echo '=== kernel OOM records ==='
+      sudo dmesg 2>/dev/null | grep -iE 'killed process|out of memory|oom-kill' | tail -20 \
+        || echo '(none, or dmesg not readable)'
+      echo '=== disk ==='
+      df -h /
+    displayName: 'Diagnose test link failure'
+    condition: failed()
 
   - script: |
       echo "Cleaning Bazel cache before running example or tests"

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -525,24 +525,6 @@ jobs:
   - script: |
       echo "Cleaning Bazel cache before running example or tests"
       bazel clean --expunge
-      # `clean --expunge` clears the output base and leaves the --disk_cache
-      # directory untouched, so on its own it does not reclaim the largest thing
-      # on the agent. Everything from here on is examples and tests, and
-      # `cpp-tests-thread-dev` needs more than the ~4.6Gb that remains: it links
-      # 112 debug-mode test binaries and fills / completely, at which point ld
-      # fails on whichever link is running and reports only
-      # `collect2: error: ld returned 1 exit status`.
-      #
-      # Dropping the disk cache here costs nothing. It is 4.5Gb, above the 4Gb
-      # BAZEL_CACHE_MAX_SIZE_KB ceiling, so `bazel-cache-limit` already deletes
-      # it at the end of every run -- this only moves that deletion to the point
-      # where the space is needed instead of after the job that needed it.
-      if [ -d "${BAZEL_CACHE_DIR:-}" ]; then
-        echo "Reclaiming Bazel disk cache: $(du -sh "${BAZEL_CACHE_DIR}" | cut -f1)"
-        rm -rf "${BAZEL_CACHE_DIR}"
-        mkdir -p "${BAZEL_CACHE_DIR}"
-      fi
-      df -h /
     displayName: 'Clean Bazel cache (expunge)'
 
   - script: |
@@ -642,6 +624,28 @@ jobs:
   - script: |
       echo "Cleaning Bazel cache before running example or tests"
       bazel clean --expunge
+      # `clean --expunge` clears the output base and leaves the --disk_cache
+      # directory alone, so by itself it reclaims nothing of the ~4.5Gb sitting
+      # there, and the step below has only ~4.6Gb to work with. It needs more:
+      # it links 112 debug-mode test binaries, fills / to 100%, and ld then fails
+      # on whichever link is running while reporting only
+      # `collect2: error: ld returned 1 exit status`.
+      #
+      # Dropped here rather than at the first expunge of this sequence so the
+      # example suites above keep their cache hits -- without them they rebuild
+      # oneDAL from scratch six times over, which is a much larger cost than the
+      # one step below losing its own.
+      #
+      # And this costs nothing at all: at 4.5Gb the cache is already over the 4Gb
+      # BAZEL_CACHE_MAX_SIZE_KB ceiling, so `bazel-cache-limit` deletes it at the
+      # end of every run regardless. This only moves that deletion to the point
+      # where the space is needed instead of after the step that needed it.
+      if [ -d "${BAZEL_CACHE_DIR:-}" ]; then
+        echo "Reclaiming Bazel disk cache: $(du -sh "${BAZEL_CACHE_DIR}" | cut -f1)"
+        rm -rf "${BAZEL_CACHE_DIR}"
+        mkdir -p "${BAZEL_CACHE_DIR}"
+      fi
+      df -h /
     displayName: 'Clean Bazel cache (expunge)'
 
   - script: |

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -441,24 +441,21 @@ jobs:
       echo "Checking Bazel config: stdalloc"
       bazel build --nobuild :release --stdalloc=true --release_dpc=false
 
-      for parameters_lib in auto yes no; do
-        echo "Checking parameter library layout: ${parameters_lib}"
-        bazel build --nobuild :release --cpu=avx2 \
-          --build_parameters_lib="${parameters_lib}"
-      done
-
-      if bazel build @config//:validate_build_parameters_lib \
-          --platforms=@config//:windows_analysis_platform \
-          --build_parameters_lib=yes > windows_parameters_lib.log 2>&1; then
-        echo "Windows --build_parameters_lib=yes unexpectedly succeeded"
-        exit 1
-      fi
-      grep -F -- "--build_parameters_lib=yes is not supported on Windows" \
-        windows_parameters_lib.log
+      # Analysis-only: validates configured release outputs, host/DPC dependency
+      # separation, folded-target rejection, and the Windows unsupported value.
+      BAZEL=bazel dev/bazel/tests/parameters_layout_test.sh
 
       echo "Checking Bazel config: dev"
       bazel build --nobuild //cpp/oneapi/dal:tests --config=dev
     displayName: 'Bazel config smoke checks'
+
+  - script: |
+      set -euo pipefail
+      bazel build :release --release_dpc=false --build_parameters_lib=no
+      DALROOT="$(pwd)/bazel-bin/release/daal/latest" \
+        BAZEL=bazel dev/release_tests/parameters_layout_consumer_test.sh \
+        "$(pwd)/bazel-bin/release/daal/latest" "$(pwd)"
+    displayName: 'Folded parameter-layout packaged consumer smoke'
 
   - script: |
       bazel build :release --release_dpc=false
@@ -691,7 +688,7 @@ jobs:
     displayName: 'bazel-configure'
   - script: |
       call %TEMP%\oneapi\setvars.bat --force
-      "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" build //:release --nobuild --build_parameters_lib=yes > build_parameters_lib_yes.log 2>&1
+      "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" build @config//:validate_build_parameters_lib --build_parameters_lib=yes > build_parameters_lib_yes.log 2>&1
       if not errorlevel 1 (
         type build_parameters_lib_yes.log
         echo ERROR: Windows --build_parameters_lib=yes unexpectedly succeeded

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -626,10 +626,13 @@ jobs:
       bazel clean --expunge
       # `clean --expunge` clears the output base and leaves the --disk_cache
       # directory alone, so by itself it reclaims nothing of the ~4.5Gb sitting
-      # there, and the step below has only ~4.6Gb to work with. It needs more:
-      # it links 112 debug-mode test binaries, fills / to 100%, and ld then fails
-      # on whichever link is running while reporting only
-      # `collect2: error: ld returned 1 exit status`.
+      # there, and the step below -- which links 112 debug-mode test binaries and
+      # is the largest consumer in the job -- gets only ~4.6Gb to work with.
+      # Reclaiming here takes that to ~9.1Gb.
+      #
+      # This is not on its own enough; see `--disk_cache=` on that step, without
+      # which it refills the cache as it builds and fills / anyway. Both are
+      # needed: this frees the space, that stops it being spent twice.
       #
       # Dropped here rather than at the first expunge of this sequence so the
       # example suites above keep their cache hits -- without them they rebuild
@@ -649,14 +652,26 @@ jobs:
     displayName: 'Clean Bazel cache (expunge)'
 
   - script: |
-      # These links are the largest in the job and they fail without saying why:
-      # GNU ld reports only `collect2: error: ld returned 1 exit status`, and the
-      # target it dies on moves between runs -- correlation_distance, covariance,
-      # linear_regression, pca, louvain across five builds, always exactly one of
-      # 112. The cause is space: this step starts with ~4.6Gb free and ends with
-      # / at 100% and 4Mb left, and ld reports nothing when it cannot write. The
-      # step above now reclaims the disk cache so there is room; keep reporting
-      # both numbers, because the margin is what matters and it is not large.
+      # This step fills / and dies, on a target that moves between runs --
+      # correlation_distance, covariance, linear_regression, pca, louvain over
+      # five builds, always exactly one of 112, and for five of them with nothing
+      # from ld but `collect2: error: ld returned 1 exit status`, because that is
+      # all ld says when it cannot write. With enough headroom to get further,
+      # Bazel names it:
+      #
+      #   WARNING: Remote Cache: No space left on device
+      #   BulkTransferException: No space left on device
+      #
+      # "Remote Cache" there is the `--disk_cache` from `~/.bazelrc`. So this step
+      # needs room for two copies of everything it produces: the output base, and
+      # a cache entry for each action. Emptying the cache beforehand does not
+      # help, since the step immediately refills it -- with 9.1Gb free it still
+      # reached 100% and 16Mb.
+      #
+      # `--disk_cache=` drops the second copy. Nothing is lost: the step above
+      # empties the cache, so there are no entries left to hit either way, and
+      # these outputs are of no use to anything downstream -- this is the last
+      # build in the job.
       free -m
       df -h /
       du -sh "${BAZEL_CACHE_DIR:-}" 2>/dev/null || true
@@ -664,8 +679,8 @@ jobs:
                  --config=host \
                  --test_link_mode=dev \
                  --test_thread_mode=par \
-                 --verbose_failures \
-                 --sandbox_debug
+                 --disk_cache= \
+                 --verbose_failures
     displayName: 'cpp-tests-thread-dev'
 
   - script: |

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -525,6 +525,24 @@ jobs:
   - script: |
       echo "Cleaning Bazel cache before running example or tests"
       bazel clean --expunge
+      # `clean --expunge` clears the output base and leaves the --disk_cache
+      # directory untouched, so on its own it does not reclaim the largest thing
+      # on the agent. Everything from here on is examples and tests, and
+      # `cpp-tests-thread-dev` needs more than the ~4.6Gb that remains: it links
+      # 112 debug-mode test binaries and fills / completely, at which point ld
+      # fails on whichever link is running and reports only
+      # `collect2: error: ld returned 1 exit status`.
+      #
+      # Dropping the disk cache here costs nothing. It is 4.5Gb, above the 4Gb
+      # BAZEL_CACHE_MAX_SIZE_KB ceiling, so `bazel-cache-limit` already deletes
+      # it at the end of every run -- this only moves that deletion to the point
+      # where the space is needed instead of after the job that needed it.
+      if [ -d "${BAZEL_CACHE_DIR:-}" ]; then
+        echo "Reclaiming Bazel disk cache: $(du -sh "${BAZEL_CACHE_DIR}" | cut -f1)"
+        rm -rf "${BAZEL_CACHE_DIR}"
+        mkdir -p "${BAZEL_CACHE_DIR}"
+      fi
+      df -h /
     displayName: 'Clean Bazel cache (expunge)'
 
   - script: |
@@ -627,13 +645,14 @@ jobs:
     displayName: 'Clean Bazel cache (expunge)'
 
   - script: |
-      # These links are the largest in the job and they fail here without saying
-      # why: GNU ld reports only `collect2: error: ld returned 1 exit status`,
-      # and the target it dies on moves between runs -- correlation_distance,
-      # covariance, linear_regression, pca across four builds, always exactly one
-      # of 112. Disk has been measured and is not the cause (4.6Gb free at this
-      # point), so record memory too, and keep the sandbox and the failing
-      # command so ld's own stderr survives into the log.
+      # These links are the largest in the job and they fail without saying why:
+      # GNU ld reports only `collect2: error: ld returned 1 exit status`, and the
+      # target it dies on moves between runs -- correlation_distance, covariance,
+      # linear_regression, pca, louvain across five builds, always exactly one of
+      # 112. The cause is space: this step starts with ~4.6Gb free and ends with
+      # / at 100% and 4Mb left, and ld reports nothing when it cannot write. The
+      # step above now reclaims the disk cache so there is room; keep reporting
+      # both numbers, because the margin is what matters and it is not large.
       free -m
       df -h /
       du -sh "${BAZEL_CACHE_DIR:-}" 2>/dev/null || true

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -454,10 +454,18 @@ jobs:
 
   - script: |
       set -euo pipefail
-      # The CMake consumer resolves oneMKL/TBB through the same oneAPI
-      # environment as an installed package user.
-      source /opt/intel/oneapi/setvars.sh
+      # Build with the same environment as the other Bazel steps. `setvars.sh`
+      # exports `MKLROOT`, which `mkl_repo` declares in `environ`, so sourcing it
+      # before the build would repoint `@mkl` at the oneAPI installation and
+      # invalidate the dependency for this step only.
       bazel build :release --release_dpc=false --build_parameters_lib=no
+      # The CMake and pkg-config consumers resolve oneMKL/TBB through the same
+      # oneAPI environment as an installed package user. `setvars.sh` reads
+      # optional variables such as `OCL_ICD_FILENAMES` unguarded, so `nounset`
+      # has to be relaxed while it runs.
+      set +u
+      source /opt/intel/oneapi/setvars.sh
+      set -u
       DALROOT="$(pwd)/bazel-bin/release/daal/latest" \
         BAZEL=bazel dev/release_tests/parameters_layout_consumer_test.sh \
         "$(pwd)/bazel-bin/release/daal/latest" "$(pwd)"

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -446,7 +446,7 @@ jobs:
 
       # Analysis-only: validates configured release outputs, host/DPC dependency
       # separation, folded-target rejection, and the Windows unsupported value.
-      BAZEL=bazel dev/bazel/tests/parameters_layout_test.sh
+      dev/bazel/tests/parameters_layout_test.sh
 
       echo "Checking Bazel config: dev"
       bazel build --nobuild //cpp/oneapi/dal:tests --config=dev
@@ -495,7 +495,7 @@ jobs:
       source /opt/intel/oneapi/setvars.sh
       set -u
       DALROOT="$(pwd)/bazel-bin/release/daal/latest" \
-        BAZEL=bazel dev/release_tests/parameters_layout_consumer_test.sh \
+        dev/release_tests/parameters_layout_consumer_test.sh \
         "$(pwd)/bazel-bin/release/daal/latest" "$(pwd)"
       report_disk after
     displayName: 'Folded parameter-layout packaged consumer smoke'
@@ -684,17 +684,21 @@ jobs:
     displayName: 'cpp-tests-thread-dev'
 
   - script: |
-      # Only reached when a step above failed. Two concurrent link actions of
-      # debug-mode test binaries on an 8Gb agent is the current hypothesis for
-      # the failure described in the previous step, and an OOM-killed `ld` exits
-      # without printing anything itself -- the evidence is in the kernel log.
+      # Only reached when a step above failed, so it costs nothing on a green
+      # run. It stays in because the failure mode it reports on is silent: the
+      # step above exhausted `/` six times, and neither `ld` nor a sandbox copy
+      # says so -- the log showed only `collect2: error: ld returned 1 exit
+      # status` against a different target each run. `df` is the line that
+      # names it. `free -m` and the kernel OOM grep are kept because they are
+      # what ruled out memory pressure, which the same symptom also fits.
+      echo '=== disk ==='
+      df -h /
+      du -sh "${BAZEL_CACHE_DIR:-}" 2>/dev/null || true
       echo '=== memory ==='
       free -m
       echo '=== kernel OOM records ==='
       sudo dmesg 2>/dev/null | grep -iE 'killed process|out of memory|oom-kill' | tail -20 \
         || echo '(none, or dmesg not readable)'
-      echo '=== disk ==='
-      df -h /
     displayName: 'Diagnose test link failure'
     condition: failed()
 

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -451,6 +451,9 @@ jobs:
 
   - script: |
       set -euo pipefail
+      # The CMake consumer resolves oneMKL/TBB through the same oneAPI
+      # environment as an installed package user.
+      source /opt/intel/oneapi/setvars.sh
       bazel build :release --release_dpc=false --build_parameters_lib=no
       DALROOT="$(pwd)/bazel-bin/release/daal/latest" \
         BAZEL=bazel dev/release_tests/parameters_layout_consumer_test.sh \

--- a/BUILD
+++ b/BUILD
@@ -5,6 +5,7 @@ load("@onedal//dev/bazel:release.bzl",
 )
 load("@onedal//dev/bazel/config:selects.bzl",
     "parameters_lib_enabled",
+    "parameters_lib_separate_value",
     "release_dpc_parameters_lib_enabled",
 )
 load("@onedal//dev/bazel:scripts.bzl",
@@ -40,17 +41,20 @@ generate_modulefile(
 generate_pkgconfig(
     name = "release_pkgconfig",
     out = "lib/pkgconfig/onedal.pc",
+    parameters_lib = parameters_lib_separate_value(),
 )
 
 generate_pkgconfig(
     name = "release_pkgconfig_dynamic_threading_host",
     out = "lib/pkgconfig/dal-dynamic-threading-host.pc",
+    parameters_lib = parameters_lib_separate_value(),
 )
 
 generate_pkgconfig(
     name = "release_pkgconfig_static_threading_host",
     out = "lib/pkgconfig/dal-static-threading-host.pc",
     static = True,
+    parameters_lib = parameters_lib_separate_value(),
 )
 
 filegroup(
@@ -62,6 +66,7 @@ generate_cmake_config(
     name = "release_cmake_config",
     template = "cmake/templates/oneDALConfig.cmake.in",
     out = "lib/cmake/oneDAL/oneDALConfig.cmake",
+    parameters_lib = parameters_lib_separate_value(),
 )
 
 generate_cmake_config(
@@ -176,6 +181,7 @@ release(
         "@onedal//cpp/oneapi/dal:dynamic_parameters_dpc",
     ]),
     data = [
+        "@config//:validate_build_parameters_lib",
         "//data:datasets",
         ":release_package_files",
         "//examples/daal/cpp:release_files",

--- a/BUILD
+++ b/BUILD
@@ -3,6 +3,10 @@ load("@onedal//dev/bazel:release.bzl",
     "release_include",
     "release_extra_file",
 )
+load("@onedal//dev/bazel/config:selects.bzl",
+    "parameters_lib_enabled",
+    "release_dpc_parameters_lib_enabled",
+)
 load("@onedal//dev/bazel:scripts.bzl",
     "generate_cmake_config",
     "generate_modulefile",
@@ -157,22 +161,20 @@ release(
         "@onedal//cpp/daal:thread_dynamic",
         "@onedal//cpp/oneapi/dal:static",
         "@onedal//cpp/oneapi/dal:dynamic",
-    ] + select({
-        ":windows": [],
-        "//conditions:default": [
-            "@onedal//cpp/oneapi/dal:static_parameters",
-            "@onedal//cpp/oneapi/dal:dynamic_parameters",
-        ],
-    }) + select({
+    ] + parameters_lib_enabled([
+        "@onedal//cpp/oneapi/dal:static_parameters",
+        "@onedal//cpp/oneapi/dal:dynamic_parameters",
+    ]) + select({
         ":release_dpc_windows": [
             "@onedal//cpp/oneapi/dal:dynamic_dpc",
         ],
         "@config//:release_dpc_enabled": [
             "@onedal//cpp/oneapi/dal:dynamic_dpc",
-            "@onedal//cpp/oneapi/dal:dynamic_parameters_dpc",
         ],
         "//conditions:default": [],
-    }),
+    }) + release_dpc_parameters_lib_enabled([
+        "@onedal//cpp/oneapi/dal:dynamic_parameters_dpc",
+    ]),
     data = [
         "//data:datasets",
         ":release_package_files",

--- a/cmake/templates/oneDALConfig.cmake.in
+++ b/cmake/templates/oneDALConfig.cmake.in
@@ -40,11 +40,9 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type not specified, defaulting to Release" FORCE)
 endif()
 
-if(WIN32)
-    message(STATUS "Optimization library is not enabled on Windows")
-    set(ONEDAL_USE_PARAMETERS_LIBRARY no)
-else()
-    set(ONEDAL_USE_PARAMETERS_LIBRARY yes)
+set(ONEDAL_USE_PARAMETERS_LIBRARY "@ONEDAL_USE_PARAMETERS_LIBRARY@")
+if(WIN32 AND ONEDAL_USE_PARAMETERS_LIBRARY STREQUAL "yes")
+    message(FATAL_ERROR "This package advertises unsupported separate parameter libraries on Windows")
 endif()
 
 #Backward compatibility section to be removed with next major version
@@ -80,7 +78,9 @@ elseif (NOT "${ONEDAL_USE_DPCPP}" STREQUAL "yes" AND NOT "${ONEDAL_USE_DPCPP}" S
 endif()
 if ("${ONEDAL_LINK}" STREQUAL "" OR "${ONEDAL_LINK}" STREQUAL "dynamic")
     set(ONEDAL_LINK "dynamic")
-    if ("${ONEDAL_USE_DPCPP}" STREQUAL "yes")
+    if ("${ONEDAL_USE_DPCPP}" STREQUAL "yes" OR
+        "${ONEDAL_USE_PARAMETERS_LIBRARY}" STREQUAL "no")
+        # Folded parameter objects reference MKL from the main host library.
         set(MKL_DEPENDENCY "yes")
     endif()
 elseif ("${ONEDAL_LINK}" STREQUAL "static")
@@ -181,6 +181,9 @@ if(MKL_DEPENDENCY STREQUAL "yes")
                 MKL::mkl_core
                 MKL::mkl_intel_lp64
                 MKL::mkl_gnu_thread${DAL_DEBUG_SUFFIX})
+            if(ONEDAL_USE_PARAMETERS_LIBRARY STREQUAL "no")
+                list(APPEND oneDAL_IMPORTED_TARGETS -lgomp)
+            endif()
         endif()
     endif()
 

--- a/cmake/templates/oneDALConfig.cmake.in
+++ b/cmake/templates/oneDALConfig.cmake.in
@@ -78,9 +78,16 @@ elseif (NOT "${ONEDAL_USE_DPCPP}" STREQUAL "yes" AND NOT "${ONEDAL_USE_DPCPP}" S
 endif()
 if ("${ONEDAL_LINK}" STREQUAL "" OR "${ONEDAL_LINK}" STREQUAL "dynamic")
     set(ONEDAL_LINK "dynamic")
-    if ("${ONEDAL_USE_DPCPP}" STREQUAL "yes" OR
-        "${ONEDAL_USE_PARAMETERS_LIBRARY}" STREQUAL "no")
-        # Folded parameter objects reference MKL from the main host library.
+    if ("${ONEDAL_USE_DPCPP}" STREQUAL "yes")
+        set(MKL_DEPENDENCY "yes")
+    elseif (NOT WIN32 AND "${ONEDAL_USE_PARAMETERS_LIBRARY}" STREQUAL "no")
+        # A folded package has no libonedal_parameters, so the parameter objects
+        # are linked into libonedal.so, and a consumer of that layout needs
+        # oneMKL on its own link line where a consumer of the separate layout
+        # does not. Windows is excluded deliberately: `no` is the only value a
+        # Windows package ever carries, a DLL is fully resolved at link time
+        # anyway, and including it here would newly require oneMKL of every
+        # Windows dynamic consumer.
         set(MKL_DEPENDENCY "yes")
     endif()
 elseif ("${ONEDAL_LINK}" STREQUAL "static")

--- a/cmake/templates/oneDALConfig.cmake.in
+++ b/cmake/templates/oneDALConfig.cmake.in
@@ -181,8 +181,17 @@ if(MKL_DEPENDENCY STREQUAL "yes")
                 MKL::mkl_core
                 MKL::mkl_intel_lp64
                 MKL::mkl_gnu_thread${DAL_DEBUG_SUFFIX})
-            if(ONEDAL_USE_PARAMETERS_LIBRARY STREQUAL "no")
-                list(APPEND oneDAL_IMPORTED_TARGETS -lgomp)
+            # The oneMKL `gnu_thread` layer needs a GNU OpenMP runtime. MKLConfig.cmake
+            # only attaches it (through MKL_SUPP_LINK) to the aggregate `MKL::MKL`
+            # target, while the lines above link the individual component targets, so
+            # the runtime has to be requested explicitly.
+            if(MKL_THREADING STREQUAL "gnu_thread")
+                find_package(OpenMP COMPONENTS CXX)
+                if(TARGET OpenMP::OpenMP_CXX)
+                    list(APPEND oneDAL_IMPORTED_TARGETS OpenMP::OpenMP_CXX)
+                else()
+                    list(APPEND oneDAL_IMPORTED_TARGETS -lgomp)
+                endif()
             endif()
         endif()
     endif()

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -9,6 +9,23 @@ load("@onedal//dev/bazel:dal.bzl",
     "dal_collect_test_suites",
     "dal_generate_cpu_dispatcher",
 )
+load("@onedal//dev/bazel/config:selects.bzl",
+    "parameters_lib_disabled",
+    "parameters_lib_enabled",
+)
+
+_PARAMETER_MODULES = [
+    "@onedal//cpp/oneapi/dal/algo:parameters",
+    "@onedal//cpp/oneapi/dal/detail/parameters",
+]
+
+_PARAMETER_MODULES_DPC = [
+    "@onedal//cpp/oneapi/dal/algo:parameters_dpc",
+    "@onedal//cpp/oneapi/dal/detail/parameters:parameters_dpc",
+]
+
+_DAL_LIB_TAGS = ["dal"] + parameters_lib_disabled(["parameters"])
+
 
 dal_generate_cpu_dispatcher(
     name = "cpu_dispatcher",
@@ -73,10 +90,13 @@ dal_public_includes(
 dal_static_lib(
     name = "static",
     lib_name = "onedal",
+    lib_tags = _DAL_LIB_TAGS,
     dal_deps = [
         ":core",
         ":optional",
     ],
+    host_deps = parameters_lib_disabled(_PARAMETER_MODULES),
+    dpc_deps = parameters_lib_disabled(_PARAMETER_MODULES_DPC),
 )
 
 dal_static_lib(
@@ -117,7 +137,7 @@ dal_dynamic_lib(
     lib_tags = select({
         "@platforms//os:windows": ["dal", "mkl_embed"],
         "//conditions:default": ["dal"],
-    }),
+    }) + parameters_lib_disabled(["parameters"]),
     # `BUILD_PARAMETERS_LIB` defaults to `no` on Windows, so Make folds the DPC
     # parameter objects straight into onedal_dpc.dll
     # (`ONEAPI.objs_y.dpc.lib += $(PARAMETERS.objs_y.dpc.filtered)`). Those
@@ -137,28 +157,19 @@ dal_dynamic_lib(
     dpc_lib_tags = select({
         "@platforms//os:windows": ["dal", "parameters"],
         "//conditions:default": ["dal", "daal", "mkl_embed"],
-    }),
+    }) + parameters_lib_disabled(["parameters"]),
     dal_deps = [
         ":core",
         ":optional",
     ],
+    dpc_deps = parameters_lib_disabled(_PARAMETER_MODULES_DPC),
     # On Windows, link onedal_core's import library plus parameter objects and
     # delay-load threading shims. Keep DAAL/MKL implementation in onedal_core.
-    #   - core_dynamic: import library that resolves the DAAL algorithm and
-    #     MKL backend symbols the oneAPI objects reference. `host_deps` is
-    #     appended to both the host and the DPC link, so it must be listed
-    #     here only -- repeating it in `dpc_deps` makes the label duplicate in
-    #     `dynamic_dpc` and fails analysis.
-    #   - static_parameters: parameter symbols not part of any other dep tree.
-    #   - services_win_dll_shim: delay-load stubs for threading entry points
-    #     (e.g. `_threaded_scalable_*`, `_daal_static_threader_reduce`) that
-    #     the DAAL objects reference. The real TBB-backed symbols live in
-    #     onedal_thread.dll. Mirrors onedal_core.dll above and the original
-    #     Make build.
-    host_deps = select({
+    # `host_deps` is appended to both the host and the DPC link, so shared
+    # Windows dependencies belong here rather than being duplicated.
+    host_deps = parameters_lib_disabled(_PARAMETER_MODULES) + select({
         "@platforms//os:windows": [
             "@onedal//cpp/daal:core_dynamic",
-            ":static_parameters",
             "@onedal//cpp/daal:services_win_dll_shim",
         ],
         "//conditions:default": [],
@@ -204,9 +215,10 @@ filegroup(
     srcs = [
         ":static",
         ":static_dpc",
+    ] + parameters_lib_enabled([
         ":static_parameters",
         ":static_parameters_dpc",
-    ],
+    ]),
 )
 
 filegroup(
@@ -214,9 +226,10 @@ filegroup(
     srcs = [
         ":dynamic",
         ":dynamic_dpc",
+    ] + parameters_lib_enabled([
         ":dynamic_parameters",
         ":dynamic_parameters_dpc",
-    ],
+    ]),
 )
 
 dal_test_suite(

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -12,6 +12,7 @@ load("@onedal//dev/bazel:dal.bzl",
 load("@onedal//dev/bazel/config:selects.bzl",
     "parameters_lib_disabled",
     "parameters_lib_enabled",
+    "parameters_lib_target_compatible_with",
 )
 
 _PARAMETER_MODULES = [
@@ -174,6 +175,13 @@ dal_dynamic_lib(
         ],
         "//conditions:default": [],
     }),
+    dpc_host_deps = select({
+        "@platforms//os:windows": [
+            "@onedal//cpp/daal:core_dynamic",
+            "@onedal//cpp/daal:services_win_dll_shim",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 dal_dynamic_lib(
@@ -208,6 +216,14 @@ dal_dynamic_lib(
         ],
         "//conditions:default": [],
     }),
+    dpc_host_deps = select({
+        "@platforms//os:windows": [
+            "@onedal//cpp/daal:core_dynamic",
+            "@onedal//cpp/daal:services_win_dll_shim",
+        ],
+        "//conditions:default": [],
+    }),
+    target_compatible_with = parameters_lib_target_compatible_with(),
 )
 
 filegroup(

--- a/deploy/pkg-config/pkg-config.cpp
+++ b/deploy/pkg-config/pkg-config.cpp
@@ -28,13 +28,16 @@
         #error Unknown CPU architecture
     #endif
 
-    #define OTHER_LIBS -lmkl_core -lmkl_intel_lp64 -lmkl_tbb_thread -ltbb -ltbbmalloc -lpthread -ldl
     #define ONEDAL_LIBS PATH(onedal) PATH(onedal_core) PATH(onedal_thread) PATH(onedal_parameters)
 
+    // The static libraries are built against the ILP64 oneMKL interface, the
+    // dynamic ones against LP64 (see `dev/make/deps.mkl.mk`).
     #ifdef STATIC
         #define SUFFIX a
+        #define OTHER_LIBS -lmkl_core -lmkl_intel_ilp64 -lmkl_tbb_thread -ltbb -ltbbmalloc -lpthread -ldl
     #else
         #define SUFFIX so
+        #define OTHER_LIBS -lmkl_core -lmkl_intel_lp64 -lmkl_tbb_thread -ltbb -ltbbmalloc -lpthread -ldl
     #endif
 
     #define PATH(inp) ${libdir}/lib##inp.SUFFIX

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -700,7 +700,8 @@ configured release outputs, host/DPC dependency separation, folded-target
 rejection, and Windows value validation. It does not build DPC binaries.
 `dev/release_tests/parameters_layout_consumer_test.sh` separately builds and
 runs host static and dynamic consumers through packaged CMake, pkg-config, and
-Bazel metadata for the folded layout.
+Bazel metadata for the folded layout. Both take `bazel` from `PATH`; set `BAZEL`
+to run them against a specific binary, such as a downloaded `bazelisk`.
 
 ## Make → Bazel Flag Reference
 

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -682,10 +682,10 @@ Bazel mirrors Make's `BUILD_PARAMETERS_LIB` switch with the typed
 `--build_parameters_lib=auto|yes|no` setting:
 
 - `auto` (default) builds separate `libonedal_parameters` and
-  `libonedal_parameters_dpc` libraries on Linux, and folds those objects into
-  `onedal`/`onedal_dpc` on Windows.
-- `yes` selects the separate host and DPC parameter libraries on Linux. It is
-  unsupported on Windows and fails during analysis with a diagnostic.
+  `libonedal_parameters_dpc` libraries on non-Windows targets, and folds those
+  objects into `onedal`/`onedal_dpc` on Windows.
+- `yes` selects the separate host and DPC parameter libraries on non-Windows
+  targets. It is unsupported on Windows and fails during analysis with a diagnostic.
 - `no` folds the host and DPC parameter modules into the corresponding main
   libraries and omits separate parameter libraries from `//:release`.
 
@@ -695,11 +695,18 @@ For example:
 bazel build //:release --build_parameters_lib=no
 ```
 
+CI uses `dev/bazel/tests/parameters_layout_test.sh` for analysis-only checks of
+configured release outputs, host/DPC dependency separation, folded-target
+rejection, and Windows value validation. It does not build DPC binaries.
+`dev/release_tests/parameters_layout_consumer_test.sh` separately builds and
+runs host static and dynamic consumers through packaged CMake, pkg-config, and
+Bazel metadata for the folded layout.
+
 ## Make → Bazel Flag Reference
 
 | Make option                    | Bazel equivalent                                             | Notes                                                                      |
 |--------------------------------|--------------------------------------------------------------|----------------------------------------------------------------------------|
-| `BUILD_PARAMETERS_LIB=yes|no` | `--build_parameters_lib=yes|no`                              | `auto` preserves Linux `yes` / Windows `no` defaults; Windows `yes` is unsupported |
+| `BUILD_PARAMETERS_LIB=yes|no` | `--build_parameters_lib=yes|no`                              | `auto` preserves non-Windows `yes` / Windows `no` defaults; Windows `yes` is unsupported |
 | `REQDBG=yes`                   | `--config=dbg`                                               | Debug symbols + assertions                                                 |
 | `REQDBG=symbols`               | `--config=dbg-symbols`                                       | Debug symbols only                                                         |
 | `REQSAN=address`               | `--config=asan`                                              | AddressSanitizer                                                           |

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -676,10 +676,30 @@ build --linkopt=-your-link-flag
 
 ---
 
+## Parameter library layout
+
+Bazel mirrors Make's `BUILD_PARAMETERS_LIB` switch with the typed
+`--build_parameters_lib=auto|yes|no` setting:
+
+- `auto` (default) builds separate `libonedal_parameters` and
+  `libonedal_parameters_dpc` libraries on Linux, and folds those objects into
+  `onedal`/`onedal_dpc` on Windows.
+- `yes` selects the separate host and DPC parameter libraries on Linux. It is
+  unsupported on Windows and fails during analysis with a diagnostic.
+- `no` folds the host and DPC parameter modules into the corresponding main
+  libraries and omits separate parameter libraries from `//:release`.
+
+For example:
+
+```
+bazel build //:release --build_parameters_lib=no
+```
+
 ## Make → Bazel Flag Reference
 
 | Make option                    | Bazel equivalent                                             | Notes                                                                      |
 |--------------------------------|--------------------------------------------------------------|----------------------------------------------------------------------------|
+| `BUILD_PARAMETERS_LIB=yes|no` | `--build_parameters_lib=yes|no`                              | `auto` preserves Linux `yes` / Windows `no` defaults; Windows `yes` is unsupported |
 | `REQDBG=yes`                   | `--config=dbg`                                               | Debug symbols + assertions                                                 |
 | `REQDBG=symbols`               | `--config=dbg-symbols`                                       | Debug symbols only                                                         |
 | `REQSAN=address`               | `--config=asan`                                              | AddressSanitizer                                                           |

--- a/dev/bazel/cc.bzl
+++ b/dev/bazel/cc.bzl
@@ -85,12 +85,16 @@ def _init_cc_rule(ctx, features=[], disable_features=[]):
     )
     return cc_toolchain, feature_config
 
+def _is_windows(ctx):
+    return ctx.target_platform_has_constraint(
+        ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
+    )
+
+
 def _cc_module_impl(ctx):
     toolchain, feature_config = _init_cc_rule(ctx)
     dep_compilation_contexts = onedal_cc_common.collect_compilation_contexts(ctx.attr.deps)
-    is_windows = ctx.target_platform_has_constraint(
-        ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
-    )
+    is_windows = _is_windows(ctx)
     compilation_context, compilation_outputs = onedal_cc_compile.compile(
         name = ctx.label.name,
         ctx = ctx,
@@ -187,23 +191,21 @@ def cc_module(name, hdrs=[], deps=[], **kwargs):
     )
 
 
-def _validate_build_parameters_lib(ctx):
+def _validate_build_parameters_lib(ctx, is_windows):
+    # The policy itself lives in config.bzl so this rule and
+    # @config//:validate_build_parameters_lib state it once. Only the two
+    # inputs are read from the rule context here.
     value = ctx.attr._build_parameters_lib[ConfigFlagInfo].flag
-    is_windows = ctx.target_platform_has_constraint(
-        ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
-    )
     validate_build_parameters_lib(value, is_windows)
 
 
 def _cc_static_lib_impl(ctx):
-    _validate_build_parameters_lib(ctx)
+    is_windows = _is_windows(ctx)
+    _validate_build_parameters_lib(ctx, is_windows)
     toolchain, feature_config = _init_cc_rule(ctx)
     compilation_context = onedal_cc_common.collect_and_merge_compilation_contexts(ctx.attr.deps)
     linking_contexts = onedal_cc_common.collect_and_filter_linking_contexts(
         ctx.attr.deps, ctx.attr.lib_tags)
-    is_windows = ctx.target_platform_has_constraint(
-        ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
-    )
     linking_context, static_lib = onedal_cc_link.static(
         owner = ctx.label,
         name = ctx.attr.lib_name,
@@ -270,10 +272,8 @@ def _copy_dynamic_release_file(ctx, src, out_name, is_windows = False, extra_inp
 
 
 def _cc_dynamic_lib_impl(ctx):
-    _validate_build_parameters_lib(ctx)
-    is_windows = ctx.target_platform_has_constraint(
-        ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
-    )
+    is_windows = _is_windows(ctx)
+    _validate_build_parameters_lib(ctx, is_windows)
     # On Linux, keep produced shared libraries free of dynamic Bazel deps.
     # Release-dynamic tests provide standalone oneDAL libs through
     # DALROOT/LD_LIBRARY_PATH while Bazel-provided runtimes such as TBB
@@ -386,9 +386,7 @@ def _cc_exec_impl(ctx):
     if not ctx.attr.deps:
         return
     toolchain, feature_config = _init_cc_rule(ctx)
-    is_windows = ctx.target_platform_has_constraint(
-        ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
-    )
+    is_windows = _is_windows(ctx)
     tagged_linking_contexts = onedal_cc_common.collect_tagged_linking_contexts(ctx.attr.deps)
     linking_contexts = onedal_cc_common.filter_tagged_linking_contexts(
         tagged_linking_contexts, ctx.attr.lib_tags)

--- a/dev/bazel/cc.bzl
+++ b/dev/bazel/cc.bzl
@@ -23,7 +23,9 @@ load("@onedal//dev/bazel:utils.bzl",
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@onedal//dev/bazel/config:config.bzl",
     "CpuInfo",
+    "ConfigFlagInfo",
     "VersionInfo",
+    "validate_build_parameters_lib",
 )
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
@@ -185,7 +187,16 @@ def cc_module(name, hdrs=[], deps=[], **kwargs):
     )
 
 
+def _validate_build_parameters_lib(ctx):
+    value = ctx.attr._build_parameters_lib[ConfigFlagInfo].flag
+    is_windows = ctx.target_platform_has_constraint(
+        ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
+    )
+    validate_build_parameters_lib(value, is_windows)
+
+
 def _cc_static_lib_impl(ctx):
+    _validate_build_parameters_lib(ctx)
     toolchain, feature_config = _init_cc_rule(ctx)
     compilation_context = onedal_cc_common.collect_and_merge_compilation_contexts(ctx.attr.deps)
     linking_contexts = onedal_cc_common.collect_and_filter_linking_contexts(
@@ -219,6 +230,10 @@ cc_static_lib = rule(
         "deps": attr.label_list(mandatory=True),
         "_windows_constraint": attr.label(
             default = "@platforms//os:windows",
+        ),
+        "_build_parameters_lib": attr.label(
+            default = "@config//:build_parameters_lib",
+            providers = [ConfigFlagInfo],
         ),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
@@ -255,6 +270,7 @@ def _copy_dynamic_release_file(ctx, src, out_name, is_windows = False, extra_inp
 
 
 def _cc_dynamic_lib_impl(ctx):
+    _validate_build_parameters_lib(ctx)
     is_windows = ctx.target_platform_has_constraint(
         ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
     )
@@ -300,6 +316,7 @@ def _cc_dynamic_lib_impl(ctx):
         user_link_flags = linux_soname_flags + linux_linker_script_flags + (["-Wl,--exclude-libs=ALL"] if not is_windows else []) + ctx.attr.linkopts,
         is_windows = is_windows,
         additional_inputs = ctx.files.linker_scripts,
+        is_dpc = ctx.attr.lib_name.endswith("_dpc") or ctx.label.name.endswith("_dpc"),
         dll_to_implib_tool = ctx.file._dll_to_implib if is_windows else None,
     )
     default_files = dynamic_outputs.files
@@ -351,6 +368,10 @@ cc_dynamic_lib = rule(
         "_version_info": attr.label(
             default = "@config//:version",
             providers = [VersionInfo],
+        ),
+        "_build_parameters_lib": attr.label(
+            default = "@config//:build_parameters_lib",
+            providers = [ConfigFlagInfo],
         ),
         "_dll_to_implib": attr.label(
             default = "@onedal//dev/bazel/toolchains/tools:dll_to_implib.bat",

--- a/dev/bazel/cc.bzl
+++ b/dev/bazel/cc.bzl
@@ -316,7 +316,6 @@ def _cc_dynamic_lib_impl(ctx):
         user_link_flags = linux_soname_flags + linux_linker_script_flags + (["-Wl,--exclude-libs=ALL"] if not is_windows else []) + ctx.attr.linkopts,
         is_windows = is_windows,
         additional_inputs = ctx.files.linker_scripts,
-        is_dpc = ctx.attr.lib_name.endswith("_dpc") or ctx.label.name.endswith("_dpc"),
         dll_to_implib_tool = ctx.file._dll_to_implib if is_windows else None,
     )
     default_files = dynamic_outputs.files

--- a/dev/bazel/config/config.bzl
+++ b/dev/bazel/config/config.bzl
@@ -80,6 +80,33 @@ unsupported_config = rule(
     },
 )
 
+
+def validate_build_parameters_lib(value, is_windows):
+    if is_windows and value == "yes":
+        fail("--build_parameters_lib=yes is not supported on Windows; use auto or no")
+
+
+def _build_parameters_lib_validation_impl(ctx):
+    value = ctx.attr.flag[ConfigFlagInfo].flag
+    is_windows = ctx.target_platform_has_constraint(
+        ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
+    )
+    validate_build_parameters_lib(value, is_windows)
+    return []
+
+build_parameters_lib_validation = rule(
+    implementation = _build_parameters_lib_validation_impl,
+    attrs = {
+        "flag": attr.label(
+            mandatory = True,
+            providers = [ConfigFlagInfo],
+        ),
+        "_windows_constraint": attr.label(
+            default = "@platforms//os:windows",
+        ),
+    },
+)
+
 CpuInfo = provider(
     fields = [
         "enabled",

--- a/dev/bazel/config/config.tpl.BUILD
+++ b/dev/bazel/config/config.tpl.BUILD
@@ -54,8 +54,8 @@ config_setting(
     ],
 )
 
-# Make BUILD_PARAMETERS_LIB parity. "auto" follows the supported platform
-# defaults: separate parameter libraries on Linux, folded libraries on Windows.
+# Make BUILD_PARAMETERS_LIB parity. "auto" means yes on every non-Windows
+# target and no on Windows. Explicit yes is rejected on Windows.
 config_flag(
     name = "build_parameters_lib",
     build_setting_default = "auto",
@@ -67,45 +67,20 @@ config_flag(
 )
 
 config_setting(
-    name = "build_parameters_lib_auto_linux",
-    flag_values = {
-        ":build_parameters_lib": "auto",
-    },
-    constraint_values = [
-        "@platforms//os:linux",
-    ],
+    name = "build_parameters_lib_auto_windows",
+    flag_values = {":build_parameters_lib": "auto"},
+    constraint_values = ["@platforms//os:windows"],
 )
 
 config_setting(
-    name = "build_parameters_lib_yes_linux",
-    flag_values = {
-        ":build_parameters_lib": "yes",
-    },
-    constraint_values = [
-        "@platforms//os:linux",
-    ],
+    name = "build_parameters_lib_yes_windows",
+    flag_values = {":build_parameters_lib": "yes"},
+    constraint_values = ["@platforms//os:windows"],
 )
 
 config_setting(
-    name = "release_dpc_build_parameters_lib_auto_linux",
-    flag_values = {
-        ":build_parameters_lib": "auto",
-        ":release_dpc": "True",
-    },
-    constraint_values = [
-        "@platforms//os:linux",
-    ],
-)
-
-config_setting(
-    name = "release_dpc_build_parameters_lib_yes_linux",
-    flag_values = {
-        ":build_parameters_lib": "yes",
-        ":release_dpc": "True",
-    },
-    constraint_values = [
-        "@platforms//os:linux",
-    ],
+    name = "release_dpc_disabled",
+    flag_values = {":release_dpc": "False"},
 )
 
 build_parameters_lib_validation(
@@ -113,7 +88,7 @@ build_parameters_lib_validation(
     flag = ":build_parameters_lib",
 )
 
-# Toolchain-free target platform used by the analysis-only rejection smoke test.
+# Toolchain-free target platform used by cross-platform analysis smoke tests.
 platform(
     name = "windows_analysis_platform",
     constraint_values = [

--- a/dev/bazel/config/config.tpl.BUILD
+++ b/dev/bazel/config/config.tpl.BUILD
@@ -4,6 +4,7 @@ load("@onedal//dev/bazel/config:config.bzl",
     "version_info",
     "config_flag",
     "config_bool_flag",
+    "build_parameters_lib_validation",
     "dump_config_info",
     "unsupported_config",
 )
@@ -50,6 +51,74 @@ config_setting(
     },
     constraint_values = [
         "@platforms//os:linux",
+    ],
+)
+
+# Make BUILD_PARAMETERS_LIB parity. "auto" follows the supported platform
+# defaults: separate parameter libraries on Linux, folded libraries on Windows.
+config_flag(
+    name = "build_parameters_lib",
+    build_setting_default = "auto",
+    allowed_build_setting_values = [
+        "auto",
+        "yes",
+        "no",
+    ],
+)
+
+config_setting(
+    name = "build_parameters_lib_auto_linux",
+    flag_values = {
+        ":build_parameters_lib": "auto",
+    },
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "build_parameters_lib_yes_linux",
+    flag_values = {
+        ":build_parameters_lib": "yes",
+    },
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "release_dpc_build_parameters_lib_auto_linux",
+    flag_values = {
+        ":build_parameters_lib": "auto",
+        ":release_dpc": "True",
+    },
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "release_dpc_build_parameters_lib_yes_linux",
+    flag_values = {
+        ":build_parameters_lib": "yes",
+        ":release_dpc": "True",
+    },
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+build_parameters_lib_validation(
+    name = "validate_build_parameters_lib",
+    flag = ":build_parameters_lib",
+)
+
+# Toolchain-free target platform used by the analysis-only rejection smoke test.
+platform(
+    name = "windows_analysis_platform",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
     ],
 )
 
@@ -185,6 +254,7 @@ dump_config_info(
     cpu_info = ":cpu",
     version_info = ":version",
     flags = [
+        ":build_parameters_lib",
         ":test_link_mode",
         ":test_thread_mode",
     ],

--- a/dev/bazel/config/selects.bzl
+++ b/dev/bazel/config/selects.bzl
@@ -1,0 +1,38 @@
+#===============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#===============================================================================
+
+"""Central selects for the BUILD_PARAMETERS_LIB layout."""
+
+
+def parameters_lib_enabled(values):
+    """Returns values when parameter libraries use the separate layout."""
+    return select({
+        "@config//:build_parameters_lib_auto_linux": values,
+        "@config//:build_parameters_lib_yes_linux": values,
+        "//conditions:default": [],
+    })
+
+
+def parameters_lib_disabled(values):
+    """Returns values when parameter objects must be folded into main libs."""
+    return select({
+        "@config//:build_parameters_lib_auto_linux": [],
+        "@config//:build_parameters_lib_yes_linux": [],
+        "//conditions:default": values,
+    })
+
+
+def release_dpc_parameters_lib_enabled(values):
+    """Returns values when both DPC release and separate parameters are enabled."""
+    return select({
+        "@config//:release_dpc_build_parameters_lib_auto_linux": values,
+        "@config//:release_dpc_build_parameters_lib_yes_linux": values,
+        "//conditions:default": [],
+    })

--- a/dev/bazel/config/selects.bzl
+++ b/dev/bazel/config/selects.bzl
@@ -6,6 +6,12 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #===============================================================================
 
 """Central selects for the BUILD_PARAMETERS_LIB layout."""

--- a/dev/bazel/config/selects.bzl
+++ b/dev/bazel/config/selects.bzl
@@ -10,29 +10,39 @@
 
 """Central selects for the BUILD_PARAMETERS_LIB layout."""
 
+_FOLDED = [
+    "@config//:build_parameters_lib_auto_windows",
+    "@config//:build_parameters_lib_yes_windows",
+    "@config//:build_parameters_lib_no",
+]
 
 def parameters_lib_enabled(values):
-    """Returns values when parameter libraries use the separate layout."""
-    return select({
-        "@config//:build_parameters_lib_auto_linux": values,
-        "@config//:build_parameters_lib_yes_linux": values,
-        "//conditions:default": [],
-    })
-
+    """Values for separate layout: auto on non-Windows, or explicit yes."""
+    choices = {setting: [] for setting in _FOLDED}
+    choices["//conditions:default"] = values
+    return select(choices)
 
 def parameters_lib_disabled(values):
-    """Returns values when parameter objects must be folded into main libs."""
-    return select({
-        "@config//:build_parameters_lib_auto_linux": [],
-        "@config//:build_parameters_lib_yes_linux": [],
-        "//conditions:default": values,
-    })
+    """Values for folded layout: no, and auto/unsupported yes on Windows."""
+    choices = {setting: values for setting in _FOLDED}
+    choices["//conditions:default"] = []
+    return select(choices)
 
+def parameters_lib_target_compatible_with():
+    """Reject public parameter-library targets when the layout is folded."""
+    choices = {setting: ["@platforms//:incompatible"] for setting in _FOLDED}
+    choices["//conditions:default"] = []
+    return select(choices)
+
+def parameters_lib_separate_value():
+    """Boolean metadata value for the selected release layout."""
+    choices = {setting: False for setting in _FOLDED}
+    choices["//conditions:default"] = True
+    return select(choices)
 
 def release_dpc_parameters_lib_enabled(values):
-    """Returns values when both DPC release and separate parameters are enabled."""
-    return select({
-        "@config//:release_dpc_build_parameters_lib_auto_linux": values,
-        "@config//:release_dpc_build_parameters_lib_yes_linux": values,
-        "//conditions:default": [],
-    })
+    """Values when DPC release and separate parameters are both enabled."""
+    choices = {setting: [] for setting in _FOLDED}
+    choices["@config//:release_dpc_disabled"] = []
+    choices["//conditions:default"] = values
+    return select(choices)

--- a/dev/bazel/dal.bzl
+++ b/dev/bazel/dal.bzl
@@ -144,7 +144,7 @@ def dal_static_lib(name, lib_name, dal_deps=[], host_deps=[],
     )
 
 def dal_dynamic_lib(name, lib_name, dal_deps=[], host_deps=[],
-                    dpc_deps=[], extra_deps=[], lib_tags=["dal"],
+                    dpc_deps=[], dpc_host_deps=[], extra_deps=[], lib_tags=["dal"],
                     dpc_lib_tags=None, features=[], **kwargs):
     cc_dynamic_lib(
         name = name,
@@ -158,9 +158,10 @@ def dal_dynamic_lib(name, lib_name, dal_deps=[], host_deps=[],
         features = features + [ "dpc++" ],
         lib_name = lib_name + "_dpc",
         lib_tags = dpc_lib_tags if dpc_lib_tags != None else lib_tags,
-        # Some dynamic DPC libraries also need host-only objects, e.g. the
-        # Windows delay-load shim for DAAL threading symbols.
-        deps = _get_dpc_deps(dal_deps) + extra_deps + dpc_deps + host_deps,
+        # dpc_host_deps is reserved for platform glue compiled as host code
+        # into a DPC library. Never forward ordinary host_deps here: doing so
+        # folds host parameter objects into the DPC library as duplicates.
+        deps = _get_dpc_deps(dal_deps) + extra_deps + dpc_deps + dpc_host_deps,
         **kwargs
     )
 

--- a/dev/bazel/deps/onedal.bzl
+++ b/dev/bazel/deps/onedal.bzl
@@ -25,7 +25,6 @@ onedal_repo = repos.prebuilt_libs_repo_rule(
         "lib/intel64/libonedal_core.a",
         "lib/intel64/libonedal_thread.a",
         "lib/intel64/libonedal.a",
-        "lib/intel64/libonedal_parameters.a",
 
         # Dynamic
         "lib/intel64/libonedal_core.so",
@@ -40,6 +39,9 @@ onedal_repo = repos.prebuilt_libs_repo_rule(
         "lib/intel64/libonedal_dpc.so",
         "lib/intel64/libonedal_dpc.so.%{version_binary_major}",
         "lib/intel64/libonedal_dpc.so.%{version_binary_major}.%{version_binary_minor}",
+    ],
+    optional_libs = [
+        "lib/intel64/libonedal_parameters.a",
         "lib/intel64/libonedal_parameters.so",
         "lib/intel64/libonedal_parameters.so.%{version_binary_major}",
         "lib/intel64/libonedal_parameters.so.%{version_binary_major}.%{version_binary_minor}",

--- a/dev/bazel/deps/onedal.tpl.BUILD
+++ b/dev/bazel/deps/onedal.tpl.BUILD
@@ -46,17 +46,8 @@ cc_library(
     ],
 )
 
-cc_library(
-    name = "onedal_static_dpc",
-    srcs = [
-        "lib/intel64/libonedal_dpc.a",
-%{parameters_dpc_static_src}
-    ],
-    deps = [
-        ":headers",
-        "@mkl//:mkl_dpc",
-    ],
-)
+# Packaged oneDAL releases expose DPC libraries only in dynamic form, so no
+# static-DPC consumer target is declared here.
 
 cc_library(
     name = "core_dynamic",

--- a/dev/bazel/deps/onedal.tpl.BUILD
+++ b/dev/bazel/deps/onedal.tpl.BUILD
@@ -39,7 +39,7 @@ cc_library(
     name = "onedal_static",
     srcs = [
         "lib/intel64/libonedal.a",
-        "lib/intel64/libonedal_parameters.a",
+%{parameters_static_src}
     ],
     deps = [
         ":headers",
@@ -50,7 +50,7 @@ cc_library(
     name = "onedal_static_dpc",
     srcs = [
         "lib/intel64/libonedal_dpc.a",
-        "lib/intel64/libonedal_parameters_dpc.a",
+%{parameters_dpc_static_src}
     ],
     deps = [
         ":headers",
@@ -103,7 +103,7 @@ cc_library(
         # Link through the SONAME symlinks. Bazel's _solib runfiles then expose
         # names like libonedal.so.4, matching DT_NEEDED in test executables.
         "lib/intel64/libonedal.so.%{version_binary_major}",
-        "lib/intel64/libonedal_parameters.so.%{version_binary_major}",
+%{parameters_dynamic_src}
     ]),
     deps = [
         ":headers",
@@ -123,8 +123,8 @@ cc_library(
     name = "onedal_dynamic_dpc",
     srcs = glob([
         "lib/intel64/libonedal_dpc.so.%{version_binary_major}",
-        # Link through the SONAME symlink for the same _solib/runfiles reason.
-        "lib/intel64/libonedal_parameters_dpc.so.%{version_binary_major}",
+%{parameters_dpc_dynamic_src}
+        # The optional parameter SONAME follows generated package metadata.
     ], allow_empty=True),
     deps = [
         ":headers",

--- a/dev/bazel/deps/onedal.tpl.BUILD
+++ b/dev/bazel/deps/onedal.tpl.BUILD
@@ -39,8 +39,13 @@ cc_library(
     name = "onedal_static",
     srcs = [
         "lib/intel64/libonedal.a",
-%{parameters_static_src}
-    ],
+    ] + glob([
+        # Present only when the package ships separate parameter libraries.
+        # `repos.bzl` symlinks these from `optional_libs` after reading the
+        # layout out of the package's own oneDALConfig.cmake, so an absent
+        # entry here means a folded package, not a broken one.
+        "lib/intel64/libonedal_parameters.a",
+    ], allow_empty = True),
     deps = [
         ":headers",
     ],
@@ -94,8 +99,10 @@ cc_library(
         # Link through the SONAME symlinks. Bazel's _solib runfiles then expose
         # names like libonedal.so.4, matching DT_NEEDED in test executables.
         "lib/intel64/libonedal.so.%{version_binary_major}",
-%{parameters_dynamic_src}
-    ]),
+    ]) + glob([
+        # Separate-layout only; see `onedal_static` above.
+        "lib/intel64/libonedal_parameters.so.%{version_binary_major}",
+    ], allow_empty = True),
     deps = [
         ":headers",
         "@mkl//:mkl_static",
@@ -114,9 +121,9 @@ cc_library(
     name = "onedal_dynamic_dpc",
     srcs = glob([
         "lib/intel64/libonedal_dpc.so.%{version_binary_major}",
-%{parameters_dpc_dynamic_src}
-        # The optional parameter SONAME follows generated package metadata.
-    ], allow_empty=True),
+        # Separate-layout only; see `onedal_static` above.
+        "lib/intel64/libonedal_parameters_dpc.so.%{version_binary_major}",
+    ], allow_empty = True),
     deps = [
         ":headers",
         "@mkl//:mkl_dpc",

--- a/dev/bazel/repos.bzl
+++ b/dev/bazel/repos.bzl
@@ -200,7 +200,6 @@ def _prebuilt_libs_repo_impl(repo_ctx):
         parameters_lib = "yes"
     substitutions["%{parameters_static_src}"] = ("        \"lib/intel64/libonedal_parameters.a\"," if parameters_lib == "yes" else "")
     substitutions["%{parameters_dynamic_src}"] = ("        \"lib/intel64/libonedal_parameters.so.{}\",".format(_BINARY_MAJOR) if parameters_lib == "yes" else "")
-    substitutions["%{parameters_dpc_static_src}"] = ("        \"lib/intel64/libonedal_parameters_dpc.a\"," if parameters_lib == "yes" else "")
     substitutions["%{parameters_dpc_dynamic_src}"] = ("        \"lib/intel64/libonedal_parameters_dpc.so.{}\",".format(_BINARY_MAJOR) if parameters_lib == "yes" else "")
 
     _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "includes", os_id), substitutions, mapping)

--- a/dev/bazel/repos.bzl
+++ b/dev/bazel/repos.bzl
@@ -188,9 +188,25 @@ def _prebuilt_libs_repo_impl(repo_ctx):
     }
     substitutions["%{version_binary_major}"] = _BINARY_MAJOR
     substitutions["%{version_binary_minor}"] = _BINARY_MINOR
+    cmake_config = repo_ctx.path(paths.join(root, "lib/cmake/oneDAL/oneDALConfig.cmake"))
+    cmake_config_text = repo_ctx.read(cmake_config) if cmake_config.exists else ""
+    if 'set(ONEDAL_USE_PARAMETERS_LIBRARY "no")' in cmake_config_text:
+        parameters_lib = "no"
+    elif 'set(ONEDAL_USE_PARAMETERS_LIBRARY "yes")' in cmake_config_text:
+        parameters_lib = "yes"
+    else:
+        # Legacy packages predate explicit layout metadata and always used the
+        # separate non-Windows layout consumed by this template.
+        parameters_lib = "yes"
+    substitutions["%{parameters_static_src}"] = ("        \"lib/intel64/libonedal_parameters.a\"," if parameters_lib == "yes" else "")
+    substitutions["%{parameters_dynamic_src}"] = ("        \"lib/intel64/libonedal_parameters.so.{}\",".format(_BINARY_MAJOR) if parameters_lib == "yes" else "")
+    substitutions["%{parameters_dpc_static_src}"] = ("        \"lib/intel64/libonedal_parameters_dpc.a\"," if parameters_lib == "yes" else "")
+    substitutions["%{parameters_dpc_dynamic_src}"] = ("        \"lib/intel64/libonedal_parameters_dpc.so.{}\",".format(_BINARY_MAJOR) if parameters_lib == "yes" else "")
 
     _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "includes", os_id), substitutions, mapping)
     _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "libs", os_id), substitutions, mapping)
+    if parameters_lib == "yes":
+        _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "optional_libs", os_id), substitutions, mapping)
     _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "bins", os_id), substitutions, mapping)
     repo_ctx.template(
         "BUILD",
@@ -198,7 +214,7 @@ def _prebuilt_libs_repo_impl(repo_ctx):
         substitutions = substitutions,
     )
 
-def _prebuilt_libs_repo_rule(includes, libs, build_template, bins=[],
+def _prebuilt_libs_repo_rule(includes, libs, build_template, bins=[], optional_libs=[],
                              root_env_var="", fallback_root="",
                              url="", sha256="", strip_prefix="",
                              local_mapping={}, download_mapping={},
@@ -223,6 +239,7 @@ def _prebuilt_libs_repo_rule(includes, libs, build_template, bins=[],
             "strip_prefixes": attr.string_list(default=[]),
             "includes": attr.string_list(default=includes),
             "libs": attr.string_list(default=libs),
+            "optional_libs": attr.string_list(default=optional_libs),
             "bins": attr.string_list(default=bins),
             "build_template": attr.label(allow_files=True,
                                          default=Label(build_template)),

--- a/dev/bazel/repos.bzl
+++ b/dev/bazel/repos.bzl
@@ -198,12 +198,13 @@ def _prebuilt_libs_repo_impl(repo_ctx):
         # Legacy packages predate explicit layout metadata and always used the
         # separate non-Windows layout consumed by this template.
         parameters_lib = "yes"
-    substitutions["%{parameters_static_src}"] = ("        \"lib/intel64/libonedal_parameters.a\"," if parameters_lib == "yes" else "")
-    substitutions["%{parameters_dynamic_src}"] = ("        \"lib/intel64/libonedal_parameters.so.{}\",".format(_BINARY_MAJOR) if parameters_lib == "yes" else "")
-    substitutions["%{parameters_dpc_dynamic_src}"] = ("        \"lib/intel64/libonedal_parameters_dpc.so.{}\",".format(_BINARY_MAJOR) if parameters_lib == "yes" else "")
 
     _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "includes", os_id), substitutions, mapping)
     _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "libs", os_id), substitutions, mapping)
+    # `optional_libs` is the only thing the layout decides. The BUILD template
+    # picks these up with `glob(..., allow_empty = True)`, so not symlinking
+    # them is what makes a folded package resolve to a template without
+    # parameter libraries -- no template substitution is involved.
     if parameters_lib == "yes":
         _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "optional_libs", os_id), substitutions, mapping)
     _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "bins", os_id), substitutions, mapping)

--- a/dev/bazel/scripts.bzl
+++ b/dev/bazel/scripts.bzl
@@ -96,6 +96,7 @@ def _generate_cmake_config_impl(ctx):
             "@DLL_REL_PATH@": "redist",
             "@INC_REL_PATH@": "include",
             "@oneDAL_VERSION@": "",
+            "@ONEDAL_USE_PARAMETERS_LIBRARY@": "yes" if ctx.attr.parameters_lib else "no",
         },
     )
     return [DefaultInfo(files = depset([out]))]
@@ -108,6 +109,7 @@ _generate_cmake_config = rule(
             mandatory = True,
         ),
         "out": attr.string(mandatory = True),
+        "parameters_lib": attr.bool(default = True),
         "_version_info": attr.label(
             default = "@config//:version",
             providers = [VersionInfo],

--- a/dev/bazel/scripts.bzl
+++ b/dev/bazel/scripts.bzl
@@ -185,7 +185,8 @@ Cflags: /std:c++17 /MD /wd4996 /EHsc -I${{includedir}}
     else:
         suffix = "a" if ctx.attr.static else "so"
         if ctx.attr.parameters_lib:
-            onedal_libs = "${{libdir}}/libonedal.{0} ${{libdir}}/libonedal_core.{0} ${{libdir}}/libonedal_thread.{0} ${{libdir}}/libonedal_parameters.{0} -lmkl_core -lmkl_intel_lp64 -lmkl_tbb_thread -ltbb -ltbbmalloc -lpthread -ldl".format(suffix)
+            mkl_interface = "intel_ilp64" if ctx.attr.static else "intel_lp64"
+            onedal_libs = "${{libdir}}/libonedal.{0} ${{libdir}}/libonedal_core.{0} ${{libdir}}/libonedal_thread.{0} ${{libdir}}/libonedal_parameters.{0} -lmkl_core -lmkl_{1} -lmkl_tbb_thread -ltbb -ltbbmalloc -lpthread -ldl".format(suffix, mkl_interface)
         else:
             mkl_interface = "intel_ilp64" if ctx.attr.static else "intel_lp64"
             openmp = " -lgomp" if not ctx.attr.static else ""

--- a/dev/bazel/scripts.bzl
+++ b/dev/bazel/scripts.bzl
@@ -184,6 +184,12 @@ Cflags: /std:c++17 /MD /wd4996 /EHsc -I${{includedir}}
         )
     else:
         suffix = "a" if ctx.attr.static else "so"
+        if ctx.attr.parameters_lib:
+            onedal_libs = "${{libdir}}/libonedal.{0} ${{libdir}}/libonedal_core.{0} ${{libdir}}/libonedal_thread.{0} ${{libdir}}/libonedal_parameters.{0} -lmkl_core -lmkl_intel_lp64 -lmkl_tbb_thread -ltbb -ltbbmalloc -lpthread -ldl".format(suffix)
+        else:
+            mkl_interface = "intel_ilp64" if ctx.attr.static else "intel_lp64"
+            openmp = " -lgomp" if not ctx.attr.static else ""
+            onedal_libs = "-Wl,--start-group ${{libdir}}/libonedal.{0} ${{libdir}}/libonedal_core.{0} ${{libdir}}/libonedal_thread.{0} -lmkl_{1} -lmkl_tbb_thread -lmkl_core -Wl,--end-group -ltbb -ltbbmalloc -lpthread{2} -ldl".format(suffix, mkl_interface, openmp)
         ctx.actions.write(
             output = out,
             content = _PKGCONFIG_LICENSE_HEADER + """prefix=${{pcfiledir}}/../../
@@ -195,12 +201,12 @@ Name: oneDAL
 Description: oneAPI Data Analytics Library
 Version: {major}.{minor}
 URL: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onedal.html
-Libs: ${{libdir}}/libonedal.{suffix} ${{libdir}}/libonedal_core.{suffix} ${{libdir}}/libonedal_thread.{suffix} ${{libdir}}/libonedal_parameters.{suffix} -lmkl_core -lmkl_intel_lp64 -lmkl_tbb_thread -ltbb -ltbbmalloc -lpthread -ldl
+Libs: {onedal_libs}
 Cflags: -std=c++17 -Wno-deprecated-declarations -I${{includedir}}
 """.format(
                 major = vi.major,
                 minor = vi.minor,
-                suffix = suffix,
+                onedal_libs = onedal_libs,
             ),
         )
     return [DefaultInfo(files = depset([out]))]
@@ -221,6 +227,7 @@ _generate_pkgconfig = rule(
             default = False,
             doc = "Generate a static-library pkg-config file.",
         ),
+        "parameters_lib": attr.bool(default = True),
         "_version_info": attr.label(
             default = "@config//:version",
             providers = [VersionInfo],

--- a/dev/bazel/tests/BUILD
+++ b/dev/bazel/tests/BUILD
@@ -4,4 +4,5 @@ exports_files([
     "release_structure_test.sh",
     "isa_coverage_test.sh",
     "mkl_linkage_test.sh",
+    "parameters_layout_test.sh",
 ])

--- a/dev/bazel/tests/parameters_layout_test.sh
+++ b/dev/bazel/tests/parameters_layout_test.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+#===============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
 # Cheap configured-graph validation for BUILD_PARAMETERS_LIB layouts.
 set -euo pipefail
 

--- a/dev/bazel/tests/parameters_layout_test.sh
+++ b/dev/bazel/tests/parameters_layout_test.sh
@@ -18,15 +18,29 @@ if grep -E ':(static|dynamic)_parameters(_dpc)?$' "${work}/no"; then
     echo "folded release still exposes parameter-library artifacts" >&2
     exit 1
 fi
+host_parameter_modules=(
+    //cpp/oneapi/dal/algo:parameters
+    //cpp/oneapi/dal/detail/parameters
+)
+dpc_parameter_modules=(
+    //cpp/oneapi/dal/algo:parameters_dpc
+    //cpp/oneapi/dal/detail/parameters:parameters_dpc
+)
 for label in //cpp/oneapi/dal:static //cpp/oneapi/dal:dynamic; do
-    query "somepath(${label}, //cpp/oneapi/dal/algo:parameters)" --build_parameters_lib=no | grep -q .
+    for module in "${host_parameter_modules[@]}"; do
+        query "somepath(${label}, ${module})" --build_parameters_lib=no | grep -q .
+    done
 done
 for label in //cpp/oneapi/dal:static_dpc //cpp/oneapi/dal:dynamic_dpc; do
-    if query "somepath(${label}, //cpp/oneapi/dal/algo:parameters)" --build_parameters_lib=no | grep -q .; then
-        echo "${label} depends on host parameter modules" >&2
-        exit 1
-    fi
-    query "somepath(${label}, //cpp/oneapi/dal/algo:parameters_dpc)" --build_parameters_lib=no | grep -q .
+    for module in "${host_parameter_modules[@]}"; do
+        if query "somepath(${label}, ${module})" --build_parameters_lib=no | grep -q .; then
+            echo "${label} depends on host parameter module ${module}" >&2
+            exit 1
+        fi
+    done
+    for module in "${dpc_parameter_modules[@]}"; do
+        query "somepath(${label}, ${module})" --build_parameters_lib=no | grep -q .
+    done
 done
 
 for label in static_parameters static_parameters_dpc dynamic_parameters dynamic_parameters_dpc; do

--- a/dev/bazel/tests/parameters_layout_test.sh
+++ b/dev/bazel/tests/parameters_layout_test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Cheap configured-graph validation for BUILD_PARAMETERS_LIB layouts.
+set -euo pipefail
+
+bazel_cmd="${BAZEL:-bazel}"
+common=(--noshow_progress --cpu=avx2)
+query() { "${bazel_cmd}" cquery "$1" "${common[@]}" "${@:2}" --output=label 2>/dev/null | awk '{print $1}' | sort -u; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+query 'labels(lib, //:release)' --build_parameters_lib=auto >"${work}/auto"
+query 'labels(lib, //:release)' --build_parameters_lib=yes >"${work}/yes"
+cmp "${work}/auto" "${work}/yes"
+
+query 'labels(lib, //:release)' --build_parameters_lib=no >"${work}/no"
+if grep -E ':(static|dynamic)_parameters(_dpc)?$' "${work}/no"; then
+    echo "folded release still exposes parameter-library artifacts" >&2
+    exit 1
+fi
+for label in //cpp/oneapi/dal:static //cpp/oneapi/dal:dynamic; do
+    query "somepath(${label}, //cpp/oneapi/dal/algo:parameters)" --build_parameters_lib=no | grep -q .
+done
+for label in //cpp/oneapi/dal:static_dpc //cpp/oneapi/dal:dynamic_dpc; do
+    if query "somepath(${label}, //cpp/oneapi/dal/algo:parameters)" --build_parameters_lib=no | grep -q .; then
+        echo "${label} depends on host parameter modules" >&2
+        exit 1
+    fi
+    query "somepath(${label}, //cpp/oneapi/dal/algo:parameters_dpc)" --build_parameters_lib=no | grep -q .
+done
+
+for label in static_parameters static_parameters_dpc dynamic_parameters dynamic_parameters_dpc; do
+    if "${bazel_cmd}" build "//cpp/oneapi/dal:${label}" "${common[@]}" --nobuild \
+        --build_parameters_lib=no >"${work}/${label}.log" 2>&1; then
+        echo "folded layout unexpectedly permits direct target ${label}" >&2
+        exit 1
+    fi
+    grep -qi 'incompatible' "${work}/${label}.log"
+done
+
+if "${bazel_cmd}" cquery @config//:validate_build_parameters_lib \
+    --platforms=@config//:windows_analysis_platform --build_parameters_lib=yes \
+    --noshow_progress >"${work}/windows.log" 2>&1; then
+    echo "Windows --build_parameters_lib=yes unexpectedly passed validation" >&2
+    exit 1
+fi
+grep -Fq -- '--build_parameters_lib=yes is not supported on Windows' "${work}/windows.log"
+
+echo "BUILD_PARAMETERS_LIB configured-graph checks passed"

--- a/dev/bazel/tests/parameters_layout_test.sh
+++ b/dev/bazel/tests/parameters_layout_test.sh
@@ -20,10 +20,43 @@ set -euo pipefail
 
 bazel_cmd="${BAZEL:-bazel}"
 common=(--noshow_progress --cpu=avx2)
-query() { "${bazel_cmd}" cquery "$1" "${common[@]}" "${@:2}" --output=label 2>/dev/null | awk '{print $1}' | sort -u; }
 
 work="$(mktemp -d)"
 trap 'rm -rf "${work}"' EXIT
+
+# cquery writes loading/analysis chatter to stderr, so it is captured rather
+# than inherited -- but only shown when the query itself fails. Swallowing it
+# outright leaves `set -e` killing the script on a broken query with nothing in
+# the log to say which query, or why.
+query() {
+    local expr="$1"
+    shift
+    if ! "${bazel_cmd}" cquery "${expr}" "${common[@]}" "$@" --output=label \
+        >"${work}/query.out" 2>"${work}/query.err"; then
+        echo "cquery failed: ${expr} ${*}" >&2
+        cat "${work}/query.err" >&2
+        return 1
+    fi
+    awk '{print $1}' "${work}/query.out" | sort -u
+}
+
+# Every assertion below says which pair it was checking when it fails. A bare
+# `query ... | grep -q .` exits the script silently, which is indistinguishable
+# in a CI log from the step dying for an unrelated reason.
+assert_depends() {
+    if ! query "somepath($1, $2)" --build_parameters_lib=no | grep -q .; then
+        echo "expected ${1} to reach ${2} with --build_parameters_lib=no" >&2
+        exit 1
+    fi
+}
+
+assert_log_contains() {
+    if ! grep -qi -- "$2" "$1"; then
+        echo "expected ${3} to mention '${2}'; got:" >&2
+        cat "$1" >&2
+        exit 1
+    fi
+}
 
 query 'labels(lib, //:release)' --build_parameters_lib=auto >"${work}/auto"
 query 'labels(lib, //:release)' --build_parameters_lib=yes >"${work}/yes"
@@ -44,7 +77,7 @@ dpc_parameter_modules=(
 )
 for label in //cpp/oneapi/dal:static //cpp/oneapi/dal:dynamic; do
     for module in "${host_parameter_modules[@]}"; do
-        query "somepath(${label}, ${module})" --build_parameters_lib=no | grep -q .
+        assert_depends "${label}" "${module}"
     done
 done
 for label in //cpp/oneapi/dal:static_dpc //cpp/oneapi/dal:dynamic_dpc; do
@@ -55,7 +88,7 @@ for label in //cpp/oneapi/dal:static_dpc //cpp/oneapi/dal:dynamic_dpc; do
         fi
     done
     for module in "${dpc_parameter_modules[@]}"; do
-        query "somepath(${label}, ${module})" --build_parameters_lib=no | grep -q .
+        assert_depends "${label}" "${module}"
     done
 done
 
@@ -64,8 +97,12 @@ done
 # Static parameter targets remain valid direct build targets, while the dynamic
 # variants are intentionally incompatible in the folded layout.
 for label in static_parameters static_parameters_dpc; do
-    "${bazel_cmd}" build "//cpp/oneapi/dal:${label}" "${common[@]}" --nobuild \
-        --build_parameters_lib=no >"${work}/${label}.log" 2>&1
+    if ! "${bazel_cmd}" build "//cpp/oneapi/dal:${label}" "${common[@]}" --nobuild \
+        --build_parameters_lib=no >"${work}/${label}.log" 2>&1; then
+        echo "folded layout rejected direct target ${label}, which stays valid:" >&2
+        cat "${work}/${label}.log" >&2
+        exit 1
+    fi
 done
 for label in dynamic_parameters dynamic_parameters_dpc; do
     if "${bazel_cmd}" build "//cpp/oneapi/dal:${label}" "${common[@]}" --nobuild \
@@ -73,7 +110,7 @@ for label in dynamic_parameters dynamic_parameters_dpc; do
         echo "folded layout unexpectedly permits direct target ${label}" >&2
         exit 1
     fi
-    grep -qi 'incompatible' "${work}/${label}.log"
+    assert_log_contains "${work}/${label}.log" 'incompatible' "${label}'s rejection"
 done
 
 if "${bazel_cmd}" cquery @config//:validate_build_parameters_lib \
@@ -82,6 +119,8 @@ if "${bazel_cmd}" cquery @config//:validate_build_parameters_lib \
     echo "Windows --build_parameters_lib=yes unexpectedly passed validation" >&2
     exit 1
 fi
-grep -Fq -- '--build_parameters_lib=yes is not supported on Windows' "${work}/windows.log"
+assert_log_contains "${work}/windows.log" \
+    '--build_parameters_lib=yes is not supported on Windows' \
+    "the Windows validation failure"
 
 echo "BUILD_PARAMETERS_LIB configured-graph checks passed"

--- a/dev/bazel/tests/parameters_layout_test.sh
+++ b/dev/bazel/tests/parameters_layout_test.sh
@@ -59,7 +59,15 @@ for label in //cpp/oneapi/dal:static_dpc //cpp/oneapi/dal:dynamic_dpc; do
     done
 done
 
-for label in static_parameters static_parameters_dpc dynamic_parameters dynamic_parameters_dpc; do
+# BUILD_PARAMETERS_LIB=no folds parameter code into the main libraries, so
+# the release graph must not select any standalone parameter artifacts (above).
+# Static parameter targets remain valid direct build targets, while the dynamic
+# variants are intentionally incompatible in the folded layout.
+for label in static_parameters static_parameters_dpc; do
+    "${bazel_cmd}" build "//cpp/oneapi/dal:${label}" "${common[@]}" --nobuild \
+        --build_parameters_lib=no >"${work}/${label}.log" 2>&1
+done
+for label in dynamic_parameters dynamic_parameters_dpc; do
     if "${bazel_cmd}" build "//cpp/oneapi/dal:${label}" "${common[@]}" --nobuild \
         --build_parameters_lib=no >"${work}/${label}.log" 2>&1; then
         echo "folded layout unexpectedly permits direct target ${label}" >&2

--- a/dev/release_tests/BUILD
+++ b/dev/release_tests/BUILD
@@ -2,4 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "package_metadata_test.sh",
+    "parameters_layout_consumer_test.sh",
 ])

--- a/dev/release_tests/parameters_layout_consumer_test.sh
+++ b/dev/release_tests/parameters_layout_consumer_test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Linux packaged-consumer smoke for a folded (BUILD_PARAMETERS_LIB=no) release.
+set -euo pipefail
+
+DALROOT="$(cd "${1:?usage: parameters_layout_consumer_test.sh DALROOT [source-root]}" && pwd)"
+SOURCE_ROOT="$(cd "${2:-$(dirname "$0")/../..}" && pwd)"
+BAZEL_CMD="${BAZEL:-bazel}"
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+! find "${DALROOT}/lib" -type f -o -type l | grep -q 'onedal_parameters'
+grep -Fq 'set(ONEDAL_USE_PARAMETERS_LIBRARY "no")' "${DALROOT}/lib/cmake/oneDAL/oneDALConfig.cmake"
+! grep -q 'onedal_parameters' "${DALROOT}/lib/pkgconfig/"*.pc
+
+cat >"${work}/smoke.cpp" <<'CPP'
+#include <cstdint>
+#include "oneapi/dal/table/homogen.hpp"
+int main() {
+    float data[] = { 1.0f, 2.0f };
+    const auto table = oneapi::dal::homogen_table::wrap(data, 1, 2);
+    return table.get_row_count() == 1 && table.get_column_count() == 2 ? 0 : 1;
+}
+CPP
+
+cat >"${work}/CMakeLists.txt" <<'CMAKE'
+cmake_minimum_required(VERSION 3.16)
+project(onedal_folded_consumer LANGUAGES CXX)
+find_package(oneDAL REQUIRED CONFIG)
+add_executable(smoke smoke.cpp)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(smoke PRIVATE -Wl,--start-group ${oneDAL_IMPORTED_TARGETS} -Wl,--end-group)
+else()
+    target_link_libraries(smoke PRIVATE ${oneDAL_IMPORTED_TARGETS})
+endif()
+CMAKE
+cmake_dependency_args=()
+if [[ -n "${TBBROOT:-}" && -f "${TBBROOT}/lib/cmake/tbb/TBBConfig.cmake" ]]; then
+    cmake_dependency_args+=("-DTBB_DIR=${TBBROOT}/lib/cmake/tbb")
+fi
+for mode in static dynamic; do
+    cmake -S "${work}" -B "${work}/cmake-${mode}" \
+        -DoneDAL_DIR="${DALROOT}/lib/cmake/oneDAL" \
+        -DONEDAL_LINK="${mode}" -DONEDAL_USE_DPCPP=no -DONEDAL_INTERFACE=yes \
+        "${cmake_dependency_args[@]}"
+    cmake --build "${work}/cmake-${mode}" --parallel 2
+    LD_LIBRARY_PATH="${DALROOT}/lib/intel64:${LD_LIBRARY_PATH:-}" "${work}/cmake-${mode}/smoke"
+done
+
+export PKG_CONFIG_PATH="${DALROOT}/lib/pkgconfig"
+if [[ -n "${MKLROOT:-}" ]]; then
+    export LIBRARY_PATH="${MKLROOT}/lib:${LIBRARY_PATH:-}"
+fi
+if [[ -n "${TBBROOT:-}" ]]; then
+    export LIBRARY_PATH="${TBBROOT}/lib:${LIBRARY_PATH:-}"
+fi
+for pc in dal-dynamic-threading-host dal-static-threading-host; do
+    c++ "${work}/smoke.cpp" -o "${work}/pkg-${pc}" $(pkg-config --cflags --libs "${pc}")
+    LD_LIBRARY_PATH="${DALROOT}/lib/intel64:${LD_LIBRARY_PATH:-}" "${work}/pkg-${pc}"
+done
+
+cat >"${work}/MODULE.bazel" <<EOF
+module(name = "onedal_folded_consumer")
+bazel_dep(name = "onedal", version = "0.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+local_path_override(module_name = "onedal", path = "${SOURCE_ROOT}")
+tbb_repo = use_repo_rule("@onedal//dev/bazel/deps:tbb.bzl", "tbb_repo")
+tbb_repo(name = "tbb", root_env_var = "TBBROOT")
+mkl_repo = use_repo_rule("@onedal//dev/bazel/deps:mkl.bzl", "mkl_repo")
+mkl_repo(name = "mkl", root_env_var = "MKLROOT")
+onedal_repo = use_repo_rule("@onedal//dev/bazel/deps:onedal.bzl", "onedal_repo")
+onedal_repo(name = "onedal_release", root_env_var = "DALROOT")
+EOF
+cat >"${work}/BUILD" <<'BUILD'
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+cc_binary(
+    name = "static",
+    srcs = ["smoke.cpp"],
+    deps = [
+        "@onedal_release//:onedal_static",
+        "@onedal_release//:core_static",
+        "@onedal_release//:thread_static",
+    ],
+)
+cc_binary(
+    name = "dynamic",
+    srcs = ["smoke.cpp"],
+    deps = [
+        "@onedal_release//:onedal_dynamic",
+        "@onedal_release//:core_dynamic",
+        "@onedal_release//:thread_dynamic",
+    ],
+)
+BUILD
+(
+    cd "${work}"
+    DALROOT="${DALROOT}" "${BAZEL_CMD}" build //:static //:dynamic --noshow_progress --show_result=0
+    DALROOT="${DALROOT}" "${BAZEL_CMD}" run //:static --noshow_progress --show_result=0
+    DALROOT="${DALROOT}" "${BAZEL_CMD}" run //:dynamic --noshow_progress --show_result=0
+)
+
+echo "Folded packaged CMake, pkg-config, and Bazel consumers passed"

--- a/dev/release_tests/parameters_layout_consumer_test.sh
+++ b/dev/release_tests/parameters_layout_consumer_test.sh
@@ -13,12 +13,18 @@ grep -Fq 'set(ONEDAL_USE_PARAMETERS_LIBRARY "no")' "${DALROOT}/lib/cmake/oneDAL/
 ! grep -q 'onedal_parameters' "${DALROOT}/lib/pkgconfig/"*.pc
 
 cat >"${work}/smoke.cpp" <<'CPP'
-#include <cstdint>
+#include "oneapi/dal/algo/covariance.hpp"
 #include "oneapi/dal/table/homogen.hpp"
+
 int main() {
-    float data[] = { 1.0f, 2.0f };
-    const auto table = oneapi::dal::homogen_table::wrap(data, 1, 2);
-    return table.get_row_count() == 1 && table.get_column_count() == 2 ? 0 : 1;
+    namespace dal = oneapi::dal;
+    float data[] = { 1.0f, 2.0f, 3.0f, 4.0f };
+    const auto input = dal::homogen_table::wrap(data, 2, 2);
+    const auto descriptor = dal::covariance::descriptor<float>{}.set_result_options(
+        dal::covariance::result_options::cov_matrix);
+    const auto result = dal::compute(descriptor, input);
+    const auto& covariance = result.get_cov_matrix();
+    return covariance.get_row_count() == 2 && covariance.get_column_count() == 2 ? 0 : 1;
 }
 CPP
 

--- a/dev/release_tests/parameters_layout_consumer_test.sh
+++ b/dev/release_tests/parameters_layout_consumer_test.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+#===============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
 # Linux packaged-consumer smoke for a folded (BUILD_PARAMETERS_LIB=no) release.
 set -euo pipefail
 

--- a/dev/release_tests/parameters_layout_consumer_test.sh
+++ b/dev/release_tests/parameters_layout_consumer_test.sh
@@ -22,7 +22,27 @@ DALROOT="$(cd "${1:?usage: parameters_layout_consumer_test.sh DALROOT [source-ro
 SOURCE_ROOT="$(cd "${2:-$(dirname "$0")/../..}" && pwd)"
 BAZEL_CMD="${BAZEL:-bazel}"
 work="$(mktemp -d)"
-trap 'rm -rf "${work}"' EXIT
+
+# The consumer workspace below is a throwaway directory, but the Bazel output
+# base it gets is not: Bazel derives the output base from a hash of the
+# workspace path, so it lands in its own directory under
+# `~/.cache/bazel/_bazel_$USER/` and survives `rm -rf "${work}"`. It also
+# survives the `bazel clean --expunge` steps around this test in
+# .ci/pipeline/ci.yml, which expunge the *oneDAL* workspace's output base and
+# know nothing about this one. Left behind, it costs about a gigabyte and a
+# stranded Bazel server for the rest of the job -- on an agent that already
+# reports over 95% of / in use, that is enough to make a later link fail with
+# nothing but `collect2: error: ld returned 1 exit status`.
+#
+# Expunge it while the workspace still exists, before removing the workspace.
+# `clean --expunge` also stops the server, so nothing keeps holding the files.
+cleanup() {
+    if [ -f "${work}/MODULE.bazel" ]; then
+        (cd "${work}" && "${BAZEL_CMD}" clean --expunge) >/dev/null 2>&1 || true
+    fi
+    rm -rf "${work}"
+}
+trap cleanup EXIT
 
 # `! producer | grep -q` is also satisfied when the *producer* fails, so an
 # absent lib/ directory or an unmatched .pc glob would pass these three checks

--- a/dev/release_tests/parameters_layout_consumer_test.sh
+++ b/dev/release_tests/parameters_layout_consumer_test.sh
@@ -24,9 +24,31 @@ BAZEL_CMD="${BAZEL:-bazel}"
 work="$(mktemp -d)"
 trap 'rm -rf "${work}"' EXIT
 
-! find "${DALROOT}/lib" -type f -o -type l | grep -q 'onedal_parameters'
-grep -Fq 'set(ONEDAL_USE_PARAMETERS_LIBRARY "no")' "${DALROOT}/lib/cmake/oneDAL/oneDALConfig.cmake"
-! grep -q 'onedal_parameters' "${DALROOT}/lib/pkgconfig/"*.pc
+# `! producer | grep -q` is also satisfied when the *producer* fails, so an
+# absent lib/ directory or an unmatched .pc glob would pass these three checks
+# without looking at anything. Materialise the inputs first, then assert.
+find "${DALROOT}/lib" \( -type f -o -type l \) -print >"${work}/lib-entries"
+if grep 'onedal_parameters' "${work}/lib-entries"; then
+    echo "folded release still ships a parameters library (above)" >&2
+    exit 1
+fi
+
+config="${DALROOT}/lib/cmake/oneDAL/oneDALConfig.cmake"
+if ! grep -Fq 'set(ONEDAL_USE_PARAMETERS_LIBRARY "no")' "${config}"; then
+    echo "${config} does not advertise the folded layout; it says:" >&2
+    grep -F 'ONEDAL_USE_PARAMETERS_LIBRARY' "${config}" >&2 || echo "  (no such line)" >&2
+    exit 1
+fi
+
+pc_files=("${DALROOT}/lib/pkgconfig/"*.pc)
+if [[ ! -e "${pc_files[0]}" ]]; then
+    echo "no pkg-config files staged under ${DALROOT}/lib/pkgconfig" >&2
+    exit 1
+fi
+if grep -H 'onedal_parameters' "${pc_files[@]}"; then
+    echo "folded release still advertises a parameters library in pkg-config (above)" >&2
+    exit 1
+fi
 
 cat >"${work}/smoke.cpp" <<'CPP'
 #include "oneapi/dal/algo/covariance.hpp"
@@ -76,7 +98,13 @@ if [[ -n "${TBBROOT:-}" ]]; then
     export LIBRARY_PATH="${TBBROOT}/lib:${LIBRARY_PATH:-}"
 fi
 for pc in dal-dynamic-threading-host dal-static-threading-host; do
-    c++ "${work}/smoke.cpp" -o "${work}/pkg-${pc}" $(pkg-config --cflags --libs "${pc}")
+    # Resolved in its own statement: inside `c++ ... $(pkg-config ...)` a failing
+    # substitution is not the command's own status, so `set -e` would let the
+    # compile proceed with no flags and report a wall of undefined references
+    # instead of the missing .pc.
+    pc_flags="$(pkg-config --cflags --libs "${pc}")"
+    # shellcheck disable=SC2086 # deliberate word splitting of the flag list
+    c++ "${work}/smoke.cpp" -o "${work}/pkg-${pc}" ${pc_flags}
     LD_LIBRARY_PATH="${DALROOT}/lib/intel64:${LD_LIBRARY_PATH:-}" "${work}/pkg-${pc}"
 done
 

--- a/dev/release_tests/parameters_layout_consumer_test.sh
+++ b/dev/release_tests/parameters_layout_consumer_test.sh
@@ -60,6 +60,23 @@ if ! grep -Fq 'set(ONEDAL_USE_PARAMETERS_LIBRARY "no")' "${config}"; then
     exit 1
 fi
 
+# Report, rather than assert, the oneMKL references left undefined in the folded
+# host library. The generated CMake config sets MKL_DEPENDENCY for this layout on
+# non-Windows, and this is the evidence for whether that is necessary: these are
+# the symbols a consumer of the folded package has to resolve itself and a
+# consumer of the separate package resolves through libonedal_parameters. Not an
+# assertion, because the correct count is whatever the layout implies, not a
+# number this test should pin.
+if command -v nm >/dev/null 2>&1; then
+    host_lib="${DALROOT}/lib/intel64/libonedal.so"
+    if [[ -e "${host_lib}" ]]; then
+        echo "Undefined oneMKL references in $(basename "${host_lib}"):"
+        # `grep -c` exits 1 on a count of zero, which is a valid answer here.
+        nm -D --undefined-only "${host_lib}" 2>/dev/null \
+            | grep -ciE 'mkl|_dgemm|_sgemm' || true
+    fi
+fi
+
 pc_files=("${DALROOT}/lib/pkgconfig/"*.pc)
 if [[ ! -e "${pc_files[0]}" ]]; then
     echo "no pkg-config files staged under ${DALROOT}/lib/pkgconfig" >&2

--- a/makefile
+++ b/makefile
@@ -1100,7 +1100,7 @@ $(foreach t,$(releasetbb.LIBS_A),$(eval $(call .release.t,$t,$(RELEASEDIR.tbb.li
 #----- cmake configs generation
 
 _release_cmake_configs:
-	$(if $(shell bash -c "command -v cmake"),cmake -DINSTALL_DIR=$(RELEASEDIR.lib)/cmake/oneDAL -DARCH_DIR_ONEDAL=$(ARCH_DIR_ONEDAL) -P cmake/scripts/generate_config.cmake,echo 'cmake configs generation skipped')
+	$(if $(shell bash -c "command -v cmake"),cmake -DINSTALL_DIR=$(RELEASEDIR.lib)/cmake/oneDAL -DARCH_DIR_ONEDAL=$(ARCH_DIR_ONEDAL) -DONEDAL_USE_PARAMETERS_LIBRARY=$(BUILD_PARAMETERS_LIB) -P cmake/scripts/generate_config.cmake,echo 'cmake configs generation skipped')
 
 #----- nuspecs generation
 _release_common: _release_nuspec


### PR DESCRIPTION
## Description

Adds Bazel control for the parameter-library layout to match the existing Make `BUILD_PARAMETERS_LIB` behavior.

- adds `--build_parameters_lib=auto|yes|no`;
- preserves platform defaults (`auto`: separate libraries on non-Windows, folded into the main libraries on Windows);
- rejects `yes` on Windows during analysis;
- keeps host and DPC parameter objects separated;
- makes release CMake, pkg-config, and Bazel consumer metadata match the selected layout;
- disables conflicting direct parameter-library targets in folded mode;
- removes the unsupported prebuilt static-DPC consumer target (release packages provide dynamic DPC libraries).

Part of #3530.

Supersedes #3717, rebased onto latest `main`.

## Validation

- configured graph checks for host/DPC and `auto|yes|no` layouts;
- Windows `yes` analysis rejection;
- host static and dynamic consumers;
- folded release package consumers via CMake static/dynamic, pkg-config, and Bazel;
- real DPC++ builds for separate and folded layouts;
- symbol placement proof:
  - separate: `system_parameters::dump` absent from `libonedal_dpc.so`, present in `libonedal_parameters_dpc.so`;
  - folded: symbol present in `libonedal_dpc.so`;
- shell/YAML checks, `git diff --check`, clean worktree;
- independent architecture/build-system review: APPROVE.