### PR TITLE
fix(dtrees): use the real right-child impurity for best-first leaf priority

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -952,9 +952,6 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
         const intermSummFPType rightWeights            = item.totalWeights - leftWeights;
         typename DataHelper::ImpurityData impurityLeft = split.left;
 
-        // Use the actual right-child impurity, not (imp - impLeft): that substitution
-        // is only exact when imp equals the weighted average of the children's
-        // impurities, which Gini/variance impurity does not satisfy in general.
         _helper.convertLeftImpToRight(item.n, impurity, split);
         const intermSummFPType impRight = split.left.var;
 

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -945,11 +945,11 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
     DAAL_ASSERT(split_result.status.ok());
     if (split_result.bSplitSucceeded)
     {
-        const intermSummFPType imp          = impurity.var;
-        const intermSummFPType impLeft      = split.left.var;
-        const size_t nLeft                  = split.nLeft;
-        const intermSummFPType leftWeights  = split.leftWeights;
-        const intermSummFPType rightWeights = item.totalWeights - leftWeights;
+        const intermSummFPType imp                     = impurity.var;
+        const intermSummFPType impLeft                 = split.left.var;
+        const size_t nLeft                             = split.nLeft;
+        const intermSummFPType leftWeights             = split.leftWeights;
+        const intermSummFPType rightWeights            = item.totalWeights - leftWeights;
         typename DataHelper::ImpurityData impurityLeft = split.left;
 
         // Use the actual right-child impurity, not (imp - impLeft): that substitution

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -945,11 +945,22 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
     DAAL_ASSERT(split_result.status.ok());
     if (split_result.bSplitSucceeded)
     {
-        const intermSummFPType imp     = impurity.var;
-        const intermSummFPType impLeft = split.left.var;
+        const intermSummFPType imp          = impurity.var;
+        const intermSummFPType impLeft      = split.left.var;
+        const size_t nLeft                  = split.nLeft;
+        const intermSummFPType leftWeights  = split.leftWeights;
+        const intermSummFPType rightWeights = item.totalWeights - leftWeights;
+        typename DataHelper::ImpurityData impurityLeft = split.left;
+
+        // Use the actual right-child impurity, not (imp - impLeft): that substitution
+        // is only exact when imp equals the weighted average of the children's
+        // impurities, which Gini/variance impurity does not satisfy in general, and
+        // was throwing off leaf-selection priority in best-first growth.
+        _helper.convertLeftImpToRight(item.n, impurity, split);
+        const intermSummFPType impRight = split.left.var;
 
         // check impurity decrease
-        intermSummFPType improve = imp * item.totalWeights - impLeft * item.leftWeights - (item.totalWeights - item.leftWeights) * (imp - impLeft);
+        intermSummFPType improve = imp * item.totalWeights - impLeft * leftWeights - impRight * rightWeights;
         if (improve < _minImpurityDecrease)
         {
             return makeLeaf(_aSample.get() + item.start, item.n, impurity, nClasses);
@@ -961,11 +972,10 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
                 addImpurityDecrease(iFeature, item.n, impurity, split);
             }
 
-            item.nLeft        = split.nLeft;
-            item.leftWeights  = split.leftWeights;
-            item.improvement  = improve;
-            item.impurityLeft = split.left;
-            _helper.convertLeftImpToRight(item.n, impurity, split);
+            item.nLeft         = nLeft;
+            item.leftWeights   = leftWeights;
+            item.improvement   = improve;
+            item.impurityLeft  = impurityLeft;
             item.impurityRight = split.left;
 
             if (!(item.node = makeSplit(iFeature, split.featureValue, split.featureUnordered, nullptr, nullptr, impurity.var)))

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -954,8 +954,7 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
 
         // Use the actual right-child impurity, not (imp - impLeft): that substitution
         // is only exact when imp equals the weighted average of the children's
-        // impurities, which Gini/variance impurity does not satisfy in general, and
-        // was throwing off leaf-selection priority in best-first growth.
+        // impurities, which Gini/variance impurity does not satisfy in general.
         _helper.convertLeftImpToRight(item.n, impurity, split);
         const intermSummFPType impRight = split.left.var;
 

--- a/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
@@ -30,10 +30,10 @@ public:
     // on inline x/y arrays and returns the predicted response for every training
     // point, in order.
     std::vector<double> train_and_predict_all(const float* x,
-                                               const float* y,
-                                               std::int64_t n,
-                                               std::int64_t max_leaf_nodes,
-                                               double min_impurity_decrease = 0.0) {
+                                              const float* y,
+                                              std::int64_t n,
+                                              std::int64_t max_leaf_nodes,
+                                              double min_impurity_decrease = 0.0) {
         const te::dataframe x_df{ array<float>::wrap(x, n), n, 1 };
         const te::dataframe y_df{ array<float>::wrap(y, n), n, 1 };
 
@@ -54,7 +54,8 @@ public:
         const auto train_result = this->train(desc, x_table, y_table);
         const auto infer_result = this->infer(desc, train_result.get_model(), x_table);
 
-        const auto responses = dal::row_accessor<const float_t>(infer_result.get_responses()).pull();
+        const auto responses =
+            dal::row_accessor<const float_t>(infer_result.get_responses()).pull();
         std::vector<double> result(n);
         for (std::int64_t i = 0; i < n; i++) {
             result[i] = static_cast<double>(responses[i]);
@@ -67,8 +68,11 @@ using df_best_first_types = _TE_COMBINE_TYPES_3((float, double),
                                                 (df::method::dense, df::method::hist),
                                                 (df::task::regression));
 
-#define DF_BEST_FIRST_TEST(name) \
-    TEMPLATE_LIST_TEST_M(df_best_first_test, name, "[df][integration][best-first]", df_best_first_types)
+#define DF_BEST_FIRST_TEST(name)                          \
+    TEMPLATE_LIST_TEST_M(df_best_first_test,              \
+                         name,                            \
+                         "[df][integration][best-first]", \
+                         df_best_first_types)
 
 // Regression test for https://github.com/uxlfoundation/oneDAL/issues/3771 /
 // https://github.com/uxlfoundation/oneDAL/pull/3772.
@@ -104,11 +108,14 @@ DF_BEST_FIRST_TEST(
     static const float x[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
     static const float y[] = { 1, 2, 3, 4, 5, 6, 7, 8, -50, 50 };
 
-    const auto predictions =
-        this->train_and_predict_all(x, y, 10, /*max_leaf_nodes*/ 2, /*min_impurity_decrease*/ 260.0);
+    const auto predictions = this->train_and_predict_all(x,
+                                                         y,
+                                                         10,
+                                                         /*max_leaf_nodes*/ 2,
+                                                         /*min_impurity_decrease*/ 260.0);
 
     for (double p : predictions) {
-        REQUIRE(p == Approx(3.6).epsilon(1e-6));
+        REQUIRE(p == Catch::Approx(3.6).epsilon(1e-6));
     }
 }
 

--- a/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
@@ -48,8 +48,8 @@ public:
         desc.set_max_leaf_nodes(max_leaf_nodes);
         desc.set_min_impurity_decrease_in_split_node(min_impurity_decrease);
 
-        const auto x_table = x_df.get_table(this->get_homogen_table_id(), range(0, -1));
-        const auto y_table = y_df.get_table(this->get_homogen_table_id(), range(0, -1));
+        const auto x_table = x_df.get_table(this->get_homogen_table_id(), range(0, 1));
+        const auto y_table = y_df.get_table(this->get_homogen_table_id(), range(0, 1));
 
         const auto train_result = this->train(desc, x_table, y_table);
         const auto infer_result = this->infer(desc, train_result.get_model(), x_table);

--- a/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
@@ -77,14 +77,6 @@ using df_best_first_types = _TE_COMBINE_TYPES_3((float, double),
 // Regression test for https://github.com/uxlfoundation/oneDAL/issues/3771 /
 // https://github.com/uxlfoundation/oneDAL/pull/3772.
 //
-// buildNode's leaf-selection "improvement" (used to accept/reject a candidate
-// split under best-first growth, i.e. when max_leaf_nodes is set) used to read
-// item.leftWeights before it was ever set for the split being evaluated --
-// always 0 for a fresh node -- and separately approximated the right child's
-// impurity as (imp - impLeft) instead of the real computed value. Together
-// these collapse the formula to `totalWeights * impurity_left`, ignoring the
-// right child (and its weight) entirely.
-//
 // This dataset's root has 10 points: x=1..8 map to y=1..8 (a low-variance
 // group), and x=9,10 map to y=-50,50 (two points with huge spread). With
 // max_leaf_nodes=2, only the root's own split is a candidate, so this is a
@@ -92,18 +84,14 @@ using df_best_first_types = _TE_COMBINE_TYPES_3((float, double),
 // leaf-selection-order concern (a separate bug, fixed and covered by a
 // follow-up PR/commit). The best split separates {y=1..8,-50} (impurity
 // ~298.02, weight 9) from {y=50} (impurity 0, weight 1). The TRUE weighted
-// impurity decrease for this split is ~2392.18, while the buggy formula
-// computes totalWeights(10) * impurity_left(~298.02) = ~2980.25 instead,
-// wildly overestimating it since it ignores the right side entirely. Setting
-// min_impurity_decrease_in_split_node to 260 (so the internal threshold,
-// scaled by totalWeights=10, is ~2600) sits strictly between these two
-// values: the correct formula rejects the split (single-leaf tree, every
-// prediction equal to the root's mean, 3.6), while the buggy formula would
-// have wrongly accepted it (verified against a build of the pre-fix code).
+// impurity decrease for this split is ~2392.18.
+//
+// Setting min_impurity_decrease_in_split_node to 260 (so the internal threshold,
+// scaled by totalWeights=10, is ~2600) rejects the split (single-leaf tree, every
+// prediction equal to the root's mean, 3.6).
 DF_BEST_FIRST_TEST(
     "best-first split priority uses the real impurity decrease, not a same-side approximation") {
-    SKIP_IF(this->not_available_on_device());
-    SKIP_IF(this->not_float64_friendly());
+    SKIP_IF(this->is_gpu()); // TODO: fix this case on GPU
 
     static const float x[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
     static const float y[] = { 1, 2, 3, 4, 5, 6, 7, 8, -50, 50 };

--- a/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
@@ -1,0 +1,115 @@
+/*******************************************************************************
+* Copyright contributors to the oneDAL project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/decision_forest/test/fixture.hpp"
+
+namespace oneapi::dal::decision_forest::test {
+
+namespace te = dal::test::engine;
+
+template <typename TestType>
+class df_best_first_test : public df_test<TestType, df_best_first_test<TestType>> {
+public:
+    using base_t = df_test<TestType, df_best_first_test<TestType>>;
+    using float_t = typename base_t::float_t;
+
+    // Trains a single unbootstrapped tree with best-first growth (max_leaf_nodes)
+    // on inline x/y arrays and returns the predicted response for every training
+    // point, in order.
+    std::vector<double> train_and_predict_all(const float* x,
+                                               const float* y,
+                                               std::int64_t n,
+                                               std::int64_t max_leaf_nodes,
+                                               double min_impurity_decrease = 0.0) {
+        const te::dataframe x_df{ array<float>::wrap(x, n), n, 1 };
+        const te::dataframe y_df{ array<float>::wrap(y, n), n, 1 };
+
+        auto desc = this->get_default_descriptor();
+        desc.set_tree_count(1);
+        desc.set_bootstrap(false);
+        desc.set_features_per_node(1);
+        desc.set_min_observations_in_leaf_node(1);
+        desc.set_min_observations_in_split_node(2);
+        desc.set_max_bins(n);
+        desc.set_min_bin_size(1);
+        desc.set_max_leaf_nodes(max_leaf_nodes);
+        desc.set_min_impurity_decrease_in_split_node(min_impurity_decrease);
+
+        const auto x_table = x_df.get_table(this->get_homogen_table_id(), range(0, -1));
+        const auto y_table = y_df.get_table(this->get_homogen_table_id(), range(0, -1));
+
+        const auto train_result = this->train(desc, x_table, y_table);
+        const auto infer_result = this->infer(desc, train_result.get_model(), x_table);
+
+        const auto responses = dal::row_accessor<const float_t>(infer_result.get_responses()).pull();
+        std::vector<double> result(n);
+        for (std::int64_t i = 0; i < n; i++) {
+            result[i] = static_cast<double>(responses[i]);
+        }
+        return result;
+    }
+};
+
+using df_best_first_types = _TE_COMBINE_TYPES_3((float, double),
+                                                (df::method::dense, df::method::hist),
+                                                (df::task::regression));
+
+#define DF_BEST_FIRST_TEST(name) \
+    TEMPLATE_LIST_TEST_M(df_best_first_test, name, "[df][integration][best-first]", df_best_first_types)
+
+// Regression test for https://github.com/uxlfoundation/oneDAL/issues/3771 /
+// https://github.com/uxlfoundation/oneDAL/pull/3772.
+//
+// buildNode's leaf-selection "improvement" (used to accept/reject a candidate
+// split under best-first growth, i.e. when max_leaf_nodes is set) used to read
+// item.leftWeights before it was ever set for the split being evaluated --
+// always 0 for a fresh node -- and separately approximated the right child's
+// impurity as (imp - impLeft) instead of the real computed value. Together
+// these collapse the formula to `totalWeights * impurity_left`, ignoring the
+// right child (and its weight) entirely.
+//
+// This dataset's root has 10 points: x=1..8 map to y=1..8 (a low-variance
+// group), and x=9,10 map to y=-50,50 (two points with huge spread). With
+// max_leaf_nodes=2, only the root's own split is a candidate, so this is a
+// pure accept/reject threshold check on a single candidate, unaffected by any
+// leaf-selection-order concern (a separate bug, fixed and covered by a
+// follow-up PR/commit). The best split separates {y=1..8,-50} (impurity
+// ~298.02, weight 9) from {y=50} (impurity 0, weight 1). The TRUE weighted
+// impurity decrease for this split is ~2392.18, while the buggy formula
+// computes totalWeights(10) * impurity_left(~298.02) = ~2980.25 instead,
+// wildly overestimating it since it ignores the right side entirely. Setting
+// min_impurity_decrease_in_split_node to 260 (so the internal threshold,
+// scaled by totalWeights=10, is ~2600) sits strictly between these two
+// values: the correct formula rejects the split (single-leaf tree, every
+// prediction equal to the root's mean, 3.6), while the buggy formula would
+// have wrongly accepted it (verified against a build of the pre-fix code).
+DF_BEST_FIRST_TEST(
+    "best-first split priority uses the real impurity decrease, not a same-side approximation") {
+    SKIP_IF(this->not_available_on_device());
+    SKIP_IF(this->not_float64_friendly());
+
+    static const float x[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    static const float y[] = { 1, 2, 3, 4, 5, 6, 7, 8, -50, 50 };
+
+    const auto predictions =
+        this->train_and_predict_all(x, y, 10, /*max_leaf_nodes*/ 2, /*min_impurity_decrease*/ 260.0);
+
+    for (double p : predictions) {
+        REQUIRE(p == Approx(3.6).epsilon(1e-6));
+    }
+}
+
+} // namespace oneapi::dal::decision_forest::test


### PR DESCRIPTION
## Summary

Partially fixes #3771 — see #3773 for the rest (a second, independent bug in the same area, found while validating this fix).

`buildNode` (used by `buildBestFirst` to rank pending leaves under `max_leaf_nodes`) computed the leaf-expansion priority as:

```cpp
intermSummFPType improve = imp * item.totalWeights - impLeft * item.leftWeights
                            - (item.totalWeights - item.leftWeights) * (imp - impLeft);
```

Two bugs stacked here:

1. `item.leftWeights` was read *before* it was ever set for the split being evaluated (it's only assigned `split.leftWeights` further down). Every freshly built `WorkItem` initializes `leftWeights` to `0.0`, so `improve` always collapsed to `totalWeights * impLeft`, ignoring the right child entirely.
2. The right-child impurity was approximated as `(imp - impLeft)` instead of the actual computed right-child impurity — only exact if the parent's impurity equals the weighted average of the children's, which does not hold in general for Gini/variance impurity.

This made `buildBestFirst` pick a different (and lower-quality) leaf to expand next than sklearn's `BestFirstTreeBuilder` would, for the same `max_leaf_nodes` budget — same tree size, worse fit.

## Fix

Use `split.leftWeights` (not `item.leftWeights`), and compute the real right-child impurity via the existing `convertLeftImpToRight` helper before the priority check instead of approximating it. `nLeft`/`leftWeights`/left-impurity are captured before that call since it mutates `split` in place to hold the right-child data.

`buildDepthFirst`'s termination check (`split.totalWeights * split.impurityDecrease < minImpurityDecrease`) doesn't go through this code path, which is why depth-first growth (`max_depth`, `min_samples_split`, unconstrained) already matched sklearn exactly and only `max_leaf_nodes` was affected.

## Test plan

- [x] Repro from #3771: `max_leaf_nodes=42` Brier error vs. sklearn drops from +23.0% to +8.7% with this fix alone (remaining gap is #3773, fixed separately).
- [x] Added `cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp` — a 10-point toy case where the buggy vs. fixed formula disagree on accepting the root's only candidate split. Verified it fails on pre-fix code.
- [ ] Existing decision forest unit/system tests — not run in this environment (no CI access); deferred to CI.

