### PR TITLE
ci: restrict the ABI baseline cache lookup to main and fail on a miss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,17 @@ jobs:
       - name: Check Cache
         id: get-cache-key
         run: |
-          CACHE_KEY=`gh cache list --sort created_at --key __release_lnx --json key --jq .[0].key`
+          # `gh cache list` reports every scope in the repository, not only the
+          # ones this run can restore from. Without `--ref` the newest matching
+          # key can belong to another pull request's scope, which `cache/restore`
+          # cannot read: the restore then misses silently and the check below
+          # compares against an empty directory. Only main-scoped entries are
+          # both restorable here and produced by a build of main.
+          CACHE_KEY=`gh cache list --ref refs/heads/main --sort created_at --limit 1 --key __release_lnx --json key --jq '.[0].key'`
+          if [ -z "${CACHE_KEY}" ] || [ "${CACHE_KEY}" = "null" ]; then
+            echo "::error::No __release_lnx cache found on refs/heads/main. Rerun the 'CI' workflow on main via workflow dispatch to regenerate it."
+            exit 1
+          fi
           echo "key=${CACHE_KEY}" >> "$GITHUB_OUTPUT"
           echo $CACHE_KEY
         env:
@@ -155,6 +165,9 @@ jobs:
         with:
           path: ./__release_lnx_main
           key: ${{ steps.get-cache-key.outputs.key }}
+          # A miss must stop the job. Continuing leaves `__release_lnx_main`
+          # empty, and an ABI comparison against nothing reports success.
+          fail-on-cache-miss: true
       - name: Download oneDAL build artifact
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
           # cannot read: the restore then misses silently and the check below
           # compares against an empty directory. Only main-scoped entries are
           # both restorable here and produced by a build of main.
-          CACHE_KEY=`gh cache list --ref refs/heads/main --sort created_at --limit 1 --key __release_lnx --json key --jq '.[0].key'`
+          CACHE_KEY=$(gh cache list --ref refs/heads/main --sort created_at --limit 1 --key __release_lnx --json key --jq '.[0].key')
           if [ -z "${CACHE_KEY}" ] || [ "${CACHE_KEY}" = "null" ]; then
             echo "::error::No __release_lnx cache found on refs/heads/main. Rerun the 'CI' workflow on main via workflow dispatch to regenerate it."
             exit 1


### PR DESCRIPTION
## Problem

`LinuxABICheck` in `ci.yml` picks its baseline like this:

```yaml
CACHE_KEY=`gh cache list --sort created_at --key __release_lnx --json key --jq .[0].key`
```

`gh cache list` reports caches from **every scope in the repository**, while `actions/cache/restore` reads only the current branch's scope and the default branch's. Verified against the live repository — `--json key,ref` returns a `ref` field per entry; today all seven `__release_lnx-*` entries happen to be `refs/heads/main` only because the save step is gated on `github.event_name != 'pull_request'`.

So a pull request that writes a cache entry keyed `__release_lnx-*` in its own `refs/pull/N/merge` scope becomes the newest match in the listing for **other** pull requests' runs. Those runs cannot restore it. The restore misses, nothing fails, `__release_lnx_main` stays empty, and `abi_check.sh` compares against an empty directory. That degrades or bypasses the ABI gate on an unrelated PR, with no code execution involved.

Independent of that, any missing baseline currently produces a pass rather than a failure.

## Change

- `--ref refs/heads/main` on the listing. That scope is both the only one this job can restore from and the only one a build of main writes, so the two now agree.
- `--limit 1`, matching what the `jq` expression already takes.
- Explicit failure with an actionable message when no main-scoped entry exists, instead of handing an empty key to the restore.
- `fail-on-cache-miss: true` on `actions/cache/restore`, so a restore that misses anyway stops the job.

`--sort created_at` keeps its existing default descending order; that behaviour is unchanged.

## Verification

`gh cache list --ref refs/heads/main --sort created_at --limit 1 --key __release_lnx --json key --jq '.[0].key'` against `uxlfoundation/oneDAL` returns `__release_lnx-eab19c86d2fd26a22e554c57242cf3ec06d66a0f`, the current main HEAD build. Workflow parses and the step's shell body passes `sh -n`.

The check is `pull_request`-gated, so this PR's own `ABI Conformance(avx2)` run exercises the new lookup directly — it must resolve a main key and pass as before.

## Related

Companion to #3776, which stops `nightly-test.yml` from handing fork-controlled code a credential for main's cache scope. The two are independent: this one is exploitable without any code execution, that one is the write side.