### PR TITLE
ci: do not check out fork commits in privileged Nightly-test

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -27,6 +27,16 @@ name: Nightly-test
 # Post the dispatch run URL as a comment on the PR for reviewers.
 # The CVE scan is intentionally skipped on dispatch — it uploads SARIF to
 # the Security tab and must only run on genuine Nightly-build completions.
+#
+# SECURITY: `workflow_run` is privileged — it runs in the base repository context
+# with base-repo secrets, a base-repo GITHUB_TOKEN, and write access to the
+# default-branch Actions cache that other workflows read. The Bazel jobs check
+# out `workflow_run.head_sha` and then execute it (`.ci/env/*.sh`, `BUILD`,
+# `dev/bazel/**`, `dev/release_tests/*.py`). Nightly-build runs on
+# `pull_request`, so head_sha may be a fork commit. The Bazel jobs are therefore
+# gated on `head_repository == github.repository`: reaching a branch here needs
+# write access, so that commit is trusted. To Bazel-test a fork PR, push its
+# branch to this repository or use the workflow_dispatch procedure above.
 
 on:
   workflow_run:
@@ -90,7 +100,8 @@ jobs:
     if: >
       ${{ github.repository == 'uxlfoundation/oneDAL'
           && (github.event_name == 'workflow_dispatch'
-              || github.event.workflow_run.conclusion == 'success') }}
+              || (github.event.workflow_run.conclusion == 'success'
+                  && github.event.workflow_run.head_repository.full_name == github.repository)) }}
     timeout-minutes: 120
     permissions:
       contents: read
@@ -125,6 +136,9 @@ jobs:
           # workflow_run: pin to the commit that produced the artifacts.
           # workflow_dispatch: default to the dispatched ref (github.ref).
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          # The build steps below execute this checkout; keep GITHUB_TOKEN out
+          # of .git/config so they cannot read it.
+          persist-credentials: false
       - name: Download oneDAL Linux build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -177,7 +191,8 @@ jobs:
     if: >
       ${{ github.repository == 'uxlfoundation/oneDAL'
           && (github.event_name == 'workflow_dispatch'
-              || github.event.workflow_run.conclusion == 'success') }}
+              || (github.event.workflow_run.conclusion == 'success'
+                  && github.event.workflow_run.head_repository.full_name == github.repository)) }}
     timeout-minutes: 180
     permissions:
       contents: read
@@ -212,6 +227,9 @@ jobs:
           # workflow_run: pin to the commit that produced the artifacts.
           # workflow_dispatch: default to the dispatched ref (github.ref).
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          # The build steps below execute this checkout; keep GITHUB_TOKEN out
+          # of .git/config so they cannot read it.
+          persist-credentials: false
       - name: Download oneDAL Windows build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
Nightly-test is triggered by workflow_run, which runs privileged in the base repository context. Nightly-build runs on pull_request including fork PRs, so workflow_run.head_sha can be an attacker-controlled commit; the Bazel jobs checked it out and then executed it via .ci/env/*.sh, BUILD, dev/bazel/** and dev/release_tests/*.py. That gave fork PRs code execution with the base-repo GITHUB_TOKEN (checks: write) and write access to the default-branch Actions cache scope that ci.yml restores from.

Gate both Bazel jobs on workflow_run.head_repository.full_name matching this repository, so only commits that reached the base repo (which requires write access) or workflow_dispatch runs are built. Also pass persist-credentials: false so the checked-out code cannot read the token from .git/config.

Fixes CodeQL actions/untrusted-checkout/critical.

## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
