### PR TITLE
[DO NOT MERGE] ci: bisect the sklearnex segfaults across four suspect sklearnex PRs

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -13,43 +13,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #===============================================================================
-# C/C++ with GCC
-# Build your C/C++ project with GCC using make.
-# Add steps that publish test results, save build artifacts, deploy, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/apps/c-cpp/gcc
+#
+# TEMPORARY DEBUG PIPELINE -- DO NOT MERGE.
+#
+# Purpose: bisect the recurrent segfaults seen in the LinuxSklearnex job by
+# running the very same job against several historical scikit-learn-intelex
+# commits instead of `main`.
+#
+# Everything except `LinuxMakeGNU_MKL` (which produces the oneDAL artifacts the
+# sklearnex jobs consume) has been deselected so the runs finish quickly and the
+# only signal in the pipeline is sklearnex.
+#
+# Each `Sklearnex_*` job is a verbatim copy of the original `LinuxSklearnex`
+# job; the ONLY difference is the scikit-learn-intelex commit it checks out.
+# The commits are the first parent of each suspect PR's squash merge, i.e. the
+# state of `main` immediately BEFORE that PR landed. Because the PRs landed at
+# different times, the list also forms a cumulative ladder -- see the comment
+# above each job for which of the four PRs it does and does not contain.
+#
+# The `sklearnex` repository resource below is only used to pull in the
+# `build-and-test-lnx.yml` steps template. That file is byte-identical at
+# `main` and at all four pinned commits, so keeping the resource at `main`
+# does not perturb the experiment.
 
-trigger:
-  branches:
-    include:
-    - main
-    - rls/*
-  paths:
-    exclude:
-    - docs
-    - .ci/pipeline/docs.yml
+trigger: none
+
 pr:
   branches:
     include:
     - main
     - rls/*
-  paths:
-    exclude:
-    - docs
-    - .ci/pipeline/docs.yml
 
 variables:
-  OPENBLAS_VERSION : 'v0.3.27'
-  TBB_VERSION : 'v2023.1.0'
   VM_IMAGE : 'ubuntu-24.04'
-  WIN_VM_IMAGE : 'windows-2022'
-  SYSROOT_OS: 'noble'
   PY_VERSION: '3.14'
   SKL_VERSION: '1.8'
-  # Link to latest version can be taken from basekit download page:
-  # https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html
-  # Check section 'Install through a Command Line':
-  WINDOWS_BASEKIT_URL: 'https://registrationcenter-download.intel.com/akdlm/IRC_NAS/4144bec3-82ce-4672-bd71-5c93a79cd5e7/intel-oneapi-toolkit-2026.1.0.191_offline.exe'
-  WINDOWS_DPCPP_COMPONENTS: 'intel.oneapi.win.cpp-dpcpp-common:intel.oneapi.win.mkl.devel:intel.oneapi.win.tbb.devel:intel.oneapi.win.dpl'
 
 resources:
   repositories:
@@ -60,24 +58,8 @@ resources:
       endpoint: intel-daal-connection
 
 jobs:
-- job: 'FormatterChecks'
-  pool:
-    vmImage: '$(VM_IMAGE)'
-  steps:
-    - script: |
-        .ci/env/apt.sh clang-format
-        .ci/env/editorconfig-checker.sh
-      displayName: 'Install Dependencies'
-    - script: |
-        .ci/scripts/clang-format.sh
-      displayName: 'clang-format check'
-      failOnStderr: true
-    - script: |
-        editorconfig-checker
-      displayName: 'editorconfig-checker'
-      failOnStderr: true
-
 - job: 'LinuxMakeGNU_MKL'
+  displayName: 'oneDAL build (artifact producer)'
   timeoutInMinutes: 0
   variables:
     release.dir: '__release_lnx_gnu'
@@ -115,645 +97,202 @@ jobs:
       targetPath: '$(Build.Repository.LocalPath)/.ci/env'
     displayName: 'Upload environment artifacts'
     continueOnError: true
-  - script: |
-      source /opt/intel/oneapi/setvars.sh
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface daal/cpp --build-system cmake
-    displayName: 'daal/cpp examples'
-  - script: |
-      source /opt/intel/oneapi/setvars.sh
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface oneapi/cpp --build-system cmake
-    displayName: 'oneapi/cpp examples'
-  - script: |
-      .ci/env/apt.sh miniforge
-    displayName: 'conda install'
-  - script: |
-      source /opt/intel/oneapi/setvars.sh
-      .ci/scripts/test.sh --test-kind samples --build-dir $(release.dir) --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build-system cmake
-    displayName: 'daal/cpp/mpi samples'
-  - script: |
-      source /opt/intel/oneapi/setvars.sh
-      .ci/scripts/test.sh --test-kind samples --build-dir $(release.dir) --compiler gnu --interface oneapi/cpp/mpi --conda-env ci-env --build-system cmake
-    displayName: 'oneapi/cpp/mpi samples'
-  - script: |
-      deploy/nuget/prepare_dal_nuget.sh --release-dir $(release.dir) --build-nupkg yes
-      tree -h -I include __nuget/inteldal*/
-      ls -lh __nuget/inteldal*.nupkg
-    displayName: 'nuget pkg'
-  - task: PublishPipelineArtifact@1
-    inputs:
-      artifactName: '$(platform.type) fail'
-      targetPath: '$(Build.Repository.LocalPath)/$(release.dir)'
-    displayName: 'Uploading on fail'
-    condition: failed()
-    continueOnError: true
+  # The examples / samples / nuget steps of the upstream job are deselected:
+  # they run after the artifacts are published and cannot influence sklearnex.
 
-- job: 'LinuxMakeIntel_MKL'
+# The four suspect PRs, in the order they landed on scikit-learn-intelex main:
+#
+#   2026-08-10  #3363  Replace the per-call std::regex result-option scan
+#                      with a shared parser
+#   2026-08-12  #3361  Fix reference counting and buffer ownership in the
+#                      NumPy/NumericTable conversions
+#   2026-08-26  #3368  Build the base-1 CSR index arrays without an
+#                      intermediate cast array
+#   2026-08-27  #3360  Make the CMake backend build reproducible and its
+#                      oneDAL discovery explicit
+#
+# Reading the results: the first job below that reproduces the segfault clears
+# every PR at or after it; the last green job indicts the PR named in the first
+# red job after it.
+
+- job: Sklearnex_Before_PR3363_RegexResultOptionParser
+  displayName: 'before #3363 (regex result-option parser) @ 7b4847a'
+  dependsOn: LinuxMakeGNU_MKL
   timeoutInMinutes: 0
   variables:
-    release.dir: '__release_lnx'
-    platform.type : 'lnx32e'
-  pool:
-    vmImage: '$(VM_IMAGE)'
-  steps:
-  - script: |
-      .ci/env/apt.sh dev-base
-    displayName: 'apt-get install'
-  - script: |
-      .ci/env/apt.sh dpcpp
-    displayName: 'dpcpp installation'
-  - script: |
-      .ci/env/apt.sh mkl
-    displayName: 'mkl installation'
-  - script: |
-      source /opt/intel/oneapi/setvars.sh
-      .ci/scripts/describe_system.sh
-    displayName: 'System info'
-  - script: |
-      source /opt/intel/oneapi/setvars.sh
-      .ci/scripts/build.sh --compiler icx --optimizations avx2 --target daal
-    displayName: 'make daal'
-  - script: |
-      source /opt/intel/oneapi/setvars.sh
-      .ci/scripts/build.sh --compiler icx --optimizations avx2 --target onedal_dpc
-    displayName: 'make onedal_dpc'
-  - script: |
-      source /opt/intel/oneapi/setvars.sh
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler icx --interface daal/cpp --build-system cmake
-    displayName: 'daal/cpp examples'
-  - script: |
-      source /opt/intel/oneapi/setvars.sh
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler icx --interface oneapi/cpp --build-system cmake
-    displayName: 'oneapi/cpp examples'
-  - script: |
-      source /opt/intel/oneapi/setvars.sh
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler icx --interface oneapi/dpc --build-system cmake
-    displayName: 'oneapi/dpc examples'
-  - script: |
-      .ci/env/apt.sh miniforge
-    displayName: 'conda install'
-  - script: |
-      source /opt/intel/oneapi/setvars.sh
-      .ci/scripts/test.sh --test-kind samples --build-dir $(release.dir) --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build-system cmake
-    displayName: 'daal/cpp/mpi samples'
-  - script: |
-      source /opt/intel/oneapi/setvars.sh
-      .ci/scripts/test.sh --test-kind samples --build-dir $(release.dir) --compiler gnu --interface oneapi/cpp/mpi --conda-env ci-env --build-system cmake
-    displayName: 'oneapi/cpp/mpi samples'
-
-- job: 'LinuxMakeGNU_MKL_Conda'
-  timeoutInMinutes: 300
-  variables:
-    release.dir: '__release_lnx_gnu_conda'
+    # 7b4847a3 = "Update dependency numpy to v2.5.2 (#3365)", 2026-08-10.
+    # Contains none of the four suspect PRs.
+    sklearnex.commit: '7b4847a3e938cc941b72633fe2602f00ac9b2b51'
+    release.dir: '__release_lnx_gnu'
     platform.type: 'lnx32e'
-    CONDA_ENV: 'onedal_env'
+    DALROOT: '$(Pipeline.Workspace)/daal/latest'
+    TBBROOT: '/opt/intel/oneapi/tbb/latest'
+    NO_DPC: 1
+    NO_DIST: 1
   pool:
     vmImage: '$(VM_IMAGE)'
+    maxParallel: 2
+  strategy:
+    matrix:
+      Python311:
+        PYTHON_VERSION: '$(PY_VERSION)'
+        SKLEARN_VERSION: '$(SKL_VERSION)'
   steps:
+  - checkout: none
   - script: |
-      .ci/env/apt.sh miniforge
-    displayName: 'apt-get install'
-  - script: |
-      source $(conda info --base)/etc/profile.d/conda.sh
-      conda create -y -n $(CONDA_ENV)
-      conda activate $(CONDA_ENV)
-      conda install -y -c conda-forge \
-          make \
-          tbb tbb-devel \
-          mkl mkl-devel mkl-static \
-          cmake \
-          impi-devel impi_rt
-    displayName: 'Create conda environment'
-  - script: |
-      source $(conda info --base)/etc/profile.d/conda.sh
-      conda activate $(CONDA_ENV)
-      .ci/scripts/describe_system.sh
-    displayName: 'System info'
-  - script: |
-      source $(conda info --base)/etc/profile.d/conda.sh
-      conda activate $(CONDA_ENV)
-      export TBBROOT="${CONDA_PREFIX}"
-      export MKLROOT="${CONDA_PREFIX}"
-      .ci/scripts/build.sh --compiler gnu --optimizations avx2 --backend-config mkl --target daal
-    displayName: 'make daal'
-  - script: |
-      source $(conda info --base)/etc/profile.d/conda.sh
-      conda activate $(CONDA_ENV)
-      export TBBROOT="${CONDA_PREFIX}"
-      export MKLROOT="${CONDA_PREFIX}"
-      .ci/scripts/build.sh --compiler gnu --optimizations avx2 --backend-config mkl --target onedal_c
-    displayName: 'make onedal_c'
-  - script: |
-      source $(conda info --base)/etc/profile.d/conda.sh
-      conda activate $(CONDA_ENV)
-      conda install -y -c conda-forge \
-          mkl-dpcpp mkl-devel-dpcpp \
-          dpcpp-cpp-rt dpcpp_linux-64 intel-sycl-rt \
-          onedpl-devel
-      export TBBROOT="${CONDA_PREFIX}"
-      export MKLROOT="${CONDA_PREFIX}"
-      .ci/scripts/build.sh --compiler gnu --optimizations avx2 --backend-config mkl --target onedal_dpc
-      mv __release_lnx_gnu __release_lnx_gnu_conda
-    displayName: 'make onedal_dpc'
-  - script: |
-      source $(conda info --base)/etc/profile.d/conda.sh
-      conda activate $(CONDA_ENV)
-      export TBBROOT="${CONDA_PREFIX}"
-      export MKLROOT="${CONDA_PREFIX}"
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface daal/cpp --build-system cmake
-    displayName: 'daal/cpp examples'
-  - script: |
-      source $(conda info --base)/etc/profile.d/conda.sh
-      conda activate $(CONDA_ENV)
-      export TBBROOT="${CONDA_PREFIX}"
-      export MKLROOT="${CONDA_PREFIX}"
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface oneapi/cpp --build-system cmake
-    displayName: 'oneapi/cpp examples'
-  - script: |
-      source $(conda info --base)/etc/profile.d/conda.sh
-      conda activate $(CONDA_ENV)
-      export TBBROOT="${CONDA_PREFIX}"
-      export MKLROOT="${CONDA_PREFIX}"
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler icx --interface oneapi/dpc --build-system cmake
-    displayName: 'oneapi/dpc examples'
-  - script: |
-      source $(conda info --base)/etc/profile.d/conda.sh
-      conda activate $(CONDA_ENV)
-      export TBBROOT="${CONDA_PREFIX}"
-      export MKLROOT="${CONDA_PREFIX}"
-      .ci/scripts/test.sh --test-kind samples --build-dir $(release.dir) --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build-system cmake
-    displayName: 'daal/cpp/mpi samples'
-
-- job: 'LinuxMakeLLVM_OpenBLAS_rv64'
-  timeoutInMinutes: 0
-  variables:
-    release.dir: '__release_lnx_clang'
-    platform.type : 'lnxriscv64'
-    OPENBLAS_VERSION : 'v0.3.27'
-    OPENBLAS_CACHE_DIR : $(Pipeline.Workspace)/openblas-riscv64-clang
-    TBB_VERSION : 'v2023.1.0'
-    TBB_CACHE_DIR : $(Pipeline.Workspace)/tbb-riscv64-clang
-    SYSROOT_CACHE_DIR: $(Pipeline.Workspace)/sysroot-riscv64
-  pool:
-    vmImage: 'ubuntu-24.04'
-  steps:
-  - script: |
-      .ci/env/apt.sh dev-base
-    displayName: 'apt-get install'
-  - script: |
-      .ci/env/apt.sh gnu-cross-compilers riscv64
-    displayName: 'riscv64-compiler installation'
-  - script: |
-      .ci/env/apt.sh llvm-version 18
-    displayName: 'llvm 18 installation'
-  - script: |
-      .ci/env/apt.sh qemu-apt
-    displayName: 'qemu-emulation installation'
-  - task: Cache@2
-    inputs:
-      key: '"riscv64" | "sysroot" | "$(SYSROOT_OS)"'
-      path: $(SYSROOT_CACHE_DIR)
-      cacheHitVar: SYSROOT_RESTORED
-  - script: |
-      .ci/env/apt.sh build-sysroot $(Pipeline.Workspace) riscv64 $(SYSROOT_OS) sysroot-riscv64
-    displayName: 'Build riscv64 sysroot'
-    condition: ne(variables.SYSROOT_RESTORED, 'true')
-  - script: |
-      .ci/scripts/describe_system.sh
-    displayName: 'System info'
-  - task: Cache@2
-    inputs:
-      key: '"clang" | "riscv64" | "openblas" | "$(OPENBLAS_VERSION)" | "ILP64" | "$(SYSROOT_OS)"'
-      path: $(OPENBLAS_CACHE_DIR)
-      cacheHitVar: OPENBLAS_RESTORED
-  - script: |
-      .ci/env/openblas.sh --target RISCV64_ZVL128B --host-compiler gcc --compiler clang --target-arch riscv64 --cross-compile --prefix $(OPENBLAS_CACHE_DIR) --sysroot $(SYSROOT_CACHE_DIR) --version $(OPENBLAS_VERSION)
-    displayName: 'Build OpenBLAS'
-    condition: ne(variables.OPENBLAS_RESTORED, 'true')
-  - task: Cache@2
-    inputs:
-      key: '"clang" | "riscv64" | "tbb" | "$(TBB_VERSION)" | "$(SYSROOT_OS)"'
-      path: $(TBB_CACHE_DIR)
-      cacheHitVar: TBB_RESTORED
-  - script: |
-      export ONEDAL_SYSROOT=$(SYSROOT_CACHE_DIR)
-      .ci/env/tbb.sh --cross-compile --toolchain-file $(Build.Repository.LocalPath)/.ci/env/riscv64-clang-crosscompile-toolchain.cmake --target-arch riscv64 --prefix $(TBB_CACHE_DIR) --version $(TBB_VERSION)
-    displayName: 'Build oneTBB'
-    condition: ne(variables.TBB_RESTORED, 'true')
-  - script: |
-      .ci/scripts/build.sh --compiler clang --optimizations rv64 --target daal --backend-config ref --cross-compile --plat lnxriscv64 --sysroot $(SYSROOT_CACHE_DIR) --blas-dir $(OPENBLAS_CACHE_DIR) --tbb-dir $(TBB_CACHE_DIR)
-    displayName: 'make daal'
-  - script: |
-      .ci/scripts/build.sh --compiler clang --optimizations rv64 --target onedal_c --backend-config ref --cross-compile --plat lnxriscv64 --sysroot $(SYSROOT_CACHE_DIR) --blas-dir $(OPENBLAS_CACHE_DIR) --tbb-dir $(TBB_CACHE_DIR)
-    displayName: 'make onedal_c'
-  - task: PublishPipelineArtifact@1
-    inputs:
-      artifactName: '$(platform.type) RISCV64 OpenBLAS build'
-      targetPath: '$(Build.Repository.LocalPath)/$(release.dir)'
-    displayName: 'Upload build artifacts'
-    continueOnError: true
-  - script: |
-      export QEMU_LD_PREFIX=$(SYSROOT_CACHE_DIR)
-      export QEMU_CPU="max"
-      export TBBROOT=$(TBB_CACHE_DIR)
-      export ARCH_ONEDAL=riscv64
-      export ONEDAL_SYSROOT=$(SYSROOT_CACHE_DIR)
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler clang --interface daal/cpp --build-system cmake --platform lnxriscv64 --cross-compile --backend ref
-    displayName: 'daal/cpp examples'
-  - script: |
-      export QEMU_LD_PREFIX=$(SYSROOT_CACHE_DIR)
-      export QEMU_CPU="max"
-      export TBBROOT=$(TBB_CACHE_DIR)
-      export ARCH_ONEDAL=riscv64
-      export ONEDAL_SYSROOT=$(SYSROOT_CACHE_DIR)
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler clang --interface oneapi/cpp --build-system cmake --platform lnxriscv64 --cross-compile --backend ref
-    displayName: 'oneapi/cpp examples'
-  - task: PublishPipelineArtifact@1
-    inputs:
-      artifactName: '$(platform.type) fail'
-      targetPath: '$(Build.Repository.LocalPath)/$(release.dir)'
-    displayName: 'Uploading on fail'
-    condition: failed()
-    continueOnError: true
-
-- job: 'LinuxBazel'
-  timeoutInMinutes: 0
-  pool:
-    vmImage: '$(VM_IMAGE)'
-  variables:
-    platform.type : 'lnx32e'
-    BAZEL_CACHE_DIR: $(Pipeline.Workspace)/.bazel-cache
-    BAZEL_VERSION: $(Pipeline.Workspace)/bazelisk-linux-amd64
-    BAZEL_CACHE_MAX_SIZE_KB: 4194304 # Size in kilobytes ~ 4Gb
-  steps:
-  - script: |
-      .ci/env/apt.sh opencl
-    displayName: 'install opencl'
-  - script: |
-      # sourcing done to set bazel version value from script
-      source .ci/env/bazelisk.sh
-      echo "##vso[task.setvariable variable=BAZEL_VERSION]${BAZEL_VERSION}"
-    displayName: 'install-bazel'
-
-  - script: |
-      .ci/scripts/describe_system.sh
-    displayName: 'System info'
-  - task: Cache@2
-    inputs:
-      # Commit ID is added to a cache key. Caches are immutable by design,
-      # so we always need to change a key to upload the last version
-      # of the Bazel cache. Cache lookup is based on `restoreKeys` option.
-      key: '"$(BAZEL_VERSION)" | "$(Agent.OS)" | "v1" | "$(Build.SourceVersion)"'
-      restoreKeys: |
-        "$(BAZEL_VERSION)" | "$(Agent.OS)" | "v1"
-      path: $(BAZEL_CACHE_DIR)
-    displayName: 'bazel-cache'
-
-  - script: |
-      if [ -f "${BAZEL_CACHE_DIR}/cache-clean-timestamp" ]; then
-        echo
-        echo "Last time the cache is cleaned:"
-        cat "${BAZEL_CACHE_DIR}/cache-clean-timestamp"
-        echo
-      fi
-
-      # Create `.bazelrc` and set cache directory
-      # Minimal CPU instruction set in Azure is AVX2
-      echo "build --disk_cache=$(BAZEL_CACHE_DIR) --cpu=avx2" > ~/.bazelrc
-
-      # Display oneDAL build configuration
-      bazel build @config//:dump
-      echo
-      cat bazel-bin/external/+declare_onedal_config+config/config.json
-      echo
-    displayName: 'bazel-configure'
-
-  - script: |
-      set -euo pipefail
-
-      for config in dbg dbg-symbols asan asan-static lsan tsan ubsan msan type; do
-        echo "Checking Bazel config: ${config}"
-        bazel build --nobuild :release --config="${config}"
-      done
-
-      echo "Checking Bazel config: release-dpc"
-      bazel build --nobuild :release --config=release-dpc --cpu=all
-
-      echo "Checking Bazel config: stdalloc"
-      bazel build --nobuild :release --stdalloc=true --release_dpc=false
-
-      echo "Checking Bazel config: dev"
-      bazel build --nobuild //cpp/oneapi/dal:tests --config=dev
-    displayName: 'Bazel config smoke checks'
-
-  - script: |
-      bazel build :release --release_dpc=false
-    displayName: 'release'
-
-  - script: |
-      echo "Move Bazel release output to standalone directory"
-      rm -rf standalone_release
-      mkdir -p standalone_release
-
-      # Move instead of copy to save disk
-      mv bazel-bin/release/* standalone_release/
-
-      # Expose DALROOT for subsequent tasks
-      echo "##vso[task.setvariable variable=DALROOT]$(pwd)/standalone_release/daal/latest"
-    displayName: 'Prepare standalone release directory'
-
-  - task: PublishPipelineArtifact@1
-    inputs:
-      artifactName: '$(platform.type) Bazel build'
-      targetPath: '$(DALROOT)'
-    displayName: 'Upload build artifacts'
-
-  - script: |
-      echo "Cleaning Bazel cache before running example or tests"
-      bazel clean --expunge
-    displayName: 'Clean Bazel cache (expunge)'
-
-  - script: |
-      bazel test //cpp/daal:mkl_linkage_test \
-                  --test_env DALROOT
-    displayName: 'Check mkl symbols'
-
-  - script: |
-      bazel test //cpp/daal:isa_coverage_test \
-                 --cpu=all
-    displayName: 'Check ISA coverage'
-
-  - script: |
-      echo "Cleaning Bazel cache before running example or tests"
-      bazel clean --expunge
-    displayName: 'Clean Bazel cache (expunge)'
-
-  - script: |
-      bazel test //examples/daal/cpp:all \
-                 --test_link_mode=dev \
-                 --test_thread_mode=par
-    displayName: 'daal-cpp-examples-thread-dev'
-
-  - script: |
-      echo "Cleaning Bazel cache before running example or tests"
-      bazel clean --expunge
-    displayName: 'Clean Bazel cache (expunge)'
-
-  - script: |
-      bazel test //examples/oneapi/cpp:all \
-                 --test_link_mode=dev \
-                 --test_thread_mode=par
-    displayName: 'cpp-examples-thread-dev'
-
-  - script: |
-      echo "Cleaning Bazel cache before running example or tests"
-      bazel clean --expunge
-    displayName: 'Clean Bazel cache (expunge)'
-
-  - script: |
-      bazel test //examples/daal/cpp:all \
-                 --test_link_mode=release_static \
-                 --test_thread_mode=par \
-                 --test_env DALROOT
-    displayName: 'daal-cpp-examples-thread-release-static'
-
-  - script: |
-      echo "Cleaning Bazel cache before running example or tests"
-      bazel clean --expunge
-    displayName: 'Clean Bazel cache (expunge)'
-
-  - script: |
-      bazel test //examples/oneapi/cpp:all \
-                 --test_link_mode=release_static \
-                 --config=host \
-                 --test_thread_mode=par \
-                 --test_env DALROOT
-    displayName: 'cpp-examples-thread-release-static'
-
-  - script: |
-      echo "Cleaning Bazel cache before running example or tests"
-      bazel clean --expunge
-    displayName: 'Clean Bazel cache (expunge)'
-
-  - script: |
-      . "$(DALROOT)/env/vars.sh"
-      bazel test //examples/daal/cpp:all \
-                 --test_link_mode=release_dynamic \
-                 --test_thread_mode=par \
-                 --test_env DALROOT \
-                 --test_env LD_LIBRARY_PATH
-    displayName: 'daal-cpp-examples-thread-release-dynamic'
-
-  - script: |
-      echo "Cleaning Bazel cache before running example or tests"
-      bazel clean --expunge
-    displayName: 'Clean Bazel cache (expunge)'
-
-  - script: |
-      . "$(DALROOT)/env/vars.sh"
-      bazel test //examples/oneapi/cpp:all \
-                 --test_link_mode=release_dynamic \
-                 --test_thread_mode=par \
-                 --test_env DALROOT \
-                 --test_env LD_LIBRARY_PATH
-    displayName: 'cpp-examples-thread-release-dynamic'
-
-  - script: |
-      echo "Cleaning Bazel cache before running example or tests"
-      bazel clean --expunge
-    displayName: 'Clean Bazel cache (expunge)'
-
-  - script: |
-      bazel test //cpp/daal:tests
-    displayName: 'daal-tests-algorithms'
-
-  - script: |
-      echo "Cleaning Bazel cache before running example or tests"
-      bazel clean --expunge
-    displayName: 'Clean Bazel cache (expunge)'
-
-  - script: |
-      bazel test //cpp/oneapi/dal:tests \
-                 --config=host \
-                 --test_link_mode=dev \
-                 --test_thread_mode=par
-    displayName: 'cpp-tests-thread-dev'
-
-  - script: |
-      echo "Cleaning Bazel cache before running example or tests"
-      bazel clean --expunge
-    displayName: 'Clean Bazel cache (expunge)'
-
-  - script: |
-      # Clear cache if its size exceeds some predefined value
-      cache_size=$(du -sk "${BAZEL_CACHE_DIR}" | cut -f1)
-      cache_size_mb=$(du -sm "${BAZEL_CACHE_DIR}" | cut -f1)
-      echo "Bazel cache dir is ${BAZEL_CACHE_DIR}"
-      echo "Bazel cache size is ${cache_size_mb}Mb"
-      if [ ${cache_size} -ge ${BAZEL_CACHE_MAX_SIZE_KB} ]; then
-          echo "Run cache cleanup..."
-          echo "Current cache directory content:"
-          ls -1 "${BAZEL_CACHE_DIR}"
-          echo "--------------------------------"
-          echo "Run bazel clean with expunge"
-          echo "Remove cache directory"
-          rm -r "${BAZEL_CACHE_DIR}"
-          mkdir -p "${BAZEL_CACHE_DIR}"
-          echo "Write timestamp to the cache"
-          date > "${BAZEL_CACHE_DIR}/cache-clean-timestamp"
-          echo "Current cache directory content:"
-          ls -1 "${BAZEL_CACHE_DIR}"
-          echo "--------------------------------"
-      else
-          echo "No need for cleanup"
-      fi
-    displayName: 'bazel-cache-limit'
-
-- job: 'LinuxReleaseCompare'
-  dependsOn:
-  - LinuxMakeGNU_MKL
-  - LinuxBazel
-  pool:
-    vmImage: '$(VM_IMAGE)'
-  steps:
+      set -e
+      git clone https://github.com/uxlfoundation/scikit-learn-intelex.git .
+      git checkout --detach $(sklearnex.commit)
+      git log -1 --format='sklearnex at %H%n%s%n%ci'
+    displayName: 'Clone sklearnex @ $(sklearnex.commit)'
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifact: 'lnx32e build'
-      path: '$(Pipeline.Workspace)/make'
+      artifact: 'oneDAL environment'
+      path: '$(Build.Repository.LocalPath)/.ci/env'
   - task: DownloadPipelineArtifact@2
     inputs:
-      artifact: 'lnx32e Bazel build'
-      path: '$(Pipeline.Workspace)/bazel'
+      artifact: '$(platform.type) build'
+      path: $(Pipeline.Workspace)
   - script: |
-      python3 dev/release_tests/compare_release_trees.py \
-        --platform linux \
-        --make "$(Pipeline.Workspace)/make/daal/latest" \
-        --bazel "$(Pipeline.Workspace)/bazel"
-    displayName: 'Compare Make and Bazel release trees'
+      chmod -R 755 .ci/env
+      .ci/env/apt.sh tbb
+    displayName: 'tbb installation'
+  - template: .ci/pipeline/build-and-test-lnx.yml@sklearnex
 
-- job: 'WindowsBazel'
+- job: Sklearnex_Before_PR3361_NumpyRefCounting
+  displayName: 'before #3361 (NumPy/NumericTable refcounting) @ 7f38919'
+  dependsOn: LinuxMakeGNU_MKL
   timeoutInMinutes: 0
   variables:
-    release.dir: '__release_win_bazel_icx'
-    platform.type : 'win32e'
-    BAZELISK_VERSION: 'v1.28.1'
-    BAZELISK_EXE: '$(Build.Repository.LocalPath)\bazelisk.exe'
-    BAZEL_CACHE_DIR: '$(Pipeline.Workspace)\.bazel-cache'
-    BAZEL_CACHE_MAX_SIZE_KB: 4194304 # Size in kilobytes ~ 4Gb
-    BAZEL_OUTPUT_USER_ROOT: 'C:\b'
+    # 7f38919e = "Update dependency pre-commit to v4.6.2 (#3367)", 2026-08-11.
+    # Contains #3363; does not contain #3361, #3368, #3360.
+    sklearnex.commit: '7f38919e10c2864a97129a4ea9ff7d32038117d3'
+    release.dir: '__release_lnx_gnu'
+    platform.type: 'lnx32e'
+    DALROOT: '$(Pipeline.Workspace)/daal/latest'
+    TBBROOT: '/opt/intel/oneapi/tbb/latest'
+    NO_DPC: 1
+    NO_DIST: 1
   pool:
-    vmImage: '$(WIN_VM_IMAGE)'
+    vmImage: '$(VM_IMAGE)'
+    maxParallel: 2
+  strategy:
+    matrix:
+      Python311:
+        PYTHON_VERSION: '$(PY_VERSION)'
+        SKLEARN_VERSION: '$(SKL_VERSION)'
   steps:
-  - script: .ci/scripts/install_basekit.bat $(WINDOWS_BASEKIT_URL) $(WINDOWS_DPCPP_COMPONENTS)
-    displayName: 'Install oneAPI Base Toolkit'
-  - powershell: |
-      $ErrorActionPreference = "Stop"
-      $url = "https://github.com/bazelbuild/bazelisk/releases/download/$(BAZELISK_VERSION)/bazelisk-windows-amd64.exe"
-      Invoke-WebRequest -Uri $url -OutFile "$(BAZELISK_EXE)"
-      & "$(BAZELISK_EXE)" version
-    displayName: 'install-bazel'
+  - checkout: none
   - script: |
-      call %TEMP%\oneapi\setvars.bat --force
-      bash .ci/scripts/describe_system.sh
-    displayName: 'System info'
-  - task: Cache@2
+      set -e
+      git clone https://github.com/uxlfoundation/scikit-learn-intelex.git .
+      git checkout --detach $(sklearnex.commit)
+      git log -1 --format='sklearnex at %H%n%s%n%ci'
+    displayName: 'Clone sklearnex @ $(sklearnex.commit)'
+  - task: DownloadPipelineArtifact@2
     inputs:
-      # Commit ID is added to a cache key. Caches are immutable by design,
-      # so we always need to change a key to upload the last version
-      # of the Bazel cache. Cache lookup is based on `restoreKeys` option.
-      key: '"$(BAZELISK_VERSION)" | "$(Agent.OS)" | "v1" | "$(Build.SourceVersion)"'
-      restoreKeys: |
-        "$(BAZELISK_VERSION)" | "$(Agent.OS)" | "v1"
-      path: $(BAZEL_CACHE_DIR)
-    displayName: 'bazel-cache'
-  - script: |
-      if not exist "$(BAZEL_CACHE_DIR)" mkdir "$(BAZEL_CACHE_DIR)"
-      if not exist "$(BAZEL_OUTPUT_USER_ROOT)" mkdir "$(BAZEL_OUTPUT_USER_ROOT)"
-      set "BAZEL_CACHE_DIR_FWD=$(BAZEL_CACHE_DIR)"
-      set "BAZEL_CACHE_DIR_FWD=%BAZEL_CACHE_DIR_FWD:\=/%"
-      echo build --disk_cache=%BAZEL_CACHE_DIR_FWD% --cpu=avx2> "%USERPROFILE%\.bazelrc"
-      echo ##vso[task.setvariable variable=BAZEL_SH]C:\Program Files\Git\bin\bash.exe
-      echo ##vso[task.setvariable variable=BAZEL_JOBS]%NUMBER_OF_PROCESSORS%
-    displayName: 'bazel-configure'
-  - script: |
-      call %TEMP%\oneapi\setvars.bat --force
-      "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" shutdown
-      "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" build //:release --verbose_failures --jobs=$(BAZEL_JOBS)
-    displayName: 'release'
-  - script: |
-      rmdir /S /Q "$(release.dir)" 2>NUL
-      mkdir "$(release.dir)"
-      xcopy /E /I /Y "bazel-bin\release" "$(release.dir)" >NUL
-      echo ##vso[task.setvariable variable=DALROOT]$(Build.Repository.LocalPath)\$(release.dir)\daal\latest
-    displayName: 'Prepare standalone release directory'
-  - task: PublishPipelineArtifact@1
+      artifact: 'oneDAL environment'
+      path: '$(Build.Repository.LocalPath)/.ci/env'
+  - task: DownloadPipelineArtifact@2
     inputs:
-      artifactName: '$(platform.type) Bazel icx build'
-      targetPath: '$(DALROOT)'
-    displayName: 'Upload build artifacts'
-    continueOnError: true
+      artifact: '$(platform.type) build'
+      path: $(Pipeline.Workspace)
   - script: |
-      call %TEMP%\oneapi\setvars.bat --force
-      "$(VSDEVCMD)" -arch=amd64 -host_arch=amd64
-      "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" info output_base > output_base.txt
-      set /p OUTPUT_BASE=<output_base.txt
-      set "OUTPUT_BASE=%OUTPUT_BASE:/=\%"
-      set TEST_PATH=$(DALROOT)\redist\intel64;$(DALROOT)\lib\intel64;%OUTPUT_BASE%\external\+mkl_repo+mkl\bin;%OUTPUT_BASE%\external\+tbb_repo+tbb\bin;%PATH%
-      set PATH=%TEST_PATH%
-      "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" shutdown
-      "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" test //examples/daal/cpp:all --test_link_mode=release_dynamic --test_thread_mode=par --test_env=DALROOT "--test_env=PATH=%TEST_PATH%" --verbose_failures --jobs=$(BAZEL_JOBS)
-    displayName: 'daal-cpp-examples-thread-release-dynamic'
+      chmod -R 755 .ci/env
+      .ci/env/apt.sh tbb
+    displayName: 'tbb installation'
+  - template: .ci/pipeline/build-and-test-lnx.yml@sklearnex
+
+- job: Sklearnex_Before_PR3368_CsrBase1IndexArrays
+  displayName: 'before #3368 (base-1 CSR index arrays) @ 0447757'
+  dependsOn: LinuxMakeGNU_MKL
+  timeoutInMinutes: 0
+  variables:
+    # 04477579 = "reuse onedal utils (#3386)", 2026-08-26 06:27.
+    # Contains #3363, #3361; does not contain #3368, #3360.
+    sklearnex.commit: '04477579908aa6dde801b8986030766cecacd69f'
+    release.dir: '__release_lnx_gnu'
+    platform.type: 'lnx32e'
+    DALROOT: '$(Pipeline.Workspace)/daal/latest'
+    TBBROOT: '/opt/intel/oneapi/tbb/latest'
+    NO_DPC: 1
+    NO_DIST: 1
+  pool:
+    vmImage: '$(VM_IMAGE)'
+    maxParallel: 2
+  strategy:
+    matrix:
+      Python311:
+        PYTHON_VERSION: '$(PY_VERSION)'
+        SKLEARN_VERSION: '$(SKL_VERSION)'
+  steps:
+  - checkout: none
   - script: |
-      call %TEMP%\oneapi\setvars.bat --force
-      "$(VSDEVCMD)" -arch=amd64 -host_arch=amd64
-      "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" info output_base > output_base.txt
-      set /p OUTPUT_BASE=<output_base.txt
-      set "OUTPUT_BASE=%OUTPUT_BASE:/=\%"
-      set TEST_PATH=$(DALROOT)\redist\intel64;$(DALROOT)\lib\intel64;%OUTPUT_BASE%\external\+mkl_repo+mkl\bin;%OUTPUT_BASE%\external\+tbb_repo+tbb\bin;%PATH%
-      set PATH=%TEST_PATH%
-      "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" shutdown
-      "$(BAZELISK_EXE)" --output_user_root="$(BAZEL_OUTPUT_USER_ROOT)" test //examples/oneapi/cpp:all --config=host --test_link_mode=release_dynamic --test_thread_mode=par --test_env=DALROOT "--test_env=PATH=%TEST_PATH%" --verbose_failures --jobs=$(BAZEL_JOBS)
-    displayName: 'cpp-examples-thread-release-dynamic'
-  - powershell: |
-      $ErrorActionPreference = "Stop"
-      if (Test-Path "$(BAZEL_CACHE_DIR)\cache-clean-timestamp") {
-          Write-Host ""
-          Write-Host "Last time the cache is cleaned:"
-          Get-Content "$(BAZEL_CACHE_DIR)\cache-clean-timestamp"
-          Write-Host ""
-      }
+      set -e
+      git clone https://github.com/uxlfoundation/scikit-learn-intelex.git .
+      git checkout --detach $(sklearnex.commit)
+      git log -1 --format='sklearnex at %H%n%s%n%ci'
+    displayName: 'Clone sklearnex @ $(sklearnex.commit)'
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifact: 'oneDAL environment'
+      path: '$(Build.Repository.LocalPath)/.ci/env'
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifact: '$(platform.type) build'
+      path: $(Pipeline.Workspace)
+  - script: |
+      chmod -R 755 .ci/env
+      .ci/env/apt.sh tbb
+    displayName: 'tbb installation'
+  - template: .ci/pipeline/build-and-test-lnx.yml@sklearnex
 
-      $cacheSizeKb = 0
-      if (Test-Path "$(BAZEL_CACHE_DIR)") {
-          $cacheBytes = (Get-ChildItem "$(BAZEL_CACHE_DIR)" -Recurse -Force -ErrorAction SilentlyContinue |
-              Measure-Object -Property Length -Sum).Sum
-          if ($null -eq $cacheBytes) {
-              $cacheBytes = 0
-          }
-          $cacheSizeKb = [int64]($cacheBytes / 1KB)
-      }
-      $cacheSizeMb = [int64]($cacheSizeKb / 1KB)
-      Write-Host "Bazel cache dir is $(BAZEL_CACHE_DIR)"
-      Write-Host "Bazel cache size is ${cacheSizeMb}Mb"
-      if ($cacheSizeKb -ge [int64]"$(BAZEL_CACHE_MAX_SIZE_KB)") {
-          Write-Host "Run cache cleanup..."
-          Write-Host "Current cache directory content:"
-          Get-ChildItem "$(BAZEL_CACHE_DIR)" -Force | Select-Object -ExpandProperty Name
-          Write-Host "--------------------------------"
-          Write-Host "Remove cache directory"
-          Remove-Item "$(BAZEL_CACHE_DIR)" -Recurse -Force
-          New-Item "$(BAZEL_CACHE_DIR)" -ItemType Directory -Force | Out-Null
-          Write-Host "Write timestamp to the cache"
-          Get-Date | Out-File "$(BAZEL_CACHE_DIR)\cache-clean-timestamp"
-          Write-Host "Current cache directory content:"
-          Get-ChildItem "$(BAZEL_CACHE_DIR)" -Force | Select-Object -ExpandProperty Name
-          Write-Host "--------------------------------"
-      }
-      else {
-          Write-Host "No need for cleanup"
-      }
-    displayName: 'bazel-cache-limit'
+- job: Sklearnex_Before_PR3360_CMakeBackendReproducible
+  displayName: 'before #3360 (reproducible CMake backend build) @ 242d92c'
+  dependsOn: LinuxMakeGNU_MKL
+  timeoutInMinutes: 0
+  variables:
+    # 242d92c5 = "Update dependency polars to v1.44.1 (#3389)", 2026-08-26 17:45.
+    # Contains #3363, #3361, #3368; does not contain #3360.
+    sklearnex.commit: '242d92c5151561cb07c066f40e90e82cff738409'
+    release.dir: '__release_lnx_gnu'
+    platform.type: 'lnx32e'
+    DALROOT: '$(Pipeline.Workspace)/daal/latest'
+    TBBROOT: '/opt/intel/oneapi/tbb/latest'
+    NO_DPC: 1
+    NO_DIST: 1
+  pool:
+    vmImage: '$(VM_IMAGE)'
+    maxParallel: 2
+  strategy:
+    matrix:
+      Python311:
+        PYTHON_VERSION: '$(PY_VERSION)'
+        SKLEARN_VERSION: '$(SKL_VERSION)'
+  steps:
+  - checkout: none
+  - script: |
+      set -e
+      git clone https://github.com/uxlfoundation/scikit-learn-intelex.git .
+      git checkout --detach $(sklearnex.commit)
+      git log -1 --format='sklearnex at %H%n%s%n%ci'
+    displayName: 'Clone sklearnex @ $(sklearnex.commit)'
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifact: 'oneDAL environment'
+      path: '$(Build.Repository.LocalPath)/.ci/env'
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifact: '$(platform.type) build'
+      path: $(Pipeline.Workspace)
+  - script: |
+      chmod -R 755 .ci/env
+      .ci/env/apt.sh tbb
+    displayName: 'tbb installation'
+  - template: .ci/pipeline/build-and-test-lnx.yml@sklearnex
 
-- job: LinuxSklearnex
+- job: Sklearnex_Baseline_Main
+  displayName: 'baseline: sklearnex main (all four PRs present)'
   dependsOn: LinuxMakeGNU_MKL
   timeoutInMinutes: 0
   variables:
@@ -774,8 +313,10 @@ jobs:
   steps:
   - checkout: none
   - script: |
+      set -e
       git clone --depth 1 https://github.com/uxlfoundation/scikit-learn-intelex.git .
-    displayName: 'Clone sklearnex'
+      git log -1 --format='sklearnex at %H%n%s%n%ci'
+    displayName: 'Clone sklearnex (main)'
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: 'oneDAL environment'
@@ -789,203 +330,3 @@ jobs:
       .ci/env/apt.sh tbb
     displayName: 'tbb installation'
   - template: .ci/pipeline/build-and-test-lnx.yml@sklearnex
-  - task: PublishPipelineArtifact@1
-    inputs:
-      artifactName: '$(platform.type) sklearnex build'
-      targetPath: '$(Build.Repository.LocalPath)/build'
-
-- job: 'WindowsMakeVC'
-  timeoutInMinutes: 0
-  variables:
-    release.dir: '__release_win_vc'
-    platform.type : 'win32e'
-  pool:
-    vmImage: '$(WIN_VM_IMAGE)'
-  steps:
-  - script: .ci/scripts/install_basekit.bat $(WINDOWS_BASEKIT_URL) $(WINDOWS_DPCPP_COMPONENTS)
-    displayName: Install oneAPI Base Toolkit
-  - script: |
-      set PATH=C:\msys64\usr\bin;%PATH%
-      pip install cpufeature
-      pacman -S -y --noconfirm zip tree
-    displayName: 'pacman'
-  - script: |
-      call %TEMP%\oneapi\setvars.bat --force
-      bash .ci/scripts/describe_system.sh
-    displayName: 'System info'
-  - script: |
-      call %TEMP%\oneapi\setvars.bat --force
-      .\.ci\scripts\build.bat daal vc avx2
-    displayName: 'make daal'
-  - script: |
-      call %TEMP%\oneapi\setvars.bat --force
-      .\.ci\scripts\build.bat onedal_c vc avx2
-    displayName: 'make onedal_c'
-  - task: PublishPipelineArtifact@1
-    inputs:
-      artifactName: '$(platform.type) build'
-      targetPath: '$(Build.Repository.LocalPath)/$(release.dir)'
-    displayName: 'Upload build artifacts'
-    continueOnError: true
-  - task: PublishPipelineArtifact@1
-    inputs:
-      artifactName: 'oneDAL scripts'
-      targetPath: '$(Build.Repository.LocalPath)/.ci/scripts'
-    displayName: 'Upload environment artifacts'
-    continueOnError: true
-  - script: |
-      call %TEMP%\oneapi\setvars.bat --force
-      .\.ci\scripts\test.bat daal\cpp lib msvs cmake
-      .\.ci\scripts\test.bat daal\cpp dll msvs cmake
-    displayName: 'daal/cpp examples'
-  - script: |
-      call %TEMP%\oneapi\setvars.bat --force
-      .\.ci\scripts\test.bat oneapi\cpp lib msvs cmake
-      .\.ci\scripts\test.bat oneapi\cpp dll msvs cmake
-    displayName: 'oneapi/cpp examples'
-  - script: |
-      set PATH=C:\msys64\usr\bin;%PATH%
-      bash deploy/nuget/prepare_dal_nuget.sh --release-dir $(release.dir) --build-nupkg yes
-      tree -h -I include __nuget/inteldal*/
-      ls -lh __nuget/inteldal*.nupkg
-    displayName: 'nuget pkg'
-  - task: PublishPipelineArtifact@1
-    inputs:
-      artifactName: '$(platform.type) fail'
-      targetPath: '$(Build.Repository.LocalPath)/$(release.dir)'
-    displayName: 'Uploading on fail'
-    condition: failed()
-    continueOnError: true
-
-
-- job: 'WindowsMakeIntel'
-  timeoutInMinutes: 0
-  variables:
-    release.dir: '__release_win'
-    platform.type : 'win32e'
-  pool:
-    vmImage: '$(WIN_VM_IMAGE)'
-  steps:
-  - script: .ci/scripts/install_basekit.bat $(WINDOWS_BASEKIT_URL) $(WINDOWS_DPCPP_COMPONENTS)
-    displayName: Install oneAPI Base Toolkit
-  - script: |
-      set PATH=C:\msys64\usr\bin;%PATH%
-      pip install cpufeature
-      pacman -S -y --noconfirm zip tree
-    displayName: 'pacman'
-  - script: |
-      call %TEMP%\oneapi\setvars.bat --force
-      bash .ci/scripts/describe_system.sh
-    displayName: 'System info'
-  - script: |
-      call %TEMP%\oneapi\setvars.bat --force
-      .\.ci\scripts\build.bat daal icx avx2
-    displayName: 'make daal'
-  - script: |
-      call %TEMP%\oneapi\setvars.bat --force
-      .\.ci\scripts\build.bat onedal_dpc icx avx2
-    displayName: 'make onedal_dpc'
-  - task: PublishPipelineArtifact@1
-    inputs:
-      artifactName: '$(platform.type) icx build'
-      targetPath: '$(Build.Repository.LocalPath)/$(release.dir)'
-    displayName: 'Upload Intel build artifacts'
-    continueOnError: true
-  - script: |
-      call %TEMP%\oneapi\setvars.bat --force
-      .\.ci\scripts\test.bat daal\cpp lib icx cmake
-      .\.ci\scripts\test.bat daal\cpp dll icx cmake
-    displayName: 'daal/cpp examples'
-  - script: |
-      call %TEMP%\oneapi\setvars.bat --force
-      .\.ci\scripts\test.bat oneapi\cpp lib icx cmake
-      .\.ci\scripts\test.bat oneapi\cpp dll icx cmake
-    displayName: 'oneapi/cpp examples'
-  - script: |
-      set PATH=C:\msys64\usr\bin;%PATH%
-      bash deploy/nuget/prepare_dal_nuget.sh --release-dir $(release.dir) --build-nupkg yes
-      tree -h -I include __nuget/inteldal*/
-      ls -lh __nuget/inteldal*.nupkg
-    displayName: 'nuget pkg'
-
-- job: 'WindowsReleaseCompare'
-  dependsOn:
-  - WindowsMakeIntel
-  - WindowsBazel
-  pool:
-    vmImage: '$(WIN_VM_IMAGE)'
-  steps:
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      artifact: 'win32e icx build'
-      path: '$(Pipeline.Workspace)\make'
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      artifact: 'win32e Bazel icx build'
-      path: '$(Pipeline.Workspace)\bazel'
-  - powershell: |
-      # `read_windows_exports` shells out to dumpbin, which is not on PATH in a
-      # job that installs no toolchain. vswhere ships on every hosted image and
-      # reports the MSVC bin directory without pinning a Visual Studio version.
-      $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
-      # Collect every match first. Piping a native command into
-      # `Select-Object -First 1` closes the pipe early, which kills vswhere and
-      # leaves $LASTEXITCODE non-zero -- the Azure PowerShell task then fails the
-      # step even though the path was found. Sorting descending also picks the
-      # newest MSVC toolset instead of whichever the image lists first.
-      $found = @(& $vswhere -latest -products * `
-        -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-        -find 'VC\Tools\MSVC\*\bin\HostX64\x64\dumpbin.exe')
-      if ($LASTEXITCODE -ne 0 -or $found.Count -eq 0) {
-          Write-Error 'dumpbin.exe not found on this image'; exit 1
-      }
-      $dumpbin = ($found | Sort-Object -Descending)[0]
-      $dir = Split-Path -Parent $dumpbin
-      Write-Host "Using dumpbin from $dir"
-      Write-Host "##vso[task.prependpath]$dir"
-    displayName: 'Locate MSVC dumpbin'
-  - powershell: |
-      python dev/release_tests/compare_release_trees.py `
-        --platform windows `
-        --check-level 4 `
-        --make "$(Pipeline.Workspace)\make\daal\latest" `
-        --bazel "$(Pipeline.Workspace)\bazel"
-    displayName: 'Compare Make and Bazel release trees'
-
-
-- job: WindowsSklearnex
-  dependsOn: WindowsMakeVC
-  timeoutInMinutes: 0
-  variables:
-    release.dir: '__release_win_vc'
-    platform.type: 'win32e'
-    DALROOT: '$(Pipeline.Workspace)\daal\latest'
-    TBBROOT: '%TEMP%\oneapi\tbb\latest'
-  pool:
-    vmImage: '$(WIN_VM_IMAGE)'
-    maxParallel: 2
-  strategy:
-    matrix:
-      Python311:
-        PYTHON_VERSION: '$(PY_VERSION)'
-        SKLEARN_VERSION: '$(SKL_VERSION)'
-  steps:
-  - checkout: none
-  - script: |
-      git clone --depth 1 https://github.com/uxlfoundation/scikit-learn-intelex.git .
-    displayName: 'Clone sklearnex'
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      artifact: 'oneDAL scripts'
-      path: '$(Build.Repository.LocalPath)\.ci\env'
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      artifact: '$(platform.type) build'
-      path: $(Pipeline.Workspace)
-  - script: .ci\env\install_basekit.bat $(WINDOWS_BASEKIT_URL) $(WINDOWS_DPCPP_COMPONENTS)
-    displayName: 'TBB installation'
-  - template: .ci/pipeline/build-and-test-win.yml@sklearnex
-  - task: PublishPipelineArtifact@1
-    inputs:
-      artifactName: '$(platform.type) sklearnex build'
-      targetPath: '$(Build.Repository.LocalPath)/build'

--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -17,13 +17,8 @@
 name: "CI AArch64"
 
 on:
-  pull_request:
-    branches:
-      - main
-    # TEMPORARY (sklearnex segfault bisect branch, do not merge): see the note
-    # in .github/workflows/ci.yml.
-    paths-ignore:
-      - .ci/pipeline/ci.yml
+  # TEMPORARY (sklearnex segfault bisect branch, do not merge): `pull_request`
+  # dropped -- see the note in .github/workflows/ci.yml.
   push:
     branches:
       - main

--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -20,6 +20,10 @@ on:
   pull_request:
     branches:
       - main
+    # TEMPORARY (sklearnex segfault bisect branch, do not merge): see the note
+    # in .github/workflows/ci.yml.
+    paths-ignore:
+      - .ci/pipeline/ci.yml
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ on:
   pull_request:
     branches:
       - main
+    # TEMPORARY (sklearnex segfault bisect branch, do not merge): the debug
+    # pipeline touches only .ci/pipeline/ci.yml, so ignoring it keeps these
+    # builds from running on every bisect push.
+    paths-ignore:
+      - .ci/pipeline/ci.yml
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,9 @@
 name: CI
 
 on:
-  pull_request:
-    branches:
-      - main
-    # TEMPORARY (sklearnex segfault bisect branch, do not merge): the debug
-    # pipeline touches only .ci/pipeline/ci.yml, so ignoring it keeps these
-    # builds from running on every bisect push.
-    paths-ignore:
-      - .ci/pipeline/ci.yml
+  # TEMPORARY (sklearnex segfault bisect branch, do not merge): the
+  # `pull_request` trigger is dropped so this branch only runs the Azure
+  # sklearnex bisect jobs. Restore it before this file goes anywhere near main.
   push:
     branches:
       - main

--- a/.github/workflows/docker-validation-ci.yml
+++ b/.github/workflows/docker-validation-ci.yml
@@ -17,13 +17,8 @@
 name: docker-validation CI
 
 on:
-  pull_request:
-    branches:
-      - main
-    # TEMPORARY (sklearnex segfault bisect branch, do not merge): see the note
-    # in .github/workflows/ci.yml.
-    paths-ignore:
-      - .ci/pipeline/ci.yml
+  # TEMPORARY (sklearnex segfault bisect branch, do not merge): `pull_request`
+  # dropped -- see the note in .github/workflows/ci.yml.
   push:
     branches:
       - main

--- a/.github/workflows/docker-validation-ci.yml
+++ b/.github/workflows/docker-validation-ci.yml
@@ -20,6 +20,10 @@ on:
   pull_request:
     branches:
       - main
+    # TEMPORARY (sklearnex segfault bisect branch, do not merge): see the note
+    # in .github/workflows/ci.yml.
+    paths-ignore:
+      - .ci/pipeline/ci.yml
   push:
     branches:
       - main

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -25,25 +25,10 @@ name: Nightly-build
 on:
   schedule:
     - cron: '0 21 * * *'
-  pull_request:
-    branches:
-      - main
-    paths:
-      # running on PRs is to enable 1) no breakages in this action 2) run Nightly-test
-      - .github/workflows/nightly-build.yml
-      - .ci/pipeline/ci.yml
-      - .bazelrc
-      - MODULE.bazel
-      - BUILD
-      - makefile
-      - '.ci/env/**'
-      - '.ci/scripts/**'
-      # Bazel is included for enabling Nightly-test.yml functionality
-      - 'dev/bazel/**'
-      - 'dev/release_tests/**'
-      - 'dev/make/**'
-      - 'dev/make/compiler_definitions/**'
-      - 'dev/make/function_definitions/**'
+  # TEMPORARY (sklearnex segfault bisect branch, do not merge): the
+  # `pull_request` trigger listed .ci/pipeline/ci.yml, which this branch
+  # rewrites, so it fired on every bisect push. Dropped -- see the note in
+  # .github/workflows/ci.yml.
   workflow_dispatch:
     # use workflow dispatch to force recent changes in oneDAL for use in sklearnex.
     # That way waiting for the cron job does not occur, especially in time critical


### PR DESCRIPTION
**DO NOT MERGE / DO NOT REVIEW** — this branch exists only to run the public CI's
`LinuxSklearnex` job against historical scikit-learn-intelex commits, to find which
recent sklearnex PR introduced the recurrent segfaults.

### Where the sklearnex repo/branch is configured

Two independent places in `.ci/pipeline/ci.yml`:

1. `resources.repositories` → `repository: sklearnex`, `name: uxlfoundation/scikit-learn-intelex`,
   `ref: main` — this only supplies the **steps template** `.ci/pipeline/build-and-test-lnx.yml@sklearnex`.
2. The job's own `git clone --depth 1 https://github.com/uxlfoundation/scikit-learn-intelex.git .`
   step (the job runs with `checkout: none`) — this is what actually determines the **source** under test.

Since `build-and-test-lnx.yml` is byte-identical at `main` and at all four pinned commits,
only (2) is varied here; the resource stays at `main`.

### Jobs

Everything except `LinuxMakeGNU_MKL` (which publishes the `lnx32e build` / `oneDAL environment`
artifacts the sklearnex jobs consume) is deselected, and the heavy GitHub Actions workflows
(`CI`, `CI AArch64`, `docker-validation CI`) `paths-ignore` this file.

| job | sklearnex commit | contains |
|---|---|---|
| `Sklearnex_Before_PR3363_RegexResultOptionParser` | [`7b4847a3`](https://github.com/uxlfoundation/scikit-learn-intelex/commit/7b4847a3e938cc941b72633fe2602f00ac9b2b51) | none of the four |
| `Sklearnex_Before_PR3361_NumpyRefCounting` | [`7f38919e`](https://github.com/uxlfoundation/scikit-learn-intelex/commit/7f38919e10c2864a97129a4ea9ff7d32038117d3) | #3363 |
| `Sklearnex_Before_PR3368_CsrBase1IndexArrays` | [`04477579`](https://github.com/uxlfoundation/scikit-learn-intelex/commit/04477579908aa6dde801b8986030766cecacd69f) | #3363, #3361 |
| `Sklearnex_Before_PR3360_CMakeBackendReproducible` | [`242d92c5`](https://github.com/uxlfoundation/scikit-learn-intelex/commit/242d92c5151561cb07c066f40e90e82cff738409) | #3363, #3361, #3368 |
| `Sklearnex_Baseline_Main` | `main` | all four |

Each commit is the **first parent of that PR's squash merge**, i.e. sklearnex `main`
immediately before the PR landed. Because the four PRs landed at different times the list is
cumulative, so it doubles as a bisect ladder: the last green job indicts the PR named in the
first red job after it.

Suspect PRs, in landing order:

- 2026-08-10 uxlfoundation/scikit-learn-intelex#3363 — Replace the per-call `std::regex` result-option scan with a shared parser
- 2026-08-12 uxlfoundation/scikit-learn-intelex#3361 — Fix reference counting and buffer ownership in the NumPy/NumericTable conversions
- 2026-08-26 uxlfoundation/scikit-learn-intelex#3368 — Build the base-1 CSR index arrays without an intermediate cast array
- 2026-08-27 uxlfoundation/scikit-learn-intelex#3360 — Make the CMake backend build reproducible and its oneDAL discovery explicit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
