### PR TITLE
hdbscan init fixes

### DIFF
--- a/cpp/daal/src/algorithms/hdbscan/hdbscan_cluster_utils.h
+++ b/cpp/daal/src/algorithms/hdbscan/hdbscan_cluster_utils.h
@@ -403,7 +403,9 @@ static void computeClusterStability(const CondensedEdge * condensed, const algor
 /// grandparent sees the propagated score). If the parent wins, every
 /// descendant is unselected via an explicit stack walk over
 /// `childOffset`/`childList`. Oversized clusters (size > `mcsMax`) are forced
-/// onto the children-win branch unconditionally.
+/// onto the children-win branch unconditionally; this applies to leaf clusters
+/// too, which are otherwise skipped since they have no children to compare
+/// against.
 ///
 /// `treeTop` controls whether the root cluster participates. When the caller
 /// allows a single-cluster outcome, `treeTop == rootCid` and the root may win
@@ -431,7 +433,19 @@ static void runEomSelection(DAAL_INT nClusters, DAAL_INT treeTop, DAAL_INT mcsMa
 {
     for (DAAL_INT c = nClusters - 1; c >= treeTop; c--)
     {
-        if (isLeafCluster[c]) continue;
+        if (isLeafCluster[c])
+        {
+            // A leaf cluster has no children to compare against, so the
+            // stability comparison can never unselect it -- but the size cap
+            // still has to be honoured. Its propagated stability is the (empty)
+            // child sum, i.e. zero, matching the non-leaf children-win branch.
+            if (clusterSz[c] > mcsMax)
+            {
+                isSelected[c] = false;
+                stability[c]  = algorithmFPType(0);
+            }
+            continue;
+        }
 
         algorithmFPType childSum       = algorithmFPType(0);
         const DAAL_INT childOffsetC    = childOffset[c];

--- a/cpp/oneapi/dal/algo/hdbscan/backend/gpu/kernel_impl.hpp
+++ b/cpp/oneapi/dal/algo/hdbscan/backend/gpu/kernel_impl.hpp
@@ -1226,8 +1226,17 @@ inline sycl::event eom_select_clusters_kernel(sycl::queue& queue,
             else {
                 const std::int32_t tree_top = w.allow_single_cluster ? root_cid : (root_cid + 1);
                 for (std::int32_t c = n_clusters - 1; c >= tree_top; c--) {
-                    if (w.ilc_ptr[c])
+                    if (w.ilc_ptr[c]) {
+                        // Leaf clusters have no children, so the stability
+                        // comparison below can never unselect them -- but the
+                        // size cap still applies. Propagated stability is the
+                        // (empty) child sum, i.e. zero.
+                        if (w.csz_ptr[c] > mcs_max) {
+                            w.is_ptr[c] = 0;
+                            w.stab_ptr[c] = Float(0);
+                        }
                         continue;
+                    }
 
                     Float child_sum = Float(0);
                     if (w.cc0_ptr[c] >= 0)

--- a/cpp/oneapi/dal/algo/hdbscan/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/hdbscan/test/batch.cpp
@@ -1260,13 +1260,43 @@ TEMPLATE_LIST_TEST_M(hdbscan_batch_test,
         10.0,  10.2, //
         10.15, 10.15, //
     };
-    const auto x = homogen_table::wrap(data, 10, 2);
+    const std::int64_t row_count = 10;
+    const auto x = homogen_table::wrap(data, row_count, 2);
 
-    // max_cluster_size should run without error (functional check)
-    const auto desc = hdbscan::descriptor<Float, hdbscan::method::brute_force>(5, 5)
-                          .set_result_options(result_options::responses)
-                          .set_max_cluster_size(3);
-    REQUIRE_NOTHROW(dal::compute(desc, x));
+    // Sizes of every reported (non-noise) cluster, keyed by label.
+    const auto cluster_sizes = [&](std::int64_t max_cluster_size) {
+        const auto desc = hdbscan::descriptor<Float, hdbscan::method::brute_force>(5, 5)
+                              .set_result_options(result_options::responses)
+                              .set_max_cluster_size(max_cluster_size);
+        const auto responses = dal::compute(desc, x).get_responses();
+        const auto rows = row_accessor<const Float>(responses).pull({ 0, -1 });
+
+        std::map<std::int64_t, std::int64_t> sizes;
+        for (std::int64_t i = 0; i < row_count; i++) {
+            const auto label = static_cast<std::int64_t>(rows[i]);
+            if (label >= 0) {
+                sizes[label]++;
+            }
+        }
+        return sizes;
+    };
+
+    // Uncapped: the two blobs are found as clusters of 5 points each. They are
+    // leaves of the condensed tree, so they have no children to lose the EOM
+    // stability comparison against -- only the size cap can unselect them.
+    const auto uncapped = cluster_sizes(0);
+    REQUIRE(uncapped.size() == 2);
+    for (const auto& [label, size] : uncapped) {
+        INFO("label = " << label);
+        REQUIRE(size == 5);
+    }
+
+    // Capped below the blob size: neither blob may be reported as a cluster.
+    constexpr std::int64_t max_cluster_size = 3;
+    for (const auto& [label, size] : cluster_sizes(max_cluster_size)) {
+        INFO("label = " << label);
+        REQUIRE(size <= max_cluster_size);
+    }
 }
 
 // =========================================================================


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
