### PR TITLE
bazel: disable every Intel-specific runtime library, as make does

### DIFF
--- a/dev/bazel/flags.bzl
+++ b/dev/bazel/flags.bzl
@@ -49,6 +49,12 @@ win_icx_common_flags = [
     "-nologo",
     "-WX",
     "-Qopenmp-simd",
+    # `-Zl.icx` / `-Zl.dpcpp` disable every Intel-specific runtime library on
+    # Windows too, so the released `.lib` files never reference `__svml_*`.
+    # (`-Zl` itself, the other half of the makefile's variable, is deliberately
+    # not mirrored: it strips the CRT default-library directives that this
+    # toolchain's DLL links still rely on.)
+    "-Qno-intel-lib",
     "-Wno-deprecated-declarations",
     "-Wno-ignored-attributes",
     "-Wno-empty-body",
@@ -82,11 +88,27 @@ def get_default_flags(arch_id, os_id, compiler_id, category = "common"):
         if compiler_id == "icx" and category == "common":
             flags = flags + [
                 "-qopenmp-simd",
-                "-no-intel-lib=libirc",
+                # Disable *all* Intel-specific runtime libraries, not just
+                # libirc. This mirrors `-Zl.icx` in
+                # dev/make/compiler_definitions/icx.mkl.32e.mk, which the
+                # makefile applies to every object (makefile:528,537,692,877).
+                #
+                # It has to be the bare form: with SVML left enabled icx
+                # vectorises integer division/remainder (for example
+                # `wsIndex % nVectors` in
+                # cpp/daal/src/algorithms/svm/svm_train_thunder_impl.i) into
+                # `__svml_u64rem4_*` calls. The shared libraries hide that
+                # because the toolchain links them with `-static-intel`, but
+                # the released static archives keep the references and any
+                # consumer that links `libonedal_core.a` with gcc/g++ fails
+                # with `undefined reference to __svml_u64rem4_l9`.
+                "-qno-intel-lib",
                 "-no-canonical-prefixes",
             ]
         if compiler_id == "icpx":
             flags = flags + [
+                # `-Zl.dpcpp` in dev/make/compiler_definitions/dpcpp.mk:70.
+                "-no-intel-lib",
                 "-fsycl",
                 "-fno-canonical-system-headers",
                 "-no-canonical-prefixes",

--- a/dev/bazel/flags.bzl
+++ b/dev/bazel/flags.bzl
@@ -102,7 +102,7 @@ def get_default_flags(arch_id, os_id, compiler_id, category = "common"):
                 # the released static archives keep the references and any
                 # consumer that links `libonedal_core.a` with gcc/g++ fails
                 # with `undefined reference to __svml_u64rem4_l9`.
-                "-qno-intel-lib",
+                "-no-intel-lib",
                 "-no-canonical-prefixes",
             ]
         if compiler_id == "icpx":


### PR DESCRIPTION
## Description

The makefile compiles every object with `-Zl`, which expands to the bare `-qno-intel-lib` on Linux and to `-Zl -Qno-intel-lib` on Windows (`dev/make/compiler_definitions/icx.mkl.32e.mk`, `dpcpp.mk:70`; applied at `makefile:528`, `:537`, `:692`, `:717`, `:877`). The Bazel build asked only for `-no-intel-lib=libirc`, so SVML stayed enabled.

With SVML enabled, icx vectorises 64-bit integer division/remainder — for example `wsIndex % nVectors` in `cpp/daal/src/algorithms/svm/svm_train_thunder_impl.i` — into `__svml_u64rem4_*` calls. The shared libraries get away with it because the toolchain links them with `-static-intel`, but the **released static archives keep the unresolved references**, so a consumer linking `libonedal_core.a` with gcc fails:

```
libonedal_core.a(svm_train_thunder_batch_fpt_cpu.pic.o): In function `void daal::threader_func<...SVMTrainImpl<...>::updateGrad...>(int, void const*)':
svm_train_thunder_batch_fpt_cpu.cpp: undefined reference to `__svml_u64rem4_l9'
collect2: error: ld returned 1 exit status
```

That is a real failure observed on the static (`intel_intel64_a`) oneAPI C++ examples built against a Bazel-produced release.

## Changes

* `icx` (Linux): `-no-intel-lib=libirc` → `-qno-intel-lib`
* `icpx` (Linux): add `-no-intel-lib` (it had none, while make applies `-Zl.dpcpp`)
* `icx`/`icpx` (Windows): add `-Qno-intel-lib`

`-Zl` itself is deliberately **not** mirrored on Windows: it also strips the CRT default-library directives that this toolchain's DLL links still rely on.

## Verification

Not built locally (no bazel/icx on the machine this was prepared on). Suggested check once CI runs:

```
nm -u <release>/lib/intel64/libonedal_core.a | grep __svml_   # must be empty
```
plus the static-link example configuration that currently fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)