### PR TITLE
bazel: link the Windows TBB import libraries instead of archiving them

### DIFF
--- a/dev/bazel/cc/common.bzl
+++ b/dev/bazel/cc/common.bzl
@@ -100,6 +100,29 @@ def _collect_and_filter_linking_contexts(deps, tags):
     linking_contexts = _filter_tagged_linking_contexts(tagged_linking_contexts, tags)
     return linking_contexts
 
+# Windows import libraries that Bazel cannot tell apart from static archives:
+# they arrive as plain `.lib` files in a dependency's `srcs`, so a
+# `LibraryToLink` describes them as a static library. Merging them into oneDAL's
+# own static libraries is wrong twice over -- every import library defines
+# `__NULL_IMPORT_DESCRIPTOR`, so `lib.exe` warns
+# `LNK4006: __NULL_IMPORT_DESCRIPTOR already defined in tbb12.lib`, and the
+# released `onedal_core.lib` ends up carrying TBB import descriptors that the
+# Make package does not ship (Make links these libraries, it never archives
+# them; the pkg-config and CMake configs already tell consumers to link
+# `tbb12.lib` / `tbbmalloc.lib` themselves).
+#
+# Declaring them through `cc_import` would be the idiomatic fix, but an import
+# library with no static counterpart never reaches lld-link: neither
+# `system_provided = True` nor pairing it with its DLL puts it back on the
+# command line, and every TBB symbol comes back undefined. So keep Bazel's
+# classification and filter by name at the one place that matters.
+_WINDOWS_IMPORT_LIBRARIES = [
+    "tbb12.lib",
+    "tbb12_debug.lib",
+    "tbbmalloc.lib",
+    "tbbmalloc_debug.lib",
+]
+
 def _unpack_linking_contexts(linking_contexts):
     link_flags = []
     objects = []
@@ -122,18 +145,17 @@ def _unpack_linking_contexts(linking_contexts):
                     libs_to_link.append(lib_to_link)
                     dynamic_libs_to_link.append(lib_to_link)
                     dynamic_libs.append(lib_to_link.dynamic_library)
-                elif lib_to_link.interface_library:
-                    # A Windows import library with no shared library recorded
-                    # next to it. Without this branch it matches nothing and is
-                    # dropped without a word, and every symbol it was supposed
-                    # to import comes back undefined at link time.
-                    libs_to_link.append(lib_to_link)
-                    dynamic_libs_to_link.append(lib_to_link)
                 elif lib_to_link.static_library or lib_to_link.pic_static_library:
+                    static_lib = (lib_to_link.static_library or
+                                  lib_to_link.pic_static_library)
                     libs_to_link.append(lib_to_link)
-                    static_libs_to_link.append(lib_to_link)
-                    static_libs.append(lib_to_link.static_library or
-                                       lib_to_link.pic_static_library)
+                    if static_lib.basename in _WINDOWS_IMPORT_LIBRARIES:
+                        # Link it, propagate it, but keep it out of
+                        # `static_libraries` so the archive merge never sees it.
+                        dynamic_libs_to_link.append(lib_to_link)
+                    else:
+                        static_libs_to_link.append(lib_to_link)
+                        static_libs.append(static_lib)
             link_flags += linker_input.user_link_flags
     return struct(
         pic_objects = depset(pic_objects).to_list(),

--- a/dev/bazel/cc/common.bzl
+++ b/dev/bazel/cc/common.bzl
@@ -122,6 +122,14 @@ def _unpack_linking_contexts(linking_contexts):
                     libs_to_link.append(lib_to_link)
                     dynamic_libs_to_link.append(lib_to_link)
                     dynamic_libs.append(lib_to_link.dynamic_library)
+                elif lib_to_link.interface_library:
+                    # A `cc_import` that only carries an `interface_library`
+                    # (`system_provided = True`) is a Windows import library:
+                    # the shared object itself comes from the environment.
+                    # Treat it as a dynamic dependency so it is linked, never
+                    # merged into oneDAL's static archives.
+                    libs_to_link.append(lib_to_link)
+                    dynamic_libs_to_link.append(lib_to_link)
                 elif lib_to_link.static_library or lib_to_link.pic_static_library:
                     libs_to_link.append(lib_to_link)
                     static_libs_to_link.append(lib_to_link)

--- a/dev/bazel/cc/common.bzl
+++ b/dev/bazel/cc/common.bzl
@@ -111,11 +111,11 @@ def _collect_and_filter_linking_contexts(deps, tags):
 # them; the pkg-config and CMake configs already tell consumers to link
 # `tbb12.lib` / `tbbmalloc.lib` themselves).
 #
-# Declaring them through `cc_import` would be the idiomatic fix, but an import
-# library with no static counterpart never reaches lld-link: neither
-# `system_provided = True` nor pairing it with its DLL puts it back on the
-# command line, and every TBB symbol comes back undefined. So keep Bazel's
-# classification and filter by name at the one place that matters.
+# Declaring them through `cc_import(interface_library = ...)` would require a
+# separate `interface_library` branch in `_unpack_linking_contexts`: that
+# provider is not currently propagated by this custom linker wrapper. Keep
+# Bazel's existing classification and filter these known TBB import libraries
+# at the one place that matters, rather than broadening that behavior here.
 _WINDOWS_IMPORT_LIBRARIES = [
     "tbb12.lib",
     "tbb12_debug.lib",

--- a/dev/bazel/cc/common.bzl
+++ b/dev/bazel/cc/common.bzl
@@ -123,11 +123,10 @@ def _unpack_linking_contexts(linking_contexts):
                     dynamic_libs_to_link.append(lib_to_link)
                     dynamic_libs.append(lib_to_link.dynamic_library)
                 elif lib_to_link.interface_library:
-                    # A `cc_import` that only carries an `interface_library`
-                    # (`system_provided = True`) is a Windows import library:
-                    # the shared object itself comes from the environment.
-                    # Treat it as a dynamic dependency so it is linked, never
-                    # merged into oneDAL's static archives.
+                    # A Windows import library with no shared library recorded
+                    # next to it. Without this branch it matches nothing and is
+                    # dropped without a word, and every symbol it was supposed
+                    # to import comes back undefined at link time.
                     libs_to_link.append(lib_to_link)
                     dynamic_libs_to_link.append(lib_to_link)
                 elif lib_to_link.static_library or lib_to_link.pic_static_library:

--- a/dev/bazel/deps/tbb_win.tpl.BUILD
+++ b/dev/bazel/deps/tbb_win.tpl.BUILD
@@ -15,13 +15,18 @@ cc_library(
 # Two import libraries both define `__NULL_IMPORT_DESCRIPTOR`, so the merge
 # emits `LNK4006: __NULL_IMPORT_DESCRIPTOR already defined in tbb12.lib`, and
 # the released `onedal_core.lib` ends up carrying TBB import descriptors that
-# the Make package does not ship. `cc_import` with `system_provided = True`
-# keeps them on the link line only; the DLLs are resolved from `PATH` at run
-# time, exactly as with the Make build.
+# the Make package does not ship.
+#
+# `cc_import` pairs each import library with the DLL it stands for, which is
+# how oneDAL already models its own cross-DLL dependencies (see
+# `_make_implib_for_dll` in dev/bazel/cc/link.bzl): the import library goes on
+# the link line, the archives stay clean. Do not use `system_provided = True`
+# here -- an import library with no shared library behind it is dropped before
+# it reaches lld-link, and every TBB symbol comes back undefined.
 cc_import(
     name = "tbb_import",
     interface_library = "lib/tbb12.lib",
-    system_provided = True,
+    shared_library = "bin/tbb12.dll",
 )
 
 cc_library(
@@ -49,7 +54,7 @@ cc_library(
 cc_import(
     name = "tbbmalloc_import",
     interface_library = "lib/tbbmalloc.lib",
-    system_provided = True,
+    shared_library = "bin/tbbmalloc.dll",
 )
 
 cc_library(

--- a/dev/bazel/deps/tbb_win.tpl.BUILD
+++ b/dev/bazel/deps/tbb_win.tpl.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "headers",
@@ -8,34 +8,11 @@ cc_library(
     includes = ["include"],
 )
 
-# `tbb12.lib` and `tbbmalloc.lib` are *import* libraries for `tbb12.dll` and
-# `tbbmalloc.dll`, not static archives. Listing them in `srcs` makes Bazel
-# classify them as static libraries, which then get merged into oneDAL's own
-# static libraries by `lib.exe` (dev/bazel/cc/link.bzl `_merge_static_libs`).
-# Two import libraries both define `__NULL_IMPORT_DESCRIPTOR`, so the merge
-# emits `LNK4006: __NULL_IMPORT_DESCRIPTOR already defined in tbb12.lib`, and
-# the released `onedal_core.lib` ends up carrying TBB import descriptors that
-# the Make package does not ship.
-#
-# `cc_import` pairs each import library with the DLL it stands for, which is
-# how oneDAL already models its own cross-DLL dependencies (see
-# `_make_implib_for_dll` in dev/bazel/cc/link.bzl): the import library goes on
-# the link line, the archives stay clean. Do not use `system_provided = True`
-# here -- an import library with no shared library behind it is dropped before
-# it reaches lld-link, and every TBB symbol comes back undefined.
-cc_import(
-    name = "tbb_import",
-    interface_library = "lib/tbb12.lib",
-    shared_library = "bin/tbb12.dll",
-)
-
 cc_library(
     name = "tbb",
+    srcs = ["lib/tbb12.lib"],
     data = ["bin/tbb12.dll"],
-    deps = [
-        ":headers",
-        ":tbb_import",
-    ],
+    deps = [":headers"],
 )
 
 filegroup(
@@ -51,19 +28,11 @@ cc_library(
     deps = [":tbb"],
 )
 
-cc_import(
-    name = "tbbmalloc_import",
-    interface_library = "lib/tbbmalloc.lib",
-    shared_library = "bin/tbbmalloc.dll",
-)
-
 cc_library(
     name = "tbbmalloc",
+    srcs = ["lib/tbbmalloc.lib"],
     data = ["bin/tbbmalloc.dll"],
-    deps = [
-        ":headers",
-        ":tbbmalloc_import",
-    ],
+    deps = [":headers"],
 )
 
 cc_library(

--- a/dev/bazel/deps/tbb_win.tpl.BUILD
+++ b/dev/bazel/deps/tbb_win.tpl.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
 
 cc_library(
     name = "headers",
@@ -8,11 +8,29 @@ cc_library(
     includes = ["include"],
 )
 
+# `tbb12.lib` and `tbbmalloc.lib` are *import* libraries for `tbb12.dll` and
+# `tbbmalloc.dll`, not static archives. Listing them in `srcs` makes Bazel
+# classify them as static libraries, which then get merged into oneDAL's own
+# static libraries by `lib.exe` (dev/bazel/cc/link.bzl `_merge_static_libs`).
+# Two import libraries both define `__NULL_IMPORT_DESCRIPTOR`, so the merge
+# emits `LNK4006: __NULL_IMPORT_DESCRIPTOR already defined in tbb12.lib`, and
+# the released `onedal_core.lib` ends up carrying TBB import descriptors that
+# the Make package does not ship. `cc_import` with `system_provided = True`
+# keeps them on the link line only; the DLLs are resolved from `PATH` at run
+# time, exactly as with the Make build.
+cc_import(
+    name = "tbb_import",
+    interface_library = "lib/tbb12.lib",
+    system_provided = True,
+)
+
 cc_library(
     name = "tbb",
-    srcs = ["lib/tbb12.lib"],
     data = ["bin/tbb12.dll"],
-    deps = [":headers"],
+    deps = [
+        ":headers",
+        ":tbb_import",
+    ],
 )
 
 filegroup(
@@ -28,11 +46,19 @@ cc_library(
     deps = [":tbb"],
 )
 
+cc_import(
+    name = "tbbmalloc_import",
+    interface_library = "lib/tbbmalloc.lib",
+    system_provided = True,
+)
+
 cc_library(
     name = "tbbmalloc",
-    srcs = ["lib/tbbmalloc.lib"],
     data = ["bin/tbbmalloc.dll"],
-    deps = [":headers"],
+    deps = [
+        ":headers",
+        ":tbbmalloc_import",
+    ],
 )
 
 cc_library(


### PR DESCRIPTION
## Description

`tbb12.lib` and `tbbmalloc.lib` are Windows import libraries for `tbb12.dll` / `tbbmalloc.dll`. Because the TBB Bazel template supplies them as `srcs`, Bazel represents them as static libraries. `_merge_static_libs` therefore passed them to `lib.exe` while building oneDAL's static archives.

That is wrong twice over:

* both import libraries define `__NULL_IMPORT_DESCRIPTOR`, producing `LNK4006` during the archive merge;
* the released `onedal_core.lib` then carries TBB import descriptors that Make does not ship. Package CMake and pkg-config already require consumers to link `tbb12.lib` / `tbbmalloc.lib` themselves.

## Changes

* In `_unpack_linking_contexts`, recognise the known Windows TBB import-library filenames while they still arrive as static libraries.
* Keep them as link inputs and propagated dependencies, but exclude them from `static_libraries`, so `_merge_static_libs` never archives them into oneDAL.
* Clarify why this focused workaround is used instead of changing the custom linker wrapper to propagate `LibraryToLink.interface_library`: that provider has no branch there today and broadening it is separate work.

Linux is unchanged: `libtbb.so*` follows the existing dynamic-library path.

## Follow-up

PR #3740 adds the debug TBB import-library names; they are included in the same exclusion list.

## Verification

* Local: `git diff --check`.
* CI required: Windows Bazel must have no `LNK4006` for `__NULL_IMPORT_DESCRIPTOR`; `dumpbin /symbols onedal_core.lib | findstr __NULL_IMPORT_DESCRIPTOR` must be empty; `compare_windows_release.ps1` must stay clean.