### PR TITLE
ci: do not fail the Coverity scan when its queue is busy

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -87,7 +87,23 @@ jobs:
             -d file_name=@cov-int.tgz \
             https://scan.coverity.com/projects/${{env.COVERITY_PROJECT_ID}}/builds/init \
             | tee response
-          upload_url=$(jq -r '.url' response)
+          # Coverity refuses a second submission while the previous one is still
+          # being analysed, and answers in plain text rather than JSON:
+          #
+          #   Your build is already in the queue for analysis. Please wait till
+          #   analysis finishes before uploading another build.
+          #
+          # That is a state of the Coverity queue, not a defect in this build, so
+          # it ends the job green with an annotation. It has to be handled before
+          # the jq below: the default shell is `bash -e`, so jq's parse error on
+          # that body aborts the step (exit 5) before the diagnostics underneath
+          # ever run -- which is how the scheduled scan came to report a queue
+          # collision as `jq: parse error: Invalid numeric literal`.
+          if grep -qi 'already in the queue' response; then
+            echo "::warning title=Coverity upload skipped::A previous build is still queued for analysis; ${GITHUB_SHA} was not uploaded. The next scheduled scan covers it."
+            exit 0
+          fi
+          upload_url=$(jq -r '.url' response 2>/dev/null || true)
           if [ -z "$upload_url" ] || [ "$upload_url" == "null" ]; then
             echo "Error: Failed to extract 'url' from API response." >&2
             cat response >&2


### PR DESCRIPTION
## Description

The scheduled Coverity scan of 2026-08-18 ([run 32185812094](https://github.com/uxlfoundation/oneDAL/actions/runs/32185812094)) went red after a clean build — 4030 compilation units, 99% ready for analysis — on the submission step:

```
Your build is already in the queue for analysis. Please wait till analysis finishes before uploading another build.
jq: parse error: Invalid numeric literal at line 1, column 5
##[error]Process completed with exit code 5
```

Two separate problems.

**The queue collision is not a defect.** Coverity accepts one build at a time per project and answers a second submission in plain text. Nothing about oneDAL is wrong in that case, and the commit is covered by the next scheduled scan. It now ends the job green with a warning annotation naming the commit that was not uploaded.

**The step's own diagnostic was unreachable.** There was already a branch for an unusable response — print the body, exit 1 — but the default shell is `bash -e`, so `upload_url=$(jq -r '.url' response)` aborts the step on jq's exit status before that branch runs. Hence exit 5, and a jq parse error as the only clue about what Coverity actually said. jq's failure no longer kills the step, so a genuinely broken response now reaches the message written for it.

## Verification

The step's shell body was run under `bash -e` (what the runner uses) against three canned responses, with `curl` stubbed:

| response | before | after |
|---|---|---|
| `already in the queue` | exit 5, `jq: parse error` | exit 0, warning annotation |
| valid JSON with `url` | exit 0 | exit 0, proceeds to the upload |
| other non-JSON (`503 …`) | exit 5, `jq: parse error` | exit 1, body printed |

CI cannot exercise this on a pull request: the step is gated on `github.ref == 'refs/heads/main'` and needs `COVERITY_TOKEN`, so it only runs post-merge on the scheduled scan.

---

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
