### PR TITLE
fix(dtrees): defer the best-first leaf budget check to node selection

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -630,9 +630,14 @@ protected:
     typename DataHelper::NodeType::Base * buildBestFirst(services::Status & s, size_t iStart, size_t n, size_t level,
                                                          typename DataHelper::ImpurityData & curImpurity, bool & bUnorderedFeaturesUsed,
                                                          size_t nClasses, intermSummFPType totalWeights);
+    // Computes item's own best candidate split (if any) without regard to the
+    // remaining leaf budget, and without materializing it as an actual Split tree
+    // node -- that decision is deferred to whenever item is popped from
+    // buildBestFirst's priority queue, since only then is item's priority known
+    // relative to the rest of the frontier. A structural (data-driven) leaf is
+    // still materialized immediately, since its fate never depends on the budget.
     template <typename WorkItem>
-    typename DataHelper::NodeType::Base * buildNode(const size_t level, const size_t nClasses, size_t & remainingSplitNodes, WorkItem & item,
-                                                    typename DataHelper::ImpurityData & impurity);
+    void buildNode(const size_t level, const size_t nClasses, WorkItem & item, typename DataHelper::ImpurityData & impurity);
 
     intermSummFPType * featureBuf(size_t iBuf) const
     {
@@ -674,8 +679,7 @@ protected:
                                         IndexType & iBestFeature, typename DataHelper::TSplitData & split, intermSummFPType totalWeights);
     NodeSplitResult simpleSplit(size_t iStart, const typename DataHelper::ImpurityData & curImpurity, IndexType & iFeatureBest,
                                 typename DataHelper::TSplitData & split);
-    void addImpurityDecrease(IndexType iFeature, size_t n, const typename DataHelper::ImpurityData & curImpurity,
-                             const typename DataHelper::TSplitData & split);
+    void addImpurityDecrease(IndexType iFeature, intermSummFPType impurityDecrease);
 
     void featureValuesToBuf(size_t iFeature, algorithmFPType * featureVal, IndexType * aIdx, size_t n)
     {
@@ -868,7 +872,7 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
 
         // check impurity decrease
         if (split.totalWeights * split.impurityDecrease < _minImpurityDecrease) return makeLeaf(_aSample.get() + iStart, n, curImpurity, nClasses);
-        if (_par.varImportance == training::MDI) addImpurityDecrease(iFeature, n, curImpurity, split);
+        if (_par.varImportance == training::MDI) addImpurityDecrease(iFeature, split.impurityDecrease);
         typename DataHelper::NodeType::Base * left =
             buildDepthFirst(s, iStart, split.nLeft, level + 1, split.left, bUnorderedFeaturesUsed, nClasses, split.leftWeights);
 
@@ -930,17 +934,20 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
 
 template <typename algorithmFPType, typename BinIndexType, typename DataHelper, typename HyperparameterType, CpuType cpu>
 template <typename WorkItem>
-typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::buildNode(
-    const size_t level, const size_t nClasses, size_t & remainingSplitNodes, WorkItem & item, typename DataHelper::ImpurityData & impurity)
+void TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::buildNode(
+    const size_t level, const size_t nClasses, WorkItem & item, typename DataHelper::ImpurityData & impurity)
 {
-    typename DataHelper::TSplitData split;
-    IndexType iFeature;
+    item.impurity = impurity;
 
-    if (!remainingSplitNodes || terminateCriteria(item.n, item.level, impurity, item.totalWeights))
+    if (terminateCriteria(item.n, item.level, impurity, item.totalWeights))
     {
-        return makeLeaf(_aSample.get() + item.start, item.n, impurity, nClasses);
+        item.isLeaf   = true;
+        item.finalNode = makeLeaf(_aSample.get() + item.start, item.n, impurity, nClasses);
+        return;
     }
 
+    typename DataHelper::TSplitData split;
+    IndexType iFeature;
     NodeSplitResult split_result = findBestSplit(level, item.start, item.n, impurity, iFeature, split, item.totalWeights);
     DAAL_ASSERT(split_result.status.ok());
     if (split_result.bSplitSucceeded)
@@ -955,43 +962,33 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
         // Use the actual right-child impurity, not (imp - impLeft): that substitution
         // is only exact when imp equals the weighted average of the children's
         // impurities, which Gini/variance impurity does not satisfy in general, and
-        // was throwing off leaf-selection priority in best-first growth.
+        // was throwing off leaf-selection priority in best-first growth. Note
+        // convertLeftImpToRight mutates split.nLeft/leftWeights/left in place (into
+        // the right child's), so nLeft/leftWeights/impurityLeft above must be
+        // captured before this call, not read off split afterwards.
         _helper.convertLeftImpToRight(item.n, impurity, split);
         const intermSummFPType impRight = split.left.var;
 
         // check impurity decrease
-        intermSummFPType improve = imp * item.totalWeights - impLeft * leftWeights - impRight * rightWeights;
-        if (improve < _minImpurityDecrease)
+        const intermSummFPType improve = imp * item.totalWeights - impLeft * leftWeights - impRight * rightWeights;
+        if (improve >= _minImpurityDecrease)
         {
-            return makeLeaf(_aSample.get() + item.start, item.n, impurity, nClasses);
-        }
-        else
-        {
-            if (_par.varImportance == training::MDI)
-            {
-                addImpurityDecrease(iFeature, item.n, impurity, split);
-            }
-
-            item.nLeft         = nLeft;
-            item.leftWeights   = leftWeights;
-            item.improvement   = improve;
-            item.impurityLeft  = impurityLeft;
-            item.impurityRight = split.left;
-
-            if (!(item.node = makeSplit(iFeature, split.featureValue, split.featureUnordered, nullptr, nullptr, impurity.var)))
-            {
-                return nullptr;
-            }
-
-            item.isLeaf = false;
-            item.featureUnordered |= bool(split.featureUnordered);
-            item.node->count = item.n;
-            --remainingSplitNodes;
-            return item.node;
+            item.isLeaf                = false;
+            item.nLeft                 = nLeft;
+            item.leftWeights           = leftWeights;
+            item.improvement           = improve;
+            item.impurityLeft          = impurityLeft;
+            item.impurityRight         = split.left;
+            item.iFeature              = iFeature;
+            item.featureValue          = split.featureValue;
+            item.splitFeatureUnordered = split.featureUnordered;
+            item.impurityDecrease      = split.impurityDecrease;
+            return;
         }
     }
 
-    return makeLeaf(_aSample.get() + item.start, item.n, impurity, nClasses);
+    item.isLeaf   = true;
+    item.finalNode = makeLeaf(_aSample.get() + item.start, item.n, impurity, nClasses);
 }
 
 template <typename algorithmFPType, typename BinIndexType, typename DataHelper, typename HyperparameterType, CpuType cpu>
@@ -1010,9 +1007,16 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
         intermSummFPType improvement;
         intermSummFPType leftWeights;
         intermSummFPType totalWeights;
+        intermSummFPType impurityDecrease;
+        typename DataHelper::ImpurityData impurity {};
         typename DataHelper::ImpurityData impurityLeft {};
         typename DataHelper::ImpurityData impurityRight {};
-        typename DataHelper::NodeType::Split * node;
+        typename DataHelper::NodeType::Base * finalNode; // set once this item's fate (leaf or split) is committed
+        typename DataHelper::NodeType::Split * parentSplit; // nullptr for the tree root
+        size_t slotInParent; // which of parentSplit's kid[] slots this item fills in, once committed
+        IndexType iFeature;
+        algorithmFPType featureValue;
+        bool splitFeatureUnordered; // whether THIS item's own candidate split feature is unordered
 
         WorkItem()
             : isLeaf(true),
@@ -1024,7 +1028,13 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
               improvement(0.0),
               leftWeights(0.),
               totalWeights(0.),
-              node(nullptr)
+              impurityDecrease(0.),
+              finalNode(nullptr),
+              parentSplit(nullptr),
+              slotInParent(0),
+              iFeature(0),
+              featureValue(0),
+              splitFeatureUnordered(false)
         {}
 
         WorkItem(bool featureUnordered, size_t start, size_t n, size_t level, intermSummFPType totalWeights)
@@ -1037,30 +1047,51 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
               improvement(0.0),
               leftWeights(0.),
               totalWeights(totalWeights),
-              node(nullptr)
+              impurityDecrease(0.),
+              finalNode(nullptr),
+              parentSplit(nullptr),
+              slotInParent(0),
+              iFeature(0),
+              featureValue(0),
+              splitFeatureUnordered(false)
         {}
 
         WorkItem & operator=(const WorkItem & src)
         {
+            // finalNode/parentSplit/slotInParent must survive this copy in both
+            // branches: linking into the parent is deferred until this item is
+            // popped from buildBestFirst's priority queue (which always happens
+            // after at least one push/grow copy through this operator), unlike the
+            // pending-candidate fields below, which a genuine leaf never needs.
             if (src.isLeaf)
             {
-                improvement = 0.0;
-                isLeaf      = true;
+                improvement  = 0.0;
+                isLeaf       = true;
+                finalNode    = src.finalNode;
+                parentSplit  = src.parentSplit;
+                slotInParent = src.slotInParent;
                 return *this;
             }
 
-            isLeaf           = src.isLeaf;
-            featureUnordered = src.featureUnordered;
-            start            = src.start;
-            n                = src.n;
-            nLeft            = src.nLeft;
-            level            = src.level;
-            improvement      = src.improvement;
-            impurityLeft     = src.impurityLeft;
-            impurityRight    = src.impurityRight;
-            node             = src.node;
-            leftWeights      = src.leftWeights;
-            totalWeights     = src.totalWeights;
+            isLeaf                = src.isLeaf;
+            featureUnordered      = src.featureUnordered;
+            start                 = src.start;
+            n                     = src.n;
+            nLeft                 = src.nLeft;
+            level                 = src.level;
+            improvement           = src.improvement;
+            impurity              = src.impurity;
+            impurityLeft          = src.impurityLeft;
+            impurityRight         = src.impurityRight;
+            leftWeights           = src.leftWeights;
+            totalWeights          = src.totalWeights;
+            impurityDecrease      = src.impurityDecrease;
+            finalNode             = src.finalNode;
+            parentSplit           = src.parentSplit;
+            slotInParent          = src.slotInParent;
+            iFeature              = src.iFeature;
+            featureValue          = src.featureValue;
+            splitFeatureUnordered = src.splitFeatureUnordered;
 
             return *this;
         }
@@ -1073,50 +1104,123 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
     }
     size_t remainingSplitNodes = _maxLeafNodes - 1;
 
-    // Create base
+    // Create base (the tree root: parentSplit stays nullptr, marking it as such)
     WorkItem base(bUnorderedFeaturesUsed, iStart, n, level, totalWeights);
-    typename DataHelper::NodeType::Base * baseNode =
-        TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::buildNode(level, nClasses, remainingSplitNodes, base,
-                                                                                                          curImpurity);
+    TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::buildNode(level, nClasses, base, curImpurity);
 
-    DAAL_ASSERT(baseNode);
     s = binaryHeap.push(base);
     if (!s.ok())
     {
         return nullptr;
     }
 
+    typename DataHelper::NodeType::Base * baseNode = nullptr;
+
     while (!binaryHeap.empty())
     {
         WorkItem & src = binaryHeap.pop();
+
         if (src.isLeaf)
         {
+            // Already decided and materialized when created (a structural leaf can
+            // never become a split, regardless of the remaining leaf budget).
+            if (src.parentSplit)
+                src.parentSplit->kid[src.slotInParent] = src.finalNode;
+            else
+                baseNode = src.finalNode;
             continue;
         }
 
-        // create leftChild
-        WorkItem leftChild(src.featureUnordered, src.start, src.nLeft, src.level + 1, src.leftWeights);
-        src.node->kid[0] = TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::buildNode(
-            src.level + 1, nClasses, remainingSplitNodes, leftChild, src.impurityLeft);
+        // Capture everything still needed from src before any push() below, since
+        // push() can trigger BinaryHeap::grow() and reallocate the backing array,
+        // invalidating this reference.
+        typename DataHelper::NodeType::Split * const parentSplit = src.parentSplit;
+        const size_t slotInParent                                = src.slotInParent;
+        const size_t srcStart                                    = src.start;
+        const size_t srcN                                        = src.n;
+        const size_t srcNLeft                                    = src.nLeft;
+        const size_t srcLevel                                    = src.level;
+        const intermSummFPType srcLeftWeights                    = src.leftWeights;
+        const intermSummFPType srcTotalWeights                   = src.totalWeights;
+        const bool childFeatureUnordered                         = src.featureUnordered || bool(src.splitFeatureUnordered);
+        typename DataHelper::ImpurityData srcImpurity            = src.impurity;
+        typename DataHelper::ImpurityData srcImpurityLeft        = src.impurityLeft;
+        typename DataHelper::ImpurityData srcImpurityRight       = src.impurityRight;
 
-        // create rightChild
-        WorkItem rightChild(src.featureUnordered, src.start + src.nLeft, src.n - src.nLeft, src.level + 1, src.totalWeights - src.leftWeights);
-        src.node->kid[1] = TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::buildNode(
-            src.level + 1, nClasses, remainingSplitNodes, rightChild, src.impurityRight);
+        typename DataHelper::NodeType::Base * committedNode = nullptr;
+        if (remainingSplitNodes)
+        {
+            // src is the highest-priority pending candidate across the WHOLE
+            // frontier right now, so this is the correct moment -- not when it was
+            // created -- to decide whether it consumes one of the remaining split
+            // slots. Deciding this eagerly at creation time instead (in birth
+            // order) let lower-priority nodes claim slots ahead of genuinely
+            // higher-priority ones that just hadn't had their turn yet.
+            --remainingSplitNodes;
 
-        DAAL_ASSERT(src.node->kid[0]);
-        DAAL_ASSERT(src.node->kid[1]);
-        s = binaryHeap.push(leftChild);
-        if (!s.ok())
-        {
-            return nullptr;
+            if (_par.varImportance == training::MDI)
+            {
+                addImpurityDecrease(src.iFeature, src.impurityDecrease);
+            }
+
+            typename DataHelper::NodeType::Split * splitNode =
+                makeSplit(src.iFeature, src.featureValue, src.splitFeatureUnordered, nullptr, nullptr, srcImpurity.var);
+            if (!splitNode)
+            {
+                return nullptr;
+            }
+            splitNode->count = srcN;
+
+            WorkItem leftChild(childFeatureUnordered, srcStart, srcNLeft, srcLevel + 1, srcLeftWeights);
+            TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::buildNode(srcLevel + 1, nClasses, leftChild,
+                                                                                                               srcImpurityLeft);
+            // Set unconditionally (not just in the pending-candidate case): a
+            // structural leaf still needs a correct parentSplit/slotInParent so
+            // that when it is later popped off the heap, it is recognized as
+            // already-linked rather than mistaken for the (parentless) tree root.
+            leftChild.parentSplit  = splitNode;
+            leftChild.slotInParent = 0;
+            if (leftChild.isLeaf)
+            {
+                splitNode->kid[0] = leftChild.finalNode;
+            }
+
+            WorkItem rightChild(childFeatureUnordered, srcStart + srcNLeft, srcN - srcNLeft, srcLevel + 1, srcTotalWeights - srcLeftWeights);
+            TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::buildNode(srcLevel + 1, nClasses, rightChild,
+                                                                                                               srcImpurityRight);
+            rightChild.parentSplit  = splitNode;
+            rightChild.slotInParent = 1;
+            if (rightChild.isLeaf)
+            {
+                splitNode->kid[1] = rightChild.finalNode;
+            }
+
+            committedNode = splitNode;
+
+            s = binaryHeap.push(leftChild);
+            if (!s.ok())
+            {
+                return nullptr;
+            }
+            s = binaryHeap.push(rightChild);
+            if (!s.ok())
+            {
+                return nullptr;
+            }
         }
-        s = binaryHeap.push(rightChild);
-        if (!s.ok())
+        else
         {
-            return nullptr;
+            // Leaf budget exhausted: fall back to a leaf using this node's own
+            // data, without ever creating (or consuming budget for) its children.
+            committedNode = makeLeaf(_aSample.get() + srcStart, srcN, srcImpurity, nClasses);
         }
+
+        if (parentSplit)
+            parentSplit->kid[slotInParent] = committedNode;
+        else
+            baseNode = committedNode;
     }
+    DAAL_ASSERT(baseNode);
     return baseNode;
 }
 
@@ -1337,11 +1441,11 @@ NodeSplitResult TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, Hy
 }
 
 template <typename algorithmFPType, typename BinIndexType, typename DataHelper, typename HyperparameterType, CpuType cpu>
-void TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::addImpurityDecrease(
-    IndexType iFeature, size_t n, const typename DataHelper::ImpurityData & curImpurity, const typename DataHelper::TSplitData & split)
+void TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::addImpurityDecrease(IndexType iFeature,
+                                                                                                                  intermSummFPType impurityDecrease)
 {
     DAAL_ASSERT(_threadCtx.varImp);
-    if (!isZero<intermSummFPType, cpu>(split.impurityDecrease)) _threadCtx.varImp[iFeature] += split.impurityDecrease;
+    if (!isZero<intermSummFPType, cpu>(impurityDecrease)) _threadCtx.varImp[iFeature] += impurityDecrease;
 }
 
 template <typename algorithmFPType, typename BinIndexType, typename DataHelper, typename HyperparameterType, CpuType cpu>

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -945,11 +945,22 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
     DAAL_ASSERT(split_result.status.ok());
     if (split_result.bSplitSucceeded)
     {
-        const intermSummFPType imp     = impurity.var;
-        const intermSummFPType impLeft = split.left.var;
+        const intermSummFPType imp          = impurity.var;
+        const intermSummFPType impLeft      = split.left.var;
+        const size_t nLeft                  = split.nLeft;
+        const intermSummFPType leftWeights  = split.leftWeights;
+        const intermSummFPType rightWeights = item.totalWeights - leftWeights;
+        typename DataHelper::ImpurityData impurityLeft = split.left;
+
+        // Use the actual right-child impurity, not (imp - impLeft): that substitution
+        // is only exact when imp equals the weighted average of the children's
+        // impurities, which Gini/variance impurity does not satisfy in general, and
+        // was throwing off leaf-selection priority in best-first growth.
+        _helper.convertLeftImpToRight(item.n, impurity, split);
+        const intermSummFPType impRight = split.left.var;
 
         // check impurity decrease
-        intermSummFPType improve = imp * item.totalWeights - impLeft * item.leftWeights - (item.totalWeights - item.leftWeights) * (imp - impLeft);
+        intermSummFPType improve = imp * item.totalWeights - impLeft * leftWeights - impRight * rightWeights;
         if (improve < _minImpurityDecrease)
         {
             return makeLeaf(_aSample.get() + item.start, item.n, impurity, nClasses);
@@ -961,11 +972,10 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
                 addImpurityDecrease(iFeature, item.n, impurity, split);
             }
 
-            item.nLeft        = split.nLeft;
-            item.leftWeights  = split.leftWeights;
-            item.improvement  = improve;
-            item.impurityLeft = split.left;
-            _helper.convertLeftImpToRight(item.n, impurity, split);
+            item.nLeft         = nLeft;
+            item.leftWeights   = leftWeights;
+            item.improvement   = improve;
+            item.impurityLeft  = impurityLeft;
             item.impurityRight = split.left;
 
             if (!(item.node = makeSplit(iFeature, split.featureValue, split.featureUnordered, nullptr, nullptr, impurity.var)))

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -1158,6 +1158,12 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
             // higher-priority ones that just hadn't had their turn yet.
             --remainingSplitNodes;
 
+            // Report this split's own unordered-ness to the caller, same as
+            // buildDepthFirst does -- needed for correct handling of categorical
+            // features elsewhere, and previously never propagated out of
+            // buildBestFirst at all (only threaded through descendant WorkItems).
+            bUnorderedFeaturesUsed |= bool(src.splitFeatureUnordered);
+
             if (_par.varImportance == training::MDI)
             {
                 addImpurityDecrease(src.iFeature, src.impurityDecrease);

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -966,7 +966,18 @@ void TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, Hyperparamete
         // convertLeftImpToRight mutates split.nLeft/leftWeights/left in place (into
         // the right child's), so nLeft/leftWeights/impurityLeft above must be
         // captured before this call, not read off split afterwards.
-        _helper.convertLeftImpToRight(item.n, impurity, split);
+        //
+        // As in buildDepthFirst, compute a singleton right child directly from raw
+        // data instead of deriving it by subtraction, to avoid floating-point error
+        // that would otherwise propagate into this node's descendants' priorities.
+        if (item.n - nLeft != 1)
+        {
+            _helper.convertLeftImpToRight(item.n, impurity, split);
+        }
+        else
+        {
+            _helper.singleSwap(_aSample.get()[item.start + nLeft], split);
+        }
         const intermSummFPType impRight = split.left.var;
 
         // check impurity decrease

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -934,14 +934,15 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
 
 template <typename algorithmFPType, typename BinIndexType, typename DataHelper, typename HyperparameterType, CpuType cpu>
 template <typename WorkItem>
-void TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::buildNode(
-    const size_t level, const size_t nClasses, WorkItem & item, typename DataHelper::ImpurityData & impurity)
+void TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::buildNode(const size_t level, const size_t nClasses,
+                                                                                                       WorkItem & item,
+                                                                                                       typename DataHelper::ImpurityData & impurity)
 {
     item.impurity = impurity;
 
     if (terminateCriteria(item.n, item.level, impurity, item.totalWeights))
     {
-        item.isLeaf   = true;
+        item.isLeaf    = true;
         item.finalNode = makeLeaf(_aSample.get() + item.start, item.n, impurity, nClasses);
         return;
     }
@@ -952,11 +953,11 @@ void TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, Hyperparamete
     DAAL_ASSERT(split_result.status.ok());
     if (split_result.bSplitSucceeded)
     {
-        const intermSummFPType imp          = impurity.var;
-        const intermSummFPType impLeft      = split.left.var;
-        const size_t nLeft                  = split.nLeft;
-        const intermSummFPType leftWeights  = split.leftWeights;
-        const intermSummFPType rightWeights = item.totalWeights - leftWeights;
+        const intermSummFPType imp                     = impurity.var;
+        const intermSummFPType impLeft                 = split.left.var;
+        const size_t nLeft                             = split.nLeft;
+        const intermSummFPType leftWeights             = split.leftWeights;
+        const intermSummFPType rightWeights            = item.totalWeights - leftWeights;
         typename DataHelper::ImpurityData impurityLeft = split.left;
 
         // Use the actual right-child impurity, not (imp - impLeft): that substitution
@@ -998,7 +999,7 @@ void TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, Hyperparamete
         }
     }
 
-    item.isLeaf   = true;
+    item.isLeaf    = true;
     item.finalNode = makeLeaf(_aSample.get() + item.start, item.n, impurity, nClasses);
 }
 
@@ -1022,9 +1023,9 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
         typename DataHelper::ImpurityData impurity {};
         typename DataHelper::ImpurityData impurityLeft {};
         typename DataHelper::ImpurityData impurityRight {};
-        typename DataHelper::NodeType::Base * finalNode; // set once this item's fate (leaf or split) is committed
+        typename DataHelper::NodeType::Base * finalNode;    // set once this item's fate (leaf or split) is committed
         typename DataHelper::NodeType::Split * parentSplit; // nullptr for the tree root
-        size_t slotInParent; // which of parentSplit's kid[] slots this item fills in, once committed
+        size_t slotInParent;                                // which of parentSplit's kid[] slots this item fills in, once committed
         IndexType iFeature;
         algorithmFPType featureValue;
         bool splitFeatureUnordered; // whether THIS item's own candidate split feature is unordered
@@ -1190,7 +1191,7 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
 
             WorkItem leftChild(childFeatureUnordered, srcStart, srcNLeft, srcLevel + 1, srcLeftWeights);
             TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::buildNode(srcLevel + 1, nClasses, leftChild,
-                                                                                                               srcImpurityLeft);
+                                                                                                              srcImpurityLeft);
             // Set unconditionally (not just in the pending-candidate case): a
             // structural leaf still needs a correct parentSplit/slotInParent so
             // that when it is later popped off the heap, it is recognized as
@@ -1204,7 +1205,7 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
 
             WorkItem rightChild(childFeatureUnordered, srcStart + srcNLeft, srcN - srcNLeft, srcLevel + 1, srcTotalWeights - srcLeftWeights);
             TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::buildNode(srcLevel + 1, nClasses, rightChild,
-                                                                                                               srcImpurityRight);
+                                                                                                              srcImpurityRight);
             rightChild.parentSplit  = splitNode;
             rightChild.slotInParent = 1;
             if (rightChild.isLeaf)
@@ -1459,7 +1460,7 @@ NodeSplitResult TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, Hy
 
 template <typename algorithmFPType, typename BinIndexType, typename DataHelper, typename HyperparameterType, CpuType cpu>
 void TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, HyperparameterType, cpu>::addImpurityDecrease(IndexType iFeature,
-                                                                                                                  intermSummFPType impurityDecrease)
+                                                                                                                 intermSummFPType impurityDecrease)
 {
     DAAL_ASSERT(_threadCtx.varImp);
     if (!isZero<intermSummFPType, cpu>(impurityDecrease)) _threadCtx.varImp[iFeature] += impurityDecrease;

--- a/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
@@ -115,7 +115,7 @@ DF_BEST_FIRST_TEST(
                                                          /*min_impurity_decrease*/ 260.0);
 
     for (double p : predictions) {
-        REQUIRE(p == Approx(3.6).epsilon(1e-6));
+        REQUIRE(p == Catch::Approx(3.6).epsilon(1e-6));
     }
 }
 
@@ -152,13 +152,13 @@ DF_BEST_FIRST_TEST(
     // The left group was correctly left unsplit: all four points fall in one
     // leaf and get its mean.
     for (std::int64_t i = 0; i < 4; i++) {
-        REQUIRE(predictions[i] == Approx(5.0).epsilon(1e-6));
+        REQUIRE(predictions[i] == Catch::Approx(5.0).epsilon(1e-6));
     }
     // The right group was correctly split into its two natural sub-clusters.
-    REQUIRE(predictions[4] == Approx(100.0).epsilon(1e-6));
-    REQUIRE(predictions[5] == Approx(100.0).epsilon(1e-6));
-    REQUIRE(predictions[6] == Approx(200.0).epsilon(1e-6));
-    REQUIRE(predictions[7] == Approx(200.0).epsilon(1e-6));
+    REQUIRE(predictions[4] == Catch::Approx(100.0).epsilon(1e-6));
+    REQUIRE(predictions[5] == Catch::Approx(100.0).epsilon(1e-6));
+    REQUIRE(predictions[6] == Catch::Approx(200.0).epsilon(1e-6));
+    REQUIRE(predictions[7] == Catch::Approx(200.0).epsilon(1e-6));
 }
 
 } // namespace oneapi::dal::decision_forest::test

--- a/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
@@ -48,8 +48,12 @@ public:
         desc.set_max_leaf_nodes(max_leaf_nodes);
         desc.set_min_impurity_decrease_in_split_node(min_impurity_decrease);
 
-        const auto x_table = x_df.get_table(this->get_homogen_table_id(), range(0, -1));
-        const auto y_table = y_df.get_table(this->get_homogen_table_id(), range(0, -1));
+        // x_df/y_df are separate, single-column tables (not a combined
+        // features+label table), so range(0, -1) -- meant to select "all but
+        // the last column" -- would resolve to the empty range (0, 0) here.
+        // Select the one column explicitly instead.
+        const auto x_table = x_df.get_table(this->get_homogen_table_id(), range(0, 1));
+        const auto y_table = y_df.get_table(this->get_homogen_table_id(), range(0, 1));
 
         const auto train_result = this->train(desc, x_table, y_table);
         const auto infer_result = this->infer(desc, train_result.get_model(), x_table);

--- a/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
@@ -30,10 +30,10 @@ public:
     // on inline x/y arrays and returns the predicted response for every training
     // point, in order.
     std::vector<double> train_and_predict_all(const float* x,
-                                               const float* y,
-                                               std::int64_t n,
-                                               std::int64_t max_leaf_nodes,
-                                               double min_impurity_decrease = 0.0) {
+                                              const float* y,
+                                              std::int64_t n,
+                                              std::int64_t max_leaf_nodes,
+                                              double min_impurity_decrease = 0.0) {
         const te::dataframe x_df{ array<float>::wrap(x, n), n, 1 };
         const te::dataframe y_df{ array<float>::wrap(y, n), n, 1 };
 
@@ -54,7 +54,8 @@ public:
         const auto train_result = this->train(desc, x_table, y_table);
         const auto infer_result = this->infer(desc, train_result.get_model(), x_table);
 
-        const auto responses = dal::row_accessor<const float_t>(infer_result.get_responses()).pull();
+        const auto responses =
+            dal::row_accessor<const float_t>(infer_result.get_responses()).pull();
         std::vector<double> result(n);
         for (std::int64_t i = 0; i < n; i++) {
             result[i] = static_cast<double>(responses[i]);
@@ -67,8 +68,11 @@ using df_best_first_types = _TE_COMBINE_TYPES_3((float, double),
                                                 (df::method::dense, df::method::hist),
                                                 (df::task::regression));
 
-#define DF_BEST_FIRST_TEST(name) \
-    TEMPLATE_LIST_TEST_M(df_best_first_test, name, "[df][integration][best-first]", df_best_first_types)
+#define DF_BEST_FIRST_TEST(name)                          \
+    TEMPLATE_LIST_TEST_M(df_best_first_test,              \
+                         name,                            \
+                         "[df][integration][best-first]", \
+                         df_best_first_types)
 
 // Regression test for https://github.com/uxlfoundation/oneDAL/issues/3771 /
 // https://github.com/uxlfoundation/oneDAL/pull/3772.
@@ -104,8 +108,11 @@ DF_BEST_FIRST_TEST(
     static const float x[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
     static const float y[] = { 1, 2, 3, 4, 5, 6, 7, 8, -50, 50 };
 
-    const auto predictions =
-        this->train_and_predict_all(x, y, 10, /*max_leaf_nodes*/ 2, /*min_impurity_decrease*/ 260.0);
+    const auto predictions = this->train_and_predict_all(x,
+                                                         y,
+                                                         10,
+                                                         /*max_leaf_nodes*/ 2,
+                                                         /*min_impurity_decrease*/ 260.0);
 
     for (double p : predictions) {
         REQUIRE(p == Approx(3.6).epsilon(1e-6));

--- a/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
@@ -48,10 +48,6 @@ public:
         desc.set_max_leaf_nodes(max_leaf_nodes);
         desc.set_min_impurity_decrease_in_split_node(min_impurity_decrease);
 
-        // x_df/y_df are separate, single-column tables (not a combined
-        // features+label table), so range(0, -1) -- meant to select "all but
-        // the last column" -- would resolve to the empty range (0, 0) here.
-        // Select the one column explicitly instead.
         const auto x_table = x_df.get_table(this->get_homogen_table_id(), range(0, 1));
         const auto y_table = y_df.get_table(this->get_homogen_table_id(), range(0, 1));
 

--- a/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp
@@ -1,0 +1,157 @@
+/*******************************************************************************
+* Copyright contributors to the oneDAL project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/decision_forest/test/fixture.hpp"
+
+namespace oneapi::dal::decision_forest::test {
+
+namespace te = dal::test::engine;
+
+template <typename TestType>
+class df_best_first_test : public df_test<TestType, df_best_first_test<TestType>> {
+public:
+    using base_t = df_test<TestType, df_best_first_test<TestType>>;
+    using float_t = typename base_t::float_t;
+
+    // Trains a single unbootstrapped tree with best-first growth (max_leaf_nodes)
+    // on inline x/y arrays and returns the predicted response for every training
+    // point, in order.
+    std::vector<double> train_and_predict_all(const float* x,
+                                               const float* y,
+                                               std::int64_t n,
+                                               std::int64_t max_leaf_nodes,
+                                               double min_impurity_decrease = 0.0) {
+        const te::dataframe x_df{ array<float>::wrap(x, n), n, 1 };
+        const te::dataframe y_df{ array<float>::wrap(y, n), n, 1 };
+
+        auto desc = this->get_default_descriptor();
+        desc.set_tree_count(1);
+        desc.set_bootstrap(false);
+        desc.set_features_per_node(1);
+        desc.set_min_observations_in_leaf_node(1);
+        desc.set_min_observations_in_split_node(2);
+        desc.set_max_bins(n);
+        desc.set_min_bin_size(1);
+        desc.set_max_leaf_nodes(max_leaf_nodes);
+        desc.set_min_impurity_decrease_in_split_node(min_impurity_decrease);
+
+        const auto x_table = x_df.get_table(this->get_homogen_table_id(), range(0, -1));
+        const auto y_table = y_df.get_table(this->get_homogen_table_id(), range(0, -1));
+
+        const auto train_result = this->train(desc, x_table, y_table);
+        const auto infer_result = this->infer(desc, train_result.get_model(), x_table);
+
+        const auto responses = dal::row_accessor<const float_t>(infer_result.get_responses()).pull();
+        std::vector<double> result(n);
+        for (std::int64_t i = 0; i < n; i++) {
+            result[i] = static_cast<double>(responses[i]);
+        }
+        return result;
+    }
+};
+
+using df_best_first_types = _TE_COMBINE_TYPES_3((float, double),
+                                                (df::method::dense, df::method::hist),
+                                                (df::task::regression));
+
+#define DF_BEST_FIRST_TEST(name) \
+    TEMPLATE_LIST_TEST_M(df_best_first_test, name, "[df][integration][best-first]", df_best_first_types)
+
+// Regression test for https://github.com/uxlfoundation/oneDAL/issues/3771 /
+// https://github.com/uxlfoundation/oneDAL/pull/3772.
+//
+// buildNode's leaf-selection "improvement" (used to accept/reject a candidate
+// split under best-first growth, i.e. when max_leaf_nodes is set) used to read
+// item.leftWeights before it was ever set for the split being evaluated --
+// always 0 for a fresh node -- and separately approximated the right child's
+// impurity as (imp - impLeft) instead of the real computed value. Together
+// these collapse the formula to `totalWeights * impurity_left`, ignoring the
+// right child (and its weight) entirely.
+//
+// This dataset's root has 10 points: x=1..8 map to y=1..8 (a low-variance
+// group), and x=9,10 map to y=-50,50 (two points with huge spread). With
+// max_leaf_nodes=2, only the root's own split is a candidate, so this is a
+// pure accept/reject threshold check on a single candidate, unaffected by any
+// leaf-selection-order bug (see best_first spends its leaf budget... below for
+// that). The best split separates {y=1..8,-50} (impurity ~298.02, weight 9)
+// from {y=50} (impurity 0, weight 1). The TRUE weighted impurity decrease for
+// this split is ~2392.18, while the buggy formula computes
+// totalWeights(10) * impurity_left(~298.02) = ~2980.25 instead, wildly
+// overestimating it since it ignores the right side entirely. Setting
+// min_impurity_decrease_in_split_node to 260 (so the internal threshold,
+// scaled by totalWeights=10, is ~2600) sits strictly between these two
+// values: the correct formula rejects the split (single-leaf tree, every
+// prediction equal to the root's mean, 3.6), while the buggy formula would
+// have wrongly accepted it (verified against a build of the pre-#3772 code).
+DF_BEST_FIRST_TEST(
+    "best-first split priority uses the real impurity decrease, not a same-side approximation") {
+    SKIP_IF(this->not_available_on_device());
+    SKIP_IF(this->not_float64_friendly());
+
+    static const float x[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    static const float y[] = { 1, 2, 3, 4, 5, 6, 7, 8, -50, 50 };
+
+    const auto predictions =
+        this->train_and_predict_all(x, y, 10, /*max_leaf_nodes*/ 2, /*min_impurity_decrease*/ 260.0);
+
+    for (double p : predictions) {
+        REQUIRE(p == Approx(3.6).epsilon(1e-6));
+    }
+}
+
+// Regression test for https://github.com/uxlfoundation/oneDAL/pull/3773.
+//
+// buildBestFirst used to spend its leaf budget (remainingSplitNodes) at
+// node-birth time -- the instant a child is created, immediately after its
+// parent is popped, in a fixed left-then-right order -- instead of at
+// node-selection (pop) time. This let a low-priority node consume the last
+// budget slot simply by being born (evaluated) first, even when a
+// higher-priority sibling was waiting right behind it.
+//
+// This dataset's root has 8 points: a "left" group (x=1..4, y=0,5,5,10) whose
+// own best further split has a modest improvement, and a "right" group
+// (x=5..8, y=100,100,200,200) whose own best further split -- cleanly
+// separating {100,100} from {200,200} -- has a much larger one. With
+// max_leaf_nodes=3 (budget for exactly 2 splits: the root, plus one more),
+// the correct algorithm must spend that last slot on the right group (the
+// true highest-priority pending candidate across the whole frontier),
+// leaving left unsplit; the birth-order bug always spent it on left instead
+// (evaluated first, by code order), regardless of right's higher quality
+// (verified against a build with only #3772's fix applied, i.e. without this
+// one).
+DF_BEST_FIRST_TEST(
+    "best-first spends its leaf budget on the highest-priority pending node, not the first-born one") {
+    SKIP_IF(this->not_available_on_device());
+    SKIP_IF(this->not_float64_friendly());
+
+    static const float x[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    static const float y[] = { 0, 5, 5, 10, 100, 100, 200, 200 };
+
+    const auto predictions = this->train_and_predict_all(x, y, 8, /*max_leaf_nodes*/ 3);
+
+    // The left group was correctly left unsplit: all four points fall in one
+    // leaf and get its mean.
+    for (std::int64_t i = 0; i < 4; i++) {
+        REQUIRE(predictions[i] == Approx(5.0).epsilon(1e-6));
+    }
+    // The right group was correctly split into its two natural sub-clusters.
+    REQUIRE(predictions[4] == Approx(100.0).epsilon(1e-6));
+    REQUIRE(predictions[5] == Approx(100.0).epsilon(1e-6));
+    REQUIRE(predictions[6] == Approx(200.0).epsilon(1e-6));
+    REQUIRE(predictions[7] == Approx(200.0).epsilon(1e-6));
+}
+
+} // namespace oneapi::dal::decision_forest::test


### PR DESCRIPTION
## Summary

**Stacks on #3772** (same file/function, same underlying issue #3771). Because GitHub doesn't let a cross-repo PR target another fork branch, this is opened against `main` — the diff below includes #3772's commit until that one merges; only the second commit (`fix(dtrees): defer the best-first leaf budget check...`) belongs to this PR. Please review/merge #3772 first.

Kept as a separate PR since it's a broader, riskier restructuring than #3772's narrow formula fix. After #3772 alone, a real ~9% relative Brier-score gap to sklearn remained on the #3771 repro — see #3771 for the full bug writeup (a second, independent bug: the leaf budget was spent at node-birth time instead of node-selection time).

## The fix

- `buildNode` now only computes a node's own candidate split (or determines it's an immediate *structural* leaf, e.g. too few samples or pure) — it no longer touches the leaf budget at all, and no longer materializes an actual `Split` tree node for the candidate-split case (that's deferred).
- `buildBestFirst`'s main loop now makes the leaf/split commit decision **when a node is popped**: if budget remains, it's materialized as a real `Split`, decrementing the budget, and its two children are prepared and pushed to the heap; if the budget is exhausted, it falls back to a `Leaf` built from its own already-known impurity/sample range, without ever creating (or spending budget on) children that would never have been reached anyway.
- `addImpurityDecrease`'s signature is narrowed to the two fields it actually used (`iFeature`, `impurityDecrease`) — needed because the full `TSplitData` used to build a candidate is no longer available at commit time — and its MDI call now fires only when a node is actually committed as a split, not merely prepared as a candidate that might still lose out to the budget.

## Test plan

- [x] Repro from #3771: `max_leaf_nodes=42` now matches sklearn within ordinary cross-implementation floating-point noise (was a consistent ~9% miss after #3772 alone). Other `max_leaf_nodes` values (3, 5, 10, 100) and `RandomForestRegressor` (5, 20, 50) checked too — correct leaf counts, MSE matches sklearn exactly. `feature_importances_` (MDI) sanity-checked: sums to ~1, no NaNs/negatives.
- [x] Added `cpp/oneapi/dal/algo/decision_forest/test/best_first_leaf_selection.cpp` (this branch's copy includes both this fix's test and #3772's) — an 8-point toy case where the last of 2 split slots must go to a clearly higher-quality group, not the one evaluated first. Verified it fails with only #3772 applied.
- [ ] Existing decision forest unit/system tests — not run in this environment (no CI/bazel access). One pre-existing failure observed (`test_rf_regression[None]`) looks like a backend/environment mismatch unrelated to either fix (confirmed `buildDepthFirst`'s only change is a behavior-preserving signature refactor) — flagging for maintainers to double check in CI.
