### PR TITLE
ci: publish nightly artifacts before comparing releases

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -83,14 +83,9 @@ jobs:
         run: |
           source /opt/intel/oneapi/setvars.sh
           bazel build //:release --config=release-dpc --cpu=avx2
-      - name: Compare make and Bazel releases
-        run: |
-          source /opt/intel/oneapi/setvars.sh
-          python dev/release_tests/compare_release_trees.py \
-            --platform linux \
-            --make ./__release_lnx/daal/latest \
-            --bazel ./bazel-bin/release/daal/latest \
-            --check-level 4
+      # Upload before validating. Downstream consumers depend on these artifacts,
+      # so a release-parity difference must not also cost them a build. The
+      # comparison below still fails the job, which is the signal we want.
       - name: Archive build
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -101,12 +96,23 @@ jobs:
         with:
           name: oneDAL_env
           path: .ci/env
+      - name: Compare make and Bazel releases
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          python dev/release_tests/compare_release_trees.py \
+            --platform linux \
+            --make ./__release_lnx/daal/latest \
+            --bazel ./bazel-bin/release/daal/latest \
+            --check-level 4
 
   build_win:
     name: oneDAL Windows nightly build
     if: github.repository == 'uxlfoundation/oneDAL'
     runs-on: windows-2025
-    timeout-minutes: 180
+    # The last run that got past the comparison took 165m, and runs that fail
+    # fast at the comparison already reach 173m, so 180 leaves no room for the
+    # steps that only execute once the gate passes.
+    timeout-minutes: 240
 
     steps:
       - name: Checkout oneDAL
@@ -160,22 +166,11 @@ jobs:
           call .\oneapi\setvars.bat
           call "%ONEAPI_ROOT%\setvars-vcvarsall.bat" %VS_VER%
           bazel build //:release --config=release-dpc --cpu=avx2
-      - name: Compare make and Bazel releases
-        shell: cmd
-        run: |
-          call .\oneapi\setvars.bat
-          call "%ONEAPI_ROOT%\setvars-vcvarsall.bat" %VS_VER%
-          powershell -NoProfile -ExecutionPolicy Bypass -File .\.ci\scripts\compare_windows_release.ps1 ^
-            -MakeReleaseDir .\__release_win_vc\daal\latest ^
-            -BazelReleaseDir .\bazel-bin\release\daal\latest ^
-            -CheckLevel 4
-      - name: Build and run CMake example from Bazel release
-        shell: cmd
-        run: |
-          call .\oneapi\setvars.bat
-          call "%ONEAPI_ROOT%\setvars-vcvarsall.bat" %VS_VER%
-          powershell -NoProfile -ExecutionPolicy Bypass -File .\.ci\scripts\test_bazel_release_cmake_example.ps1 ^
-            -ReleaseDir .\bazel-bin\release\daal\latest
+      # Upload before validating. scikit-learn-intelex's CI consumes
+      # `__release_win` (see the note at the top of this file), so a
+      # release-parity difference must not also cost that repository its Windows
+      # build. The comparison below still fails the job, which is the signal we
+      # want, but the artifacts are already published by then.
       - name: Compress Intel BaseKit
         shell: cmd
         run: |
@@ -199,3 +194,23 @@ jobs:
         with:
           name: opencl_rt_installer
           path: .\opencl_rt.msi
+      - name: Compare make and Bazel releases
+        shell: cmd
+        run: |
+          call .\oneapi\setvars.bat
+          call "%ONEAPI_ROOT%\setvars-vcvarsall.bat" %VS_VER%
+          powershell -NoProfile -ExecutionPolicy Bypass -File .\.ci\scripts\compare_windows_release.ps1 ^
+            -MakeReleaseDir .\__release_win_vc\daal\latest ^
+            -BazelReleaseDir .\bazel-bin\release\daal\latest ^
+            -CheckLevel 4
+      # Runs after the comparison but must not be gated by it: this is the only
+      # end-to-end check that the Bazel release is consumable (headers, cmake
+      # package files, import libraries, runtime DLLs).
+      - name: Build and run CMake example from Bazel release
+        if: ${{ !cancelled() }}
+        shell: cmd
+        run: |
+          call .\oneapi\setvars.bat
+          call "%ONEAPI_ROOT%\setvars-vcvarsall.bat" %VS_VER%
+          powershell -NoProfile -ExecutionPolicy Bypass -File .\.ci\scripts\test_bazel_release_cmake_example.ps1 ^
+            -ReleaseDir .\bazel-bin\release\daal\latest


### PR DESCRIPTION
## Problem

The Windows nightly has failed **17 nights running** — every night from 2026-07-26 (run [30220918643](https://github.com/uxlfoundation/oneDAL/actions/runs/30220918643)) through 2026-08-10 (run [31433209459](https://github.com/uxlfoundation/oneDAL/actions/runs/31433209459)) — always at step 11, `Compare make and Bazel releases`.

The three upload steps sat *after* that comparison. GitHub skips every later step once one fails, so `__release_win`, `intel_oneapi_basekit` and `opencl_rt_installer` have not been published since **2026-07-24** (run [30127774523](https://github.com/uxlfoundation/oneDAL/actions/runs/30127774523)).

This workflow declares at the top that it "is a dependency of uxlfoundation/scikit-learn-intelex's `CI` GitHub action" — so that repository has had no fresh Windows oneDAL build for over two weeks.

## Nothing regressed in the release

The 2026-07-24 run recorded as green also reported:

```
Check level: 4
Only Bazel files: 3
Text content mismatches: 5
Shared library export mismatches: 3
Release comparison failed: 11 difference(s)
```

The step passed anyway, because Windows PowerShell 5.1 does not turn a native command's nonzero exit into a failure. #3701 added `exit $LASTEXITCODE` to `.ci/scripts/compare_windows_release.ps1`, which made the gate start working from the next nightly. The differences were always present; only their consequence changed.

Closing those differences is the subject of #3738. This PR is only about not making downstream pay for them.

## Change

- Packaging and uploading move ahead of the comparison, on both the Linux and Windows jobs. The comparison still fails the job, so the signal is unchanged.
- `Build and run CMake example from Bazel release` stays after the comparison — it validates the Bazel tree rather than producing an artifact — but gets `if: ${{ !cancelled() }}` so it still reports. It is the only end-to-end check that the Bazel release is consumable (headers, cmake package files, import libraries, runtime DLLs), and it has not run since 2026-07-24.
- Windows job timeout 180 → 240 minutes. The last run that got past the comparison took 165m, runs that fail fast at the comparison already reach 173m, and the steps that only execute once the gate passes cost ~5m — so the first green nightly would likely have died on the timeout instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)