### PR TITLE
ci: make the nightly Bazel release comparison report real differences

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -61,6 +61,11 @@ resources:
 
 jobs:
 - job: 'FormatterChecks'
+  # Two dependency installs and two source sweeps; fifteen minutes is generous.
+  # Without a limit the job inherits the hosted-agent default of an hour and a
+  # hung download reports as a cancellation an hour later, which reads like an
+  # unrelated infrastructure fault rather than a stuck step (build 62527).
+  timeoutInMinutes: 15
   pool:
     vmImage: '$(VM_IMAGE)'
   steps:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -27,6 +27,12 @@ name: Nightly-test
 # Post the dispatch run URL as a comment on the PR for reviewers.
 # The CVE scan is intentionally skipped on dispatch — it uploads SARIF to
 # the Security tab and must only run on genuine Nightly-build completions.
+#
+# The jobs that check out the tested commit hold read-only permissions, and the
+# check runs they report through are created and completed by separate jobs that
+# check out nothing. That split is deliberate: most pull requests here come from
+# forks, and a workflow_run job may only build a fork's commit when it carries
+# none of the write scopes, secrets or caches that make such a job a target.
 
 on:
   workflow_run:
@@ -84,47 +90,84 @@ jobs:
           #              downloaded in the previous step to the working directory
           build_command: "mv ${{ runner.temp }}/${{ env.BUILD_FOLDER }} ./"
 
-  bazel_lnx:
-    name: oneDAL Linux Bazel test
+  # Check runs are created and completed by jobs that never check out the tested
+  # code, so publishing them needs no privilege inside the jobs that build it.
+  # See the `bazel_lnx` comment on why that separation is what lets a fork's
+  # pull request be tested at all.
+  check_start:
+    name: Publish Bazel test check runs
     runs-on: ubuntu-24.04
     if: >
       ${{ github.repository == 'uxlfoundation/oneDAL'
           && (github.event_name == 'workflow_dispatch'
               || github.event.workflow_run.conclusion == 'success') }}
-    timeout-minutes: 120
     permissions:
-      contents: read
       checks: write
-
+    outputs:
+      lnx_check_run_id: ${{ steps.create.outputs.lnx_check_run_id }}
+      win_check_run_id: ${{ steps.create.outputs.win_check_run_id }}
     steps:
-      # Publish a Check Run bound to the originating commit so this job appears
-      # as its own line on the PR's Checks list, even though workflow_run
-      # triggers do not otherwise surface on the PR. On workflow_dispatch,
-      # bind to github.sha (HEAD of the dispatched ref); the platform sets
-      # this — never take head_sha from a caller-supplied input.
-      - name: Report check run (start)
-        id: check_start
+      # Publish a Check Run bound to the originating commit so the test jobs
+      # appear as their own lines on the PR's Checks list, even though
+      # workflow_run triggers do not otherwise surface on the PR. On
+      # workflow_dispatch, bind to github.sha (HEAD of the dispatched ref); the
+      # platform sets this — never take head_sha from a caller-supplied input.
+      - name: Report check runs (start)
+        id: create
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const headSha = context.payload.workflow_run?.head_sha || context.sha
             const detailsUrl = context.payload.workflow_run?.html_url
               || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            const { data } = await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'Nightly-test / oneDAL Linux Bazel test',
-              head_sha: headSha,
-              status: 'in_progress',
-              details_url: detailsUrl,
-            })
-            core.setOutput('check_run_id', data.id)
+            for (const [output, name] of [
+              ['lnx_check_run_id', 'Nightly-test / oneDAL Linux Bazel test'],
+              ['win_check_run_id', 'Nightly-test / oneDAL Windows Bazel test'],
+            ]) {
+              const { data } = await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name,
+                head_sha: headSha,
+                status: 'in_progress',
+                details_url: detailsUrl,
+              })
+              core.setOutput(output, data.id)
+            }
+
+  bazel_lnx:
+    name: oneDAL Linux Bazel test
+    runs-on: ubuntu-24.04
+    needs: check_start
+    if: >
+      ${{ github.repository == 'uxlfoundation/oneDAL'
+          && (github.event_name == 'workflow_dispatch'
+              || github.event.workflow_run.conclusion == 'success') }}
+    timeout-minutes: 120
+    # This job builds the tested commit, which for a pull request means running
+    # code the fork controls. It therefore holds no write scope of any kind, and
+    # `check_start`/`check_finish` do the `checks: write` work instead. `actions:
+    # read` is what `download-artifact` needs to reach the Nightly-build run's
+    # artifacts; `contents: read` adds nothing beyond public access.
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
       - name: Checkout oneDAL
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # workflow_run: pin to the commit that produced the artifacts.
           # workflow_dispatch: default to the dispatched ref (github.ref).
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          # checkout refuses fork code under workflow_run unless this is set,
+          # because such a job normally carries the base repository's write
+          # scopes, secrets and default-branch cache — the "pwn request" shape.
+          # None of that is present here: the permissions block above grants
+          # read only, the job references no secrets, and it uses no cache
+          # action, so building a fork's commit is no more privileged than the
+          # pull_request run that already builds it.
+          allow-unsafe-pr-checkout: true
       - name: Download oneDAL Linux build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -149,69 +192,33 @@ jobs:
             --platform linux \
             --make ./__release_lnx/daal/latest \
             --bazel ./bazel-bin/release/daal/latest \
-            --check-level 4
-      - name: Report check run (finish)
-        if: always()
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          CHECK_RUN_ID: ${{ steps.check_start.outputs.check_run_id }}
-          JOB_STATUS: ${{ job.status }}
-        with:
-          script: |
-            const checkRunId = Number(process.env.CHECK_RUN_ID)
-            if (!checkRunId) return
-            const detailsUrl = context.payload.workflow_run?.html_url
-              || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            await github.rest.checks.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              check_run_id: checkRunId,
-              status: 'completed',
-              conclusion: process.env.JOB_STATUS === 'success' ? 'success' : 'failure',
-              details_url: detailsUrl,
-            })
+            --check-level 4 \
+            --make-symlinks-dereferenced
 
   bazel_win:
     name: oneDAL Windows Bazel test
     runs-on: windows-2025
+    needs: check_start
     if: >
       ${{ github.repository == 'uxlfoundation/oneDAL'
           && (github.event_name == 'workflow_dispatch'
               || github.event.workflow_run.conclusion == 'success') }}
     timeout-minutes: 180
+    # Read-only for the same reason as `bazel_lnx` above.
     permissions:
       contents: read
-      checks: write
+      actions: read
 
     steps:
-      # Publish a Check Run bound to the originating commit so this job appears
-      # as its own line on the PR's Checks list, even though workflow_run
-      # triggers do not otherwise surface on the PR. On workflow_dispatch,
-      # bind to github.sha (HEAD of the dispatched ref); the platform sets
-      # this — never take head_sha from a caller-supplied input.
-      - name: Report check run (start)
-        id: check_start
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const headSha = context.payload.workflow_run?.head_sha || context.sha
-            const detailsUrl = context.payload.workflow_run?.html_url
-              || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            const { data } = await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'Nightly-test / oneDAL Windows Bazel test',
-              head_sha: headSha,
-              status: 'in_progress',
-              details_url: detailsUrl,
-            })
-            core.setOutput('check_run_id', data.id)
       - name: Checkout oneDAL
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # workflow_run: pin to the commit that produced the artifacts.
           # workflow_dispatch: default to the dispatched ref (github.ref).
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          # See `bazel_lnx` for why opting out of checkout's fork guard is safe
+          # in a job that holds no write scope, no secrets and no cache.
+          allow-unsafe-pr-checkout: true
       - name: Download oneDAL Windows build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -262,23 +269,45 @@ jobs:
           call "%ONEAPI_ROOT%\setvars-vcvarsall.bat" %VS_VER%
           powershell -NoProfile -ExecutionPolicy Bypass -File .\.ci\scripts\test_bazel_release_cmake_example.ps1 ^
             -ReleaseDir .\bazel-bin\release\daal\latest
-      - name: Report check run (finish)
-        if: always()
+
+  check_finish:
+    name: Complete Bazel test check runs
+    runs-on: ubuntu-24.04
+    needs: [check_start, bazel_lnx, bazel_win]
+    # Runs whichever way the test jobs ended, so a check run is never left
+    # hanging in `in_progress`. `check_start` being skipped skips this too,
+    # which is correct: there is nothing to complete.
+    if: always() && needs.check_start.result == 'success'
+    permissions:
+      checks: write
+    steps:
+      - name: Report check runs (finish)
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          CHECK_RUN_ID: ${{ steps.check_start.outputs.check_run_id }}
-          JOB_STATUS: ${{ job.status }}
+          LNX_CHECK_RUN_ID: ${{ needs.check_start.outputs.lnx_check_run_id }}
+          LNX_RESULT: ${{ needs.bazel_lnx.result }}
+          WIN_CHECK_RUN_ID: ${{ needs.check_start.outputs.win_check_run_id }}
+          WIN_RESULT: ${{ needs.bazel_win.result }}
         with:
           script: |
-            const checkRunId = Number(process.env.CHECK_RUN_ID)
-            if (!checkRunId) return
             const detailsUrl = context.payload.workflow_run?.html_url
               || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            await github.rest.checks.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              check_run_id: checkRunId,
-              status: 'completed',
-              conclusion: process.env.JOB_STATUS === 'success' ? 'success' : 'failure',
-              details_url: detailsUrl,
-            })
+            // A job result the checks API accepts verbatim is passed through, so
+            // a cancelled or skipped test job does not read as a failed check.
+            const passThrough = new Set(['success', 'cancelled', 'skipped'])
+            for (const [idVar, resultVar] of [
+              ['LNX_CHECK_RUN_ID', 'LNX_RESULT'],
+              ['WIN_CHECK_RUN_ID', 'WIN_RESULT'],
+            ]) {
+              const checkRunId = Number(process.env[idVar])
+              if (!checkRunId) continue
+              const result = process.env[resultVar]
+              await github.rest.checks.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                check_run_id: checkRunId,
+                status: 'completed',
+                conclusion: passThrough.has(result) ? result : 'failure',
+                details_url: detailsUrl,
+              })
+            }

--- a/dev/release_tests/compare_release_trees.py
+++ b/dev/release_tests/compare_release_trees.py
@@ -238,8 +238,65 @@ WINDOWS_IGNORED_EXPORTS = frozenset([
 ])
 
 
+# Inheriting constructors of the exported oneAPI exception classes. Every entry
+# is a `??0` constructor of a class that declares `using Base::Base;` and nothing
+# else -- `oneapi::dal::invalid_argument`, `system_error`, ... in
+# cpp/oneapi/dal/exceptions.hpp and `coworker_error`, `communication_error` in
+# cpp/oneapi/dal/spmd/exceptions.hpp. cl materialises and exports the inherited
+# constructors of a `__declspec(dllexport)` class whether or not the DLL uses
+# them; icx and clang-cl emit them only where they are odr-used. The classes that
+# declare their own constructor out of line (`spmd::error_holder`) are emitted by
+# both, so they are absent here.
+#
+# The nightly is the only comparison that sees these: it builds the Make release
+# with `vc` (cl), while Azure's `WindowsReleaseCompare` builds it with icx and
+# reports no export differences at all.
+#
+# Not part of a consumer's link surface. `ONEDAL_EXPORT` is defined only under
+# `__ONEDAL_ENABLE_EXPORT__` (cpp/oneapi/dal/common.hpp:35), which only oneDAL's
+# own builds set (makefile:709,723 and dev/bazel/dal.bzl:532). For a consumer the
+# macro expands to nothing, so `throw oneapi::dal::invalid_argument{ msg }`
+# instantiates the constructor in the consumer's own object file and never emits
+# a reference the DLL has to satisfy.
+#
+# Listed one by one, like WINDOWS_IGNORED_EXPORTS above, so that a constructor of
+# a *different* class disappearing from a released library still fails.
+WINDOWS_IGNORED_INHERITED_CTORS = frozenset([
+    # oneapi::dal::v1, cpp/oneapi/dal/exceptions.hpp
+    "??0domain_error@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0domain_error@v1@dal@oneapi@@QEAA@PEBD@Z",
+    "??0internal_error@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0internal_error@v1@dal@oneapi@@QEAA@PEBD@Z",
+    "??0invalid_argument@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0invalid_argument@v1@dal@oneapi@@QEAA@PEBD@Z",
+    "??0out_of_range@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0out_of_range@v1@dal@oneapi@@QEAA@PEBD@Z",
+    "??0range_error@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0range_error@v1@dal@oneapi@@QEAA@PEBD@Z",
+    "??0system_error@v1@dal@oneapi@@QEAA@HAEBVerror_category@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z",
+    "??0system_error@v1@dal@oneapi@@QEAA@HAEBVerror_category@std@@PEBD@Z",
+    "??0system_error@v1@dal@oneapi@@QEAA@HAEBVerror_category@std@@@Z",
+    "??0system_error@v1@dal@oneapi@@QEAA@Verror_code@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z",
+    "??0system_error@v1@dal@oneapi@@QEAA@Verror_code@std@@PEBD@Z",
+    "??0system_error@v1@dal@oneapi@@QEAA@Verror_code@std@@@Z",
+    "??0unimplemented@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0unimplemented@v1@dal@oneapi@@QEAA@PEBD@Z",
+    "??0uninitialized_optional_result@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0uninitialized_optional_result@v1@dal@oneapi@@QEAA@PEBD@Z",
+    "??0unsupported_device@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0unsupported_device@v1@dal@oneapi@@QEAA@PEBD@Z",
+    # oneapi::dal::preview::spmd::v1, cpp/oneapi/dal/spmd/exceptions.hpp
+    "??0communication_error@v1@spmd@preview@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0communication_error@v1@spmd@preview@dal@oneapi@@QEAA@PEBD@Z",
+    "??0coworker_error@v1@spmd@preview@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0coworker_error@v1@spmd@preview@dal@oneapi@@QEAA@PEBD@Z",
+])
+
+
 def is_ignored_windows_export(symbol):
     if symbol in WINDOWS_IGNORED_EXPORTS:
+        return True
+    if symbol in WINDOWS_IGNORED_INHERITED_CTORS:
         return True
     return any(pattern.match(symbol) for pattern in WINDOWS_IGNORED_EXPORT_PATTERNS)
 
@@ -271,6 +328,55 @@ def classify(root):
                 files.add(rel_path)
 
     return dirs, files, links
+
+
+def absorb_dereferenced_links(make_root, make_files, bazel_root, bazel_links, limit):
+    """Reconcile symlinks a transport turned into copies on the Make side.
+
+    `actions/upload-artifact` stores the *contents* a symlink points at, so a
+    Make release that travels through a GitHub artifact arrives with
+    `libonedal.so` and `libonedal.so.4` as ordinary files -- the tree the
+    makefile built (`makefile:975` does `cp` plus two `ln -sf`) has them as
+    symlinks, exactly as Bazel stages them. Comparing the two verbatim reports
+    every such entry twice, as a Make-only file and a Bazel-only symlink, and
+    hides whatever else level 1 would have found.
+
+    Where Bazel has a symlink and Make a plain file at the same path, the pair is
+    removed from level 1 and checked the only way the transport still permits:
+    the Make file must be byte-identical to the target the Bazel symlink resolves
+    to. Both collections are mutated in place; the number of reconciled entries
+    is printed, because a silently tolerated difference reads like a comparison
+    that covered everything.
+    """
+    errors = 0
+    absorbed = []
+    mismatches = []
+
+    for path in sorted(set(bazel_links).intersection(make_files)):
+        target = (bazel_root / path).resolve()
+        # A symlink escaping the release tree is a staging bug, not a transport
+        # artefact, so leave it in level 1 to be reported there.
+        if not target.is_relative_to(bazel_root) or not target.is_file():
+            continue
+        make_files.discard(path)
+        del bazel_links[path]
+        absorbed.append(path)
+        if not filecmp.cmp(make_root / path, target, shallow=False):
+            mismatches.append((path, rel(target, bazel_root)))
+
+    if mismatches:
+        errors += len(mismatches)
+        print(f"Dereferenced symlink content mismatches: {len(mismatches)}")
+        for path, target in mismatches[:limit]:
+            print(f"  ! {path}: Make file differs from Bazel {path} -> {target}")
+    if absorbed:
+        print(
+            f"Make files reconciled against Bazel symlinks: {len(absorbed)}"
+            " (--make-symlinks-dereferenced)"
+        )
+        for path in absorbed[:limit]:
+            print(f"  ~ {path}")
+    return errors
 
 
 def is_text_path(path):
@@ -565,6 +671,15 @@ def main():
     parser.add_argument("--platform", choices=("linux", "windows"), required=True)
     parser.add_argument("--check-level", type=int, choices=range(1, 5), default=4)
     parser.add_argument("--structure-only", action="store_true")
+    parser.add_argument(
+        "--make-symlinks-dereferenced",
+        action="store_true",
+        help=(
+            "the Make release travelled through a transport that replaces "
+            "symlinks with copies of their targets, such as a GitHub artifact; "
+            "compare those entries by content instead of by kind"
+        ),
+    )
     parser.add_argument("--summary-limit", type=int, default=50)
     args = parser.parse_args()
     if args.structure_only:
@@ -599,6 +714,14 @@ def main():
     errors = 0
     print("")
     print("=== level 1: release tree entries ===")
+    if args.make_symlinks_dereferenced:
+        errors += absorb_dereferenced_links(
+            make_root,
+            make_files,
+            bazel_root,
+            bazel_links,
+            args.summary_limit,
+        )
     errors += compare_sets("directories", make_dirs, bazel_dirs, args.summary_limit)
     errors += compare_sets("files", make_files, bazel_files, args.summary_limit)
     errors += compare_sets("symlinks", set(make_links), set(bazel_links), args.summary_limit)


### PR DESCRIPTION
## Description

The nightly Bazel tests have been red on every pull request since they were added, for three unrelated reasons. None of them is a real release difference.

### 1. Fork pull requests never get past checkout

```
##[error]Refusing to check out fork pull request code from a 'workflow_run' workflow.
```

`actions/checkout` refuses because a `workflow_run` job carries the base repository's token scopes, secrets and default-branch cache. The only write scope these jobs held was `checks: write`, used solely to report their own check run, so that reporting moves into two jobs that check nothing out (`check_start`, `check_finish`). The test jobs keep `contents: read` plus the `actions: read` that `download-artifact` needs, reference no secrets and use no cache action — no more privileged than the `pull_request` run that already builds the same commit — and can therefore opt out of the guard.

Side effect: a cancelled or skipped test job now reports as cancelled/skipped rather than as a failure.

### 2. Linux: 24 "differences" that are 12 dereferenced symlinks

```
Make:  266 dirs, 1091 files, 0 links
Bazel: 266 dirs, 1079 files, 12 links
Only Make files: 12      -> lib/intel64/libonedal*.so, libonedal*.so.4
Only Bazel symlinks: 12  -> the same 12 paths
```

Both builds stage these identically (`makefile:975` = one `cp` plus two `ln -sf`), but the Make tree reaches the test job through `actions/upload-artifact`, which stores the contents a symlink points at. `--make-symlinks-dereferenced` takes those pairs out of level 1 and checks them the only way that remains: the Make file must be byte-identical to the target the Bazel symlink resolves to. A missing path, or different bytes, still fails. Azure's `LinuxReleaseCompare` never saw this because it downloads *both* trees as pipeline artifacts, so both sides are dereferenced alike.

### 3. Windows: 26 exports that only `cl` emits

```
! redist/intel64/onedal.4.dll: Make-only=26, Bazel-only=0
    - ??0invalid_argument@v1@dal@oneapi@@QEAA@PEBD@Z
    - ??0system_error@v1@dal@oneapi@@QEAA@Verror_code@std@@@Z
    ...
```

All 26 are `??0` constructors of the exception classes whose body is `using Base::Base;` (`cpp/oneapi/dal/exceptions.hpp`, `cpp/oneapi/dal/spmd/exceptions.hpp`). `cl` materialises the inherited constructors of a `__declspec(dllexport)` class whether the DLL uses them or not; icx and clang-cl emit them only where they are odr-used. The nightly is the only comparison that builds the Make release with `cl` — Azure's `WindowsReleaseCompare` builds it with icx and reports no export differences at all.

They cannot be part of a consumer's link surface: `ONEDAL_EXPORT` is defined only under `__ONEDAL_ENABLE_EXPORT__` (`cpp/oneapi/dal/common.hpp:35`), which only oneDAL's own builds set (`makefile:709,723`, `dev/bazel/dal.bzl:532`), so a consumer instantiates whatever constructor it uses in its own object file. Listed one by one, like the neighbouring list, so a constructor of any *other* class disappearing still fails — `spmd::error_holder`, which declares its constructor out of line and is emitted by both compilers, is deliberately absent.

### 4. Unrelated: FormatterChecks hangs for an hour

`FormatterChecks` has no `timeoutInMinutes`, so it inherits the hosted default of 60 minutes; build 62527 shows it cancelled at 60m09s with a stuck dependency install, which reads as unrelated infrastructure noise. Now 15 minutes.

### Verification

The comparator changes were exercised locally against a fixture reproducing the nightly's tree shape:

- without the flag, the 12 symlink pairs fail exactly as the nightly reports;
- with the flag, they pass;
- with the flag but different bytes behind the link, it fails with the offending path and target;
- with the flag but the entry missing on the Make side, it still fails.

And for the export list: all 26 symbols from the nightly report are ignored, the list contains nothing beyond them, and constructors of `error_holder` / `host_bad_alloc` remain compared.

`nightly-test.yml` itself cannot be verified from a fork pull request — `workflow_run` always uses the copy on `main`. It needs a `workflow_dispatch` run from a branch in this repository, per the note at the top of the file; the run URL will be posted here before this leaves draft.

---

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.

</details>
