### PR TITLE
fix: restore the clang build broken by HDBSCAN's min/max simd pragmas

### DIFF
--- a/cpp/daal/src/algorithms/hdbscan/hdbscan_ball_tree_batch_impl.i
+++ b/cpp/daal/src/algorithms/hdbscan/hdbscan_ball_tree_batch_impl.i
@@ -274,7 +274,7 @@ static DAAL_INT buildBallTree(const algorithmFPType * data, DAAL_INT * pointIndi
     algorithmFPType maxR = algorithmFPType(0);
     // `d2` is `TArrayScalable`-backed (see d2Arr above); its start is aligned to
     // DAAL_MALLOC_DEFAULT_ALIGNMENT. Reduction body uses `?:` per OMP conformance.
-    PRAGMA_OMP_SIMD_ARGS(reduction(max : maxR) aligned(d2 : DAAL_MALLOC_DEFAULT_ALIGNMENT))
+    PRAGMA_OMP_SIMD_MINMAX_ARGS(reduction(max : maxR) aligned(d2 : DAAL_MALLOC_DEFAULT_ALIGNMENT))
     for (DAAL_INT i = 0; i < count; i++)
     {
         maxR = (d2[i] > maxR) ? d2[i] : maxR;
@@ -415,7 +415,7 @@ static algorithmFPType computeMinCoreDistsBallTree(const BallNode<algorithmFPTyp
     if (node.left < 0)
     {
         algorithmFPType minCD = daal::services::internal::MaxVal<algorithmFPType>::get();
-        PRAGMA_OMP_SIMD_ARGS(reduction(min : minCD))
+        PRAGMA_OMP_SIMD_MINMAX_ARGS(reduction(min : minCD))
         for (DAAL_INT i = node.pointBegin; i < node.pointEnd; i++)
         {
             const algorithmFPType cd = coreDistances[pointIndices[i]];

--- a/cpp/daal/src/algorithms/hdbscan/hdbscan_distance_utils.h
+++ b/cpp/daal/src/algorithms/hdbscan/hdbscan_distance_utils.h
@@ -555,8 +555,11 @@ struct ChebyshevDist
         FPType mx = FPType(0);
         // OpenMP requires reduction-body updates to be expression-form (via `?:`)
         // rather than branch-form (`if (...) x = ...`) so the compiler can safely
-        // fold each lane into the max-reduction pattern under `omp simd`.
-        PRAGMA_OMP_SIMD_ARGS(reduction(max : mx))
+        // fold each lane into the max-reduction pattern under `omp simd`. That
+        // form is also why the pragma comes through PRAGMA_OMP_SIMD_MINMAX_ARGS:
+        // plain clang cannot treat a select-based FP min/max as a reduction, and
+        // says so as an error under `-Werror` (see service_defines.h).
+        PRAGMA_OMP_SIMD_MINMAX_ARGS(reduction(max : mx))
         for (size_t d = 0; d < nCols; d++)
         {
             const FPType diff = a[d] - b[d];
@@ -579,7 +582,7 @@ struct ChebyshevDist
     {
         FPType mx = FPType(0);
         // OpenMP: reduction body uses `?:` rather than `if (...) x = ...`.
-        PRAGMA_OMP_SIMD_ARGS(reduction(max : mx))
+        PRAGMA_OMP_SIMD_MINMAX_ARGS(reduction(max : mx))
         for (size_t d = 0; d < nCols; d++)
         {
             const FPType belowLo = (query[d] < lo[d]) ? (lo[d] - query[d]) : FPType(0);

--- a/cpp/daal/src/algorithms/hdbscan/hdbscan_kd_tree_batch_impl.i
+++ b/cpp/daal/src/algorithms/hdbscan/hdbscan_kd_tree_batch_impl.i
@@ -129,7 +129,7 @@ static DAAL_INT buildKdTree(const algorithmFPType * data, DAAL_INT * pointIndice
         algorithmFPType lo = daal::services::internal::MaxVal<algorithmFPType>::get();
         algorithmFPType hi = -daal::services::internal::MaxVal<algorithmFPType>::get();
         // Reduction body uses `?:` rather than `if (...) x = ...` per OMP simd conformance.
-        PRAGMA_OMP_SIMD_ARGS(reduction(min : lo) reduction(max : hi))
+        PRAGMA_OMP_SIMD_MINMAX_ARGS(reduction(min : lo) reduction(max : hi))
         for (DAAL_INT i = begin; i < end; i++)
         {
             const algorithmFPType val = data[pointIndices[i] * nCols + d];
@@ -252,7 +252,7 @@ static algorithmFPType computeMinCoreDists(const KdNode<algorithmFPType> * nodes
     {
         algorithmFPType minCD = daal::services::internal::MaxVal<algorithmFPType>::get();
         // Reduction body uses `?:` per OMP simd conformance.
-        PRAGMA_OMP_SIMD_ARGS(reduction(min : minCD))
+        PRAGMA_OMP_SIMD_MINMAX_ARGS(reduction(min : minCD))
         for (DAAL_INT i = node.pointBegin; i < node.pointEnd; i++)
         {
             const algorithmFPType cd = coreDistances[pointIndices[i]];

--- a/cpp/daal/src/services/service_defines.h
+++ b/cpp/daal/src/services/service_defines.h
@@ -153,6 +153,30 @@ DAAL_EXPORT bool daal_check_is_intel_cpu();
     #define PRAGMA_OMP_SIMD_ARGS(ARGS)
 #endif
 
+// Floating-point min/max reductions written in select (`?:`) form, which is what
+// OpenMP requires of a reduction body.
+//
+// Clang's loop vectorizer does not recognise a select-based floating-point
+// min/max as a reduction without fast-math relaxations --
+// `-Rpass-analysis=loop-vectorize` reports "value that could not be identified
+// as reduction is used outside the loop" -- and clang reports an unhonoured
+// vectorization pragma as `-Wpass-failed`, which oneDAL's clang builds promote
+// to an error through `-Werror`
+// (dev/make/compiler_definitions/clang.32e.mk:56). The pragma is therefore
+// hidden from plain clang, which is what
+// df_train_dense_default_impl.i:70, gbt_classification_train_dense_default_impl.i:165
+// and cross_entropy_loss_dense_default_batch_impl.i:100 each do inline with
+// `#ifndef __clang__`.
+//
+// icx also defines `__clang__`, but it does vectorize these loops and it is the
+// compiler oneDAL ships, so it keeps the pragma -- as do gcc and MSVC, through
+// the definitions above.
+#if defined(__clang__) && !defined(__INTEL_LLVM_COMPILER)
+    #define PRAGMA_OMP_SIMD_MINMAX_ARGS(ARGS)
+#else
+    #define PRAGMA_OMP_SIMD_MINMAX_ARGS(ARGS) PRAGMA_OMP_SIMD_ARGS(ARGS)
+#endif
+
 #ifdef DEBUG_ASSERT
     #include <assert.h>
     #define DAAL_ASSERT(cond) assert(cond);


### PR DESCRIPTION
## Description

`CI Conda Recipe / Linux(clangxx-20)` has been red on **every push to main since 51f8071e (#3593)** — 13, 16 and 18 August. Nothing else on main is affected: the `gxx-15` and `dpcpp-2025` jobs of the same workflow pass, and so do all the icx jobs.

```
./cpp/daal/src/algorithms/hdbscan/hdbscan_ball_tree_batch_impl.i:355:13: error: loop not vectorized:
  the optimizer was unable to perform the requested transformation; the transformation might be
  disabled or specified as part of an unsupported transformation ordering
  [-Werror,-Wpass-failed=transform-warning]
make: *** [makefile:567: __work_clang/md/lnx32e/core_static/hdbscan_kd_tree_batch_fpt_flt_cpu_nrh.o] Error 1
```

### Cause

clang's loop vectorizer does not treat a select-based (`?:`) floating-point min/max as a reduction without fast-math relaxations. `-Rpass-analysis=loop-vectorize` gives the real reason:

```
remark: loop not vectorized: value that could not be identified as reduction is used outside the loop
```

clang then reports the unhonoured `#pragma omp simd` as `-Wpass-failed`, and `COMPILER.lnx.clang` (`dev/make/compiler_definitions/clang.32e.mk:56`) carries `-Werror`, so a hint becomes a build failure. Reproduced outside oneDAL for all three of HDBSCAN's loop shapes — the gathered min/max in `hdbscan_kd_tree_batch_impl.i:132`, the gathered min in `hdbscan_ball_tree_batch_impl.i:418`, and the contiguous max in `hdbscan_ball_tree_batch_impl.i:277`. It is not ISA-specific: `-march=haswell` fails identically, so this is not about gather availability at the SSE2 baseline.

Note the error's line number points at the enclosing function signature rather than the loop; that is how clang attributes the remark, and it is why the log looks unrelated to any pragma.

This is also not new ground. All three floating-point min/max reductions oneDAL already had are hidden from clang inline, with the same comment each time:

- `dtrees/forest/df_train_dense_default_impl.i:70`
- `dtrees/gbt/classification/gbt_classification_train_dense_default_impl.i:165`
- `objective_function/cross_entropy_loss/cross_entropy_loss_dense_default_batch_impl.i:100`

HDBSCAN added six that are not.

### Change

Rather than a fourth spelling of `#ifndef __clang__`, `PRAGMA_OMP_SIMD_MINMAX_ARGS` joins the other pragma macros in `cpp/daal/src/services/service_defines.h`, and HDBSCAN's six sites go through it.

The macro also fixes what the inline guards get wrong: **icx defines `__clang__` too**, so `#ifndef __clang__` drops the pragma from the compiler oneDAL ships. The condition here is `defined(__clang__) && !defined(__INTEL_LLVM_COMPILER)`, so icx, gcc and MSVC keep exactly what they emit today.

### Verification

- Preprocessed the real macro chain from `service_defines.h`: the pragma is gone for plain clang and present with `__INTEL_LLVM_COMPILER` defined.
- Compiled all three loop shapes with the conda job's own flag set (`-Werror -Wno-empty-body -Wreturn-type -fopenmp-simd -O2 -march=nocona`): each fails before this change and passes after.
- icx behaviour is unchanged by construction — its branch of the macro is the pragma it emits today — but was not re-measured locally; no icx here. Azure's icx jobs are green on main with these loops as they stand.

Not done deliberately: converting the three older `#ifndef __clang__` sites to the new macro. It would restore icx vectorization in those loops, but that changes codegen in three unrelated algorithms and does not belong in a build fix.

---

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected. No codegen change for icx, gcc or MSVC; for plain clang the pragma was already having no effect, which is exactly what it was reporting.

</details>
