### PR TITLE
ci: Add AArch64 SVE runners

### DIFF
--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -46,7 +46,8 @@ jobs:
       matrix:
         os: [
           { name: GitHub hosted, label: ubuntu-24.04-arm, cxx: gnu },
-          { name: Arm hosted, label: ah-ubuntu_24_04-c6g_2x-50, cxx: clang }
+          { name: Arm hosted, label: ah-ubuntu_24_04-c6g_2x-50, cxx: clang },
+          { name: Arm hosted (SVE), label: ah-ubuntu_24_04-c7g_2x-50, cxx: gnu }
         ]
 
     name: LinuxMake${{ matrix.os.cxx }}_OpenBLAS(SVE)-${{ matrix.os.name }}


### PR DESCRIPTION
- c7g has SVE whereas c6g does not.