### PR TITLE
Ci/release parity fixes

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -15,3 +15,58 @@ The `scikit-learn-intelex` repository depends on `nightly-build.yml`. Its CI que
 Do not add steps to `nightly-build.yml`. Do not add jobs to `nightly-build.yml`. Do not rename its artifacts. Put all new test steps in `nightly-test.yml`. This includes Bazel steps, comparison steps, CVE scans, and CMake example tests.
 
 If you must rename or remove one of the artifacts above, you must also change `scikit-learn-intelex/.github/workflows/ci.yml` in the same release. Link the `scikit-learn-intelex` repository at https://github.com/uxlfoundation/scikit-learn-intelex.
+
+## Validating a `nightly-test.yml` change without waiting for a nightly
+
+`nightly-test.yml` runs on `workflow_run`, which always executes the copy of the
+workflow on `main`. A branch or PR edit to it therefore does not run, and the
+jobs it gates on need a finished `Nightly-build` first (Linux ~1h, Windows ~3h).
+
+Do not rebuild the Make release to test a change to the comparison. The Make side
+is just an artifact: reuse the `__release_lnx` / `__release_win` (and, for
+Windows, `intel_oneapi_basekit`) artifacts of any recent successful
+`Nightly-build` via `actions/download-artifact` with an explicit `run-id`, and
+pay only for the Bazel release and the comparison step. Two consequences:
+
+- A `push`-triggered run does not inherit the `actions: read` permission that a
+  `workflow_run` run gets implicitly. Request it explicitly or the cross-run
+  download fails.
+- Artifacts live in `uxlfoundation/oneDAL`, so a fork run has to pin
+  `repository:` to upstream. It needs no extra secret to read them: upstream is
+  public, and `github.token` plus `actions: read` suffices (verified from
+  `Alexandr-Solovev/oneDAL` with no secrets configured).
+
+The alternative, documented in the header of `nightly-test.yml` itself, is to
+dispatch that workflow with a `source_run_id`; use it when the change must be
+exercised through the real job definitions rather than a trimmed copy.
+
+## `.gitignore` swallows workflow files named `bazel-*`
+
+`.gitignore` carries a bare `bazel-*` rule for Bazel's convenience symlinks
+(`bazel-bin`, `bazel-out`). It is not anchored to the repository root, so it also
+matches, for example, `.github/workflows/bazel-release-parity-check.yml`, and
+`git add` reports nothing while the file stays untracked. Name workflow files so
+they do not start with `bazel-`.
+
+## Make-vs-Bazel release parity: known toolchain divergences
+
+`dev/release_tests/compare_release_trees.py` compares the two release trees, and
+some differences it reports are properties of how the trees are built or
+transported rather than build bugs. Before treating a new one as a regression,
+check it is not one of these shapes; when it is, extend the script's documented
+ignore lists rather than changing the build:
+
+- **Windows exports.** The Make release is built with `vc` (cl) and the Bazel one
+  with icx (clang-cl). They disagree about compiler-generated entities: class
+  template special members, instantiations naming lambdas, and constructors a
+  `dllexport` class inherits with `using Base::Base;` — cl exports all of them,
+  clang-cl only those the DLL odr-uses. None can be part of a consumer's link
+  surface, because `ONEDAL_EXPORT` expands to `__declspec(dllexport)` only under
+  `__ONEDAL_ENABLE_EXPORT__`, which is set solely while oneDAL itself is built.
+- **Linux symlinks.** Both trees stage a real `libonedal_core.so.<major>.<minor>`
+  plus `.so.<major>` and `.so` aliases (`makefile:975`, `dev/bazel/release.bzl`).
+  `actions/upload-artifact` follows symlinks and uploads their contents, so the
+  aliases arrive as regular files on whichever side travelled as an artifact.
+
+Out-of-line definitions are the useful signal and stay compared, so a library
+that genuinely stopped being linked still fails the comparison.

--- a/.github/workflows/release-parity-check.yml
+++ b/.github/workflows/release-parity-check.yml
@@ -1,0 +1,150 @@
+#===============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+name: Bazel release parity check
+
+# [DO NOT MERGE] Temporary, minimal stand-in for the two `Nightly-test` jobs
+# that run `dev/release_tests/compare_release_trees.py`, kept on a branch to
+# iterate on that script without waiting for a full nightly.
+#
+# Nightly-test needs a Nightly-build to finish first (Linux ~1h, Windows ~3h)
+# and then reaches the comparison through `workflow_run`, which always uses the
+# copy of the workflow on `main`. This workflow instead reuses the
+# `__release_lnx` / `__release_win` artifacts an existing Nightly-build already
+# produced, so only the Bazel release and the comparison itself are paid for,
+# and it runs straight off a `push` to the branch.
+#
+# Everything not needed to reach the comparison is gone: the CVE scan job, the
+# Check Run bookkeeping, `describe_system`, and the CMake example smoke test.
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: "Nightly-build run ID whose __release_* artifacts to compare against"
+        required: false
+        type: string
+  push:
+    branches:
+      - 'ci/release-parity**'
+
+permissions:
+  contents: read
+  # Reading artifacts from a different workflow run needs this; the nightly gets
+  # it implicitly from its `workflow_run` trigger, a `push` run does not.
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  # Nightly-build 33128609183 (schedule, 2026-08-28) built 3547b791b, which is
+  # `main` HEAD. Its artifacts are the Make side of the comparison; override with
+  # the `source_run_id` input once they expire.
+  DEFAULT_SOURCE_RUN_ID: '33128609183'
+  # The Make release artifacts live in the upstream repository, and reading them
+  # needs a token scoped to it, so this workflow only works when run there.
+  ARTIFACT_REPOSITORY: 'uxlfoundation/oneDAL'
+
+jobs:
+  parity_lnx:
+    name: Bazel release parity (Linux)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout oneDAL
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Download Make Linux release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: __release_lnx
+          github-token: ${{ github.token }}
+          repository: ${{ env.ARTIFACT_REPOSITORY }}
+          run-id: ${{ inputs.source_run_id || env.DEFAULT_SOURCE_RUN_ID }}
+          path: ./__release_lnx
+      - name: Install toolchain
+        run: |
+          .ci/env/apt.sh dpcpp
+          .ci/env/apt.sh mkl
+          .ci/env/bazelisk.sh
+      - name: Bazel release
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          bazel build //:release --config=release-dpc --cpu=avx2
+      - name: Compare make and Bazel releases
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          python dev/release_tests/compare_release_trees.py \
+            --platform linux \
+            --make ./__release_lnx/daal/latest \
+            --bazel ./bazel-bin/release/daal/latest \
+            --check-level 4
+
+  parity_win:
+    name: Bazel release parity (Windows)
+    runs-on: windows-2025
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout oneDAL
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Download Make Windows release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: __release_win
+          github-token: ${{ github.token }}
+          repository: ${{ env.ARTIFACT_REPOSITORY }}
+          run-id: ${{ inputs.source_run_id || env.DEFAULT_SOURCE_RUN_ID }}
+          path: ./__release_win_vc
+      - name: Download Intel BaseKit artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: intel_oneapi_basekit
+          github-token: ${{ github.token }}
+          repository: ${{ env.ARTIFACT_REPOSITORY }}
+          run-id: ${{ inputs.source_run_id || env.DEFAULT_SOURCE_RUN_ID }}
+      - name: Decompress Intel BaseKit
+        shell: cmd
+        run: |
+          tar -xvzf oneapi.tar.gz
+          echo "Unzip complete"
+      - name: Install Bazelisk
+        shell: pwsh
+        run: .\.ci\env\bazelisk.ps1
+      - name: Bazel release
+        shell: cmd
+        env:
+          BAZEL_SH: 'C:\Program Files\Git\bin\bash.exe'
+        run: |
+          if not exist "%BAZEL_SH%" (
+            echo ERROR: Required Bazel shell not found: %BAZEL_SH%
+            exit /b 1
+          )
+          set PATH=C:\msys64\usr\bin;%PATH%
+          call .\oneapi\setvars.bat
+          call "%ONEAPI_ROOT%\setvars-vcvarsall.bat" %VS_VER%
+          bazel build //:release --config=release-dpc --cpu=avx2
+      - name: Compare make and Bazel releases
+        shell: cmd
+        run: |
+          call .\oneapi\setvars.bat
+          call "%ONEAPI_ROOT%\setvars-vcvarsall.bat" %VS_VER%
+          powershell -NoProfile -ExecutionPolicy Bypass -File .\.ci\scripts\compare_windows_release.ps1 ^
+            -MakeReleaseDir .\__release_win_vc\daal\latest ^
+            -BazelReleaseDir .\bazel-bin\release\daal\latest ^
+            -CheckLevel 4

--- a/.github/workflows/release-parity-check.yml
+++ b/.github/workflows/release-parity-check.yml
@@ -56,8 +56,9 @@ env:
   # `main` HEAD. Its artifacts are the Make side of the comparison; override with
   # the `source_run_id` input once they expire.
   DEFAULT_SOURCE_RUN_ID: '33128609183'
-  # The Make release artifacts live in the upstream repository, and reading them
-  # needs a token scoped to it, so this workflow only works when run there.
+  # The Make release artifacts live in the upstream repository. Upstream is
+  # public, so `github.token` reaches them from a fork too, given the
+  # `actions: read` permission above; no extra secret is needed.
   ARTIFACT_REPOSITORY: 'uxlfoundation/oneDAL'
 
 jobs:

--- a/dev/release_tests/compare_release_trees.py
+++ b/dev/release_tests/compare_release_trees.py
@@ -238,8 +238,64 @@ WINDOWS_IGNORED_EXPORTS = frozenset([
 ])
 
 
+# Constructors the oneDAL exception classes inherit with `using Base::Base;`
+# (cpp/oneapi/dal/exceptions.hpp, cpp/oneapi/dal/spmd/exceptions.hpp). cl emits
+# and exports every inheriting constructor of a `__declspec(dllexport)` class;
+# clang-cl -- and therefore the icx the Bazel Windows build uses -- only emits
+# the ones the DLL itself odr-uses. The Make release is built with `vc`, so all
+# 26 of them show up as Make-only exports of onedal.4.dll.
+#
+# The list is exactly the inheriting constructors and nothing else: two per
+# class (`const char*` and `const std::string&`) for the nine single-argument
+# exceptions, and six for `system_error`, whose base adds the `error_code` and
+# `int` + `error_category` overloads. `error_holder` in the same header declares
+# its constructor explicitly and is exported by both toolchains, which is the
+# control showing this is about inheriting constructors specifically.
+#
+# None of them is part of a consumer's link surface. `ONEDAL_EXPORT` expands to
+# `__declspec(dllexport)` only under `__ONEDAL_ENABLE_EXPORT__`, which is defined
+# solely while oneDAL itself is built (cpp/oneapi/dal/common.hpp:35-53); a
+# consumer sees a plain class, so `throw invalid_argument{...}` instantiates the
+# inheriting constructor in the consumer's own object file and never emits an
+# import the DLL would have to satisfy. The `what()` and `code()` overrides
+# *are* out-of-line in exceptions.cpp, are exported by both toolchains, and stay
+# compared -- which is what keeps this entry from hiding a real regression: if
+# exceptions.cpp ever stopped being linked into onedal.4.dll, those would go
+# missing too and the comparison would still fail.
+WINDOWS_IGNORED_INHERITED_EXCEPTION_CTORS = frozenset([
+    "??0communication_error@v1@spmd@preview@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0communication_error@v1@spmd@preview@dal@oneapi@@QEAA@PEBD@Z",
+    "??0coworker_error@v1@spmd@preview@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0coworker_error@v1@spmd@preview@dal@oneapi@@QEAA@PEBD@Z",
+    "??0domain_error@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0domain_error@v1@dal@oneapi@@QEAA@PEBD@Z",
+    "??0internal_error@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0internal_error@v1@dal@oneapi@@QEAA@PEBD@Z",
+    "??0invalid_argument@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0invalid_argument@v1@dal@oneapi@@QEAA@PEBD@Z",
+    "??0out_of_range@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0out_of_range@v1@dal@oneapi@@QEAA@PEBD@Z",
+    "??0range_error@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0range_error@v1@dal@oneapi@@QEAA@PEBD@Z",
+    "??0system_error@v1@dal@oneapi@@QEAA@HAEBVerror_category@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z",
+    "??0system_error@v1@dal@oneapi@@QEAA@HAEBVerror_category@std@@PEBD@Z",
+    "??0system_error@v1@dal@oneapi@@QEAA@HAEBVerror_category@std@@@Z",
+    "??0system_error@v1@dal@oneapi@@QEAA@Verror_code@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z",
+    "??0system_error@v1@dal@oneapi@@QEAA@Verror_code@std@@PEBD@Z",
+    "??0system_error@v1@dal@oneapi@@QEAA@Verror_code@std@@@Z",
+    "??0unimplemented@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0unimplemented@v1@dal@oneapi@@QEAA@PEBD@Z",
+    "??0uninitialized_optional_result@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0uninitialized_optional_result@v1@dal@oneapi@@QEAA@PEBD@Z",
+    "??0unsupported_device@v1@dal@oneapi@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z",
+    "??0unsupported_device@v1@dal@oneapi@@QEAA@PEBD@Z",
+])
+
+
 def is_ignored_windows_export(symbol):
     if symbol in WINDOWS_IGNORED_EXPORTS:
+        return True
+    if symbol in WINDOWS_IGNORED_INHERITED_EXCEPTION_CTORS:
         return True
     return any(pattern.match(symbol) for pattern in WINDOWS_IGNORED_EXPORT_PATTERNS)
 
@@ -330,6 +386,55 @@ def compare_sets(name, make_values, bazel_values, limit):
         for item in only_bazel[:limit]:
             print(f"  + {item}")
     return errors
+
+
+def reconcile_dereferenced_symlinks(make_root, bazel_root, make_files,
+                                    bazel_links, limit):
+    """Account for Make-side symlinks that artifact transport turned into copies.
+
+    `makefile:975` stages each Linux shared object as a real
+    `libonedal_core.so.<major>.<minor>` plus two `ln -sf` aliases, and
+    `dev/bazel/release.bzl:321-331` builds the same chain out of
+    `ctx.actions.declare_symlink`. The two trees therefore agree -- but the Make
+    one reaches this job through `actions/upload-artifact`, which follows
+    symlinks and uploads their contents, so all three names arrive as regular
+    files. Comparing entry kinds then reports every alias twice, once as a
+    Make-only file and once as a Bazel-only symlink.
+
+    Only the Make side is transported, so only that direction is reconciled: a
+    path that is a regular file for Make and a symlink for Bazel. Each one has to
+    be a genuine copy of what the Bazel symlink resolves to, otherwise it stays
+    an error. Reconciled aliases are dropped from both sides because the target
+    they resolve to is a regular file on both and is compared on its own.
+
+    Returns the reconciled paths. An alias whose contents do not match is only
+    explained here and left in place, so the entry-kind comparison below counts
+    it exactly as it did before this reconciliation existed.
+    """
+    reconciled = set()
+    mismatched = []
+    for path in sorted(set(bazel_links).intersection(make_files)):
+        resolved = (bazel_root / path).resolve()
+        try:
+            same = resolved.is_file() and filecmp.cmp(
+                make_root / path, resolved, shallow=False)
+        except OSError:
+            same = False
+        if same:
+            reconciled.add(path)
+        else:
+            mismatched.append(path)
+
+    if mismatched:
+        print(f"Dereferenced symlink content mismatches: {len(mismatched)}")
+        for path in mismatched[:limit]:
+            print(f"  ! {path}: Make file differs from Bazel symlink target "
+                  f"-> {os.readlink(bazel_root / path)}")
+    if reconciled:
+        print(f"Reconciled dereferenced symlinks: {len(reconciled)}")
+        for path in sorted(reconciled)[:limit]:
+            print(f"  = {path} -> {os.readlink(bazel_root / path)}")
+    return reconciled
 
 
 def compare_link_targets(make_links, bazel_links, limit):
@@ -599,6 +704,11 @@ def main():
     errors = 0
     print("")
     print("=== level 1: release tree entries ===")
+    reconciled = reconcile_dereferenced_symlinks(
+        make_root, bazel_root, make_files, bazel_links, args.summary_limit)
+    make_files -= reconciled
+    bazel_links = {path: target for path, target in bazel_links.items()
+                   if path not in reconciled}
     errors += compare_sets("directories", make_dirs, bazel_dirs, args.summary_limit)
     errors += compare_sets("files", make_files, bazel_files, args.summary_limit)
     errors += compare_sets("symlinks", set(make_links), set(bazel_links), args.summary_limit)


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
