### PR TITLE
bazel: stage the documentation tree into the release, as make does

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ MODULE.bazel.lock
 # Configurations from file explorers
 .directory
 .DS_Store
+
+# Documentation tree staged by the build (see the `release_documentation`
+# filegroup in the root BUILD file); generated outside the repository.
+/documentation/

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,5 @@ MODULE.bazel.lock
 .directory
 .DS_Store
 
-# Documentation tree staged by the build (see the `release_documentation`
-# filegroup in the root BUILD file); generated outside the repository.
-/documentation/
+# Documentation tree staged for the release build
+documentation/

--- a/BUILD
+++ b/BUILD
@@ -91,11 +91,14 @@ filegroup(
     srcs = ["samples/daal/cpp/mpi/makefile_lnx"],
 )
 
-# The makefile stages a documentation tree into `daal/latest/documentation`
-# (makefile:442-444, :1051-1058). Its source, `$(DIR)/../documentation`, lives
-# *outside* the repository and the recipe is guarded by `if [ -d ... ]`, so the
-# Make package ships those files only in build trees that have them -- that is
-# where `documentation/en/common/license.txt` and the
+# The makefile stages a documentation tree into `daal/latest/documentation`. Its
+# source lives *outside* the repository and the recipe skips it when absent:
+#
+#     DOC.srcdir:= $(DIR)/../documentation
+#     release.DOC := $(shell if [ -d $(DOC.srcdir) ]; then find $(DOC.srcdir) ... ;fi)
+#
+# so the Make package ships those files only in build trees that have them --
+# that is where `documentation/en/common/license.txt` and the
 # `third-party-programs*.txt` files the release BOM lists come from.
 #
 # Bazel cannot glob above the workspace, so the equivalent tree has to be

--- a/BUILD
+++ b/BUILD
@@ -91,6 +91,21 @@ filegroup(
     srcs = ["samples/daal/cpp/mpi/makefile_lnx"],
 )
 
+# The makefile stages a documentation tree into `daal/latest/documentation`
+# (makefile:442-444, :1051-1058). Its source, `$(DIR)/../documentation`, lives
+# *outside* the repository and the recipe is guarded by `if [ -d ... ]`, so the
+# Make package ships those files only in build trees that have them -- that is
+# where `documentation/en/common/license.txt` and the
+# `third-party-programs*.txt` files the release BOM lists come from.
+#
+# Bazel cannot glob above the workspace, so the equivalent tree has to be
+# visible inside it. When it is absent this expands to nothing, exactly like
+# the makefile's guard.
+filegroup(
+    name = "release_documentation",
+    srcs = glob(["documentation/**"], allow_empty = True),
+)
+
 filegroup(
     name = "release_package_files",
     srcs = glob([
@@ -169,6 +184,7 @@ release(
     }),
     data = [
         "//data:datasets",
+        ":release_documentation",
         ":release_package_files",
         "//examples/daal/cpp:release_files",
         "//examples/oneapi/cpp:release_files",

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -303,41 +303,33 @@ The most used Bazel commands are `build`, `test` and `run`.
 
 ### Documentation tree in the release
 
-The release package is expected to carry a `documentation/` tree — the release
-BOM lists `documentation/en/common/license.txt` and the
-`third-party-programs*.txt` files from it. That tree is **not** part of this
-repository. It is produced by a separate documentation build, and both the Make
-and the Bazel packaging step only copy it when it happens to be present:
+The release package carries a `documentation/` tree — the release BOM lists
+`documentation/en/common/license.txt` and the `third-party-programs*.txt` files
+from it. That tree is **not** part of this repository; it comes from a separate
+documentation build. Make takes it from beside the repository and skips it when
+it is not there:
 
-| | Make | Bazel |
-|---|---|---|
-| Source | `$(DIR)/../documentation`, i.e. next to the repository | `documentation/` inside the workspace |
-| Destination | `daal/latest/documentation` | `daal/latest/documentation` |
-| When absent | recipe is guarded by `if [ -d ... ]` (`makefile:442-444`, `:1051-1058`) | `glob(..., allow_empty = True)` expands to nothing |
+```make
+DOC.srcdir:= $(DIR)/../documentation
+release.DOC := $(shell if [ -d $(DOC.srcdir) ]; then find $(DOC.srcdir) -not -wholename '*.svn*' -type f ;fi)
+```
 
-Bazel cannot glob above the workspace, so the tree has to be reachable from
-inside it. Stage it before building the release, by symlink or copy:
+Bazel cannot glob above the workspace, so the tree has to be staged inside it as
+`documentation/`, by symlink or copy, before building the release:
 
 ```sh
 ln -sfn /path/to/documentation documentation
 bazel build //:release
 ```
 
-`documentation/` is in `.gitignore` so a staged tree is never committed. The
-`release_documentation` filegroup in the root `BUILD` file picks it up, and the
-release rule copies it with its directory structure preserved, so nothing has to
-enumerate the documentation layout.
+The `release_documentation` filegroup in the root `BUILD` file globs it with
+`allow_empty = True`, so an absent tree is not an error, and the release rule
+copies it to `daal/latest/documentation` with its structure preserved.
+`/documentation/` is listed in `.gitignore`, so a staged tree is never
+committed.
 
-Nothing in CI stages the tree today, which means the Bazel release built by CI
-ships without documentation, exactly as the Make release does there. Whoever
-produces an official package is responsible for staging it first — the same
-responsibility the Make build already places on them.
-
-If a packaging job would rather copy the tree into the release directory *after*
-`bazel build //:release`, this hook is unnecessary and can be dropped; keeping it
-means the Bazel release rule owns the whole package, so the release tree is
-complete the moment the build finishes and the Make/Bazel comparator sees the
-same set of files on both sides.
+No CI job stages the tree, so releases built in CI ship without documentation on
+both Make and Bazel. Staging it is the packaging job's responsibility either way.
 
 ### Release validation and platform helpers
 

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -301,6 +301,44 @@ The most used Bazel commands are `build`, `test` and `run`.
 
   The resulting release tree is under `bazel-bin/release/daal/latest`.
 
+### Documentation tree in the release
+
+The release package is expected to carry a `documentation/` tree — the release
+BOM lists `documentation/en/common/license.txt` and the
+`third-party-programs*.txt` files from it. That tree is **not** part of this
+repository. It is produced by a separate documentation build, and both the Make
+and the Bazel packaging step only copy it when it happens to be present:
+
+| | Make | Bazel |
+|---|---|---|
+| Source | `$(DIR)/../documentation`, i.e. next to the repository | `documentation/` inside the workspace |
+| Destination | `daal/latest/documentation` | `daal/latest/documentation` |
+| When absent | recipe is guarded by `if [ -d ... ]` (`makefile:442-444`, `:1051-1058`) | `glob(..., allow_empty = True)` expands to nothing |
+
+Bazel cannot glob above the workspace, so the tree has to be reachable from
+inside it. Stage it before building the release, by symlink or copy:
+
+```sh
+ln -sfn /path/to/documentation documentation
+bazel build //:release
+```
+
+`documentation/` is in `.gitignore` so a staged tree is never committed. The
+`release_documentation` filegroup in the root `BUILD` file picks it up, and the
+release rule copies it with its directory structure preserved, so nothing has to
+enumerate the documentation layout.
+
+Nothing in CI stages the tree today, which means the Bazel release built by CI
+ships without documentation, exactly as the Make release does there. Whoever
+produces an official package is responsible for staging it first — the same
+responsibility the Make build already places on them.
+
+If a packaging job would rather copy the tree into the release directory *after*
+`bazel build //:release`, this hook is unnecessary and can be dropped; keeping it
+means the Bazel release rule owns the whole package, so the release tree is
+complete the moment the build finishes and the Make/Bazel comparator sees the
+same set of files on both sides.
+
 ### Release validation and platform helpers
 
 Nightly CI builds Make and Bazel releases on both Linux and Windows, then uses

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -325,7 +325,7 @@ bazel build //:release
 The `release_documentation` filegroup in the root `BUILD` file globs it with
 `allow_empty = True`, so an absent tree is not an error, and the release rule
 copies it to `daal/latest/documentation` with its structure preserved.
-`/documentation/` is listed in `.gitignore`, so a staged tree is never
+`documentation/` is listed in `.gitignore`, so a staged tree is never
 committed.
 
 No CI job stages the tree, so releases built in CI ship without documentation on


### PR DESCRIPTION
## Description

The makefile copies a documentation tree into `daal/latest/documentation` (`makefile:442-444`, `:1051-1058`). Its source, `$(DIR)/../documentation`, lives *outside* the repository and the recipe is guarded by `if [ -d ... ]`, so the Make package ships those files only in build trees that have them.

That is where the release BOM's `documentation/en/common/license.txt`, `third-party-programs.txt`, `third-party-programs-mkl.txt` and `third-party-programs-onetbb.txt` come from. The Bazel release rule has **no** documentation step at all (`grep -r documentation dev/bazel/` finds nothing), so the BOM generator reports every one of them missing when packaging a Bazel-produced release:

```
WARNING - Unable to find .../daal/latest/documentation/en/common/license.txt for component lnx_license_en_redist
WARNING - Unable to find .../daal/latest/documentation/en/common/third-party-programs.txt for component lnx_licensing_redist
...
```

## Changes

* new `:release_documentation` filegroup, `glob(["documentation/**"], allow_empty = True)`, added to `release(data = ...)`. `_copy_data` already keys destinations off `short_path`, so files land at `daal/latest/documentation/...` with structure preserved.
* `.gitignore` entry for the staged tree.

## Note for the packaging side

Bazel cannot glob above the workspace, so unlike make (which reads `../documentation`) the tree has to be visible **inside** the workspace as `documentation/`. The build that provides the docs must symlink or copy it there; when it is absent the glob expands to nothing, exactly like the makefile's `if [ -d ]` guard. Alternatively the packaging job can copy the tree into the release directory after `bazel build //:release` and this hook is not needed — happy to drop it if that is the preferred split.

## Verification

Not built locally. `bazel build //:release` with no `documentation/` present must behave exactly as today (empty glob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)