### PR TITLE
ci: fix release comparison failing on every dereferenced Make symlink

### DIFF
--- a/dev/release_tests/compare_release_trees.py
+++ b/dev/release_tests/compare_release_trees.py
@@ -346,10 +346,23 @@ def absorb_dereferenced_links(make_root, make_files, bazel_root, bazel_links, li
 
     Where Bazel has a symlink and Make a plain file at the same path, the pair is
     removed from level 1 and checked the only way the transport still permits:
-    the Make file must be byte-identical to the target the Bazel symlink resolves
-    to. Both collections are mutated in place; the number of reconciled entries
-    is printed, because a silently tolerated difference reads like a comparison
-    that covered everything.
+    the Make file must be byte-identical to the file the *Make* tree holds at the
+    path the Bazel symlink resolves to. That is precisely what the symlink
+    asserted before the transport flattened it -- `libonedal.so` and
+    `libonedal.so.4` carried the bytes of `libonedal.so.4.0` -- and it still
+    catches a Bazel tree whose link points somewhere else.
+
+    Comparing the Make copy against *Bazel's* build of the target instead, as
+    this did originally, demands that two independently built shared objects be
+    byte-identical. Nothing else in this script demands that: `.so` is a
+    BINARY_SUFFIX so level 3 skips it, and level 4 compares exported symbols
+    exactly because the bytes differ. The comparison therefore failed on every
+    reconciled entry on plain main (12 of 12, runs 34289321138 and 34414847486),
+    reporting the same paths as mismatches and as reconciled.
+
+    Both collections are mutated in place; the number of reconciled entries is
+    printed, because a silently tolerated difference reads like a comparison that
+    covered everything.
 
     What this cannot check, and no other comparison covers either: the *shape* of
     the Bazel link chain. `resolve()` collapses every hop, so a Bazel tree that
@@ -373,6 +386,7 @@ def absorb_dereferenced_links(make_root, make_files, bazel_root, bazel_links, li
     errors = 0
     absorbed = []
     mismatches = []
+    missing_targets = []
 
     for path in sorted(set(bazel_links).intersection(make_files)):
         target = (bazel_root / path).resolve()
@@ -380,24 +394,42 @@ def absorb_dereferenced_links(make_root, make_files, bazel_root, bazel_links, li
         # artefact, so leave it in level 1 to be reported there.
         if not target.is_relative_to(bazel_root) or not target.is_file():
             continue
+        target_path = rel(target, bazel_root)
         make_files.discard(path)
         del bazel_links[path]
-        absorbed.append(path)
-        if not filecmp.cmp(make_root / path, target, shallow=False):
-            mismatches.append((path, rel(target, bazel_root)))
+        absorbed.append((path, target_path))
+        make_target = make_root / target_path
+        # The target itself stays in both collections, so level 1 already reports
+        # a Bazel link whose target the Make release does not ship at all. Say it
+        # here too: without the target there is nothing left to check the
+        # flattened copy against, so the entry is not reconciled, only dropped.
+        if not make_target.is_file():
+            missing_targets.append((path, target_path))
+        elif not filecmp.cmp(make_root / path, make_target, shallow=False):
+            mismatches.append((path, target_path))
 
+    flagged = {path for path, _ in mismatches + missing_targets}
+
+    if missing_targets:
+        errors += len(missing_targets)
+        print(f"Dereferenced symlink targets missing from Make: {len(missing_targets)}")
+        for path, target_path in missing_targets[:limit]:
+            print(f"  ! {path}: Bazel {path} -> {target_path}, absent from Make release")
     if mismatches:
         errors += len(mismatches)
         print(f"Dereferenced symlink content mismatches: {len(mismatches)}")
-        for path, target in mismatches[:limit]:
-            print(f"  ! {path}: Make file differs from Bazel {path} -> {target}")
+        for path, target_path in mismatches[:limit]:
+            print(f"  ! {path}: Make file differs from Make {target_path}"
+                  f" (Bazel {path} -> {target_path})")
     if absorbed:
+        reconciled = [path for path, _ in absorbed if path not in flagged]
         print(
-            f"Make files reconciled against Bazel symlinks: {len(absorbed)}"
-            " (--make-symlinks-dereferenced)"
+            f"Make files reconciled against Bazel symlinks: {len(reconciled)}"
+            f" of {len(absorbed)} (--make-symlinks-dereferenced)"
         )
-        for path in absorbed[:limit]:
-            print(f"  ~ {path}")
+        for path, target_path in absorbed[:limit]:
+            if path not in flagged:
+                print(f"  ~ {path} -> {target_path}")
     return errors
 
 


### PR DESCRIPTION
## Problem

The Linux Bazel nightly has been red on plain `main`, in "Compare make and Bazel releases":

```
Make:  266 dirs, 1092 files, 0 links
Bazel: 266 dirs, 1080 files, 12 links

=== level 1: release tree entries ===
Dereferenced symlink content mismatches: 12
  ! lib/intel64/libonedal.so: Make file differs from Bazel lib/intel64/libonedal.so -> lib/intel64/libonedal.so.4.0
  ... (all 12 are .so / .so.4 version aliases)
Make files reconciled against Bazel symlinks: 12 (--make-symlinks-dereferenced)
=== level 2: symlink targets ===       Compared symlink targets: 0
=== level 3: text file contents ===    Compared text files: 1065
=== level 4: shared library exports === Compared shared library exports: 6
Release comparison failed: 12 difference(s)
```

Reproduced on nightly-test runs of plain-`main` commits `34289321138` (`e3a28f0b`) and `34414847486` (`36949e32`), both zero commits ahead of `main`. Levels 2-4 are clean; the 12 differences are entirely from level 1.

## Cause

`absorb_dereferenced_links` reconciles the shared-object aliases that `actions/upload-artifact` flattens into copies on the Make side, and checked each flattened copy against the file the **Bazel** symlink resolves to:

```python
target = (bazel_root / path).resolve()          # Bazel's libonedal.so.4.0
if not filecmp.cmp(make_root / path, target, shallow=False):
```

`make/lib/intel64/libonedal.so` is a copy of **Make's** `libonedal.so.4.0`. Byte-comparing it to **Bazel's** build of the same library asks two independently built shared objects to be byte-identical — which nothing else in this script asks: `.so` is in `BINARY_SUFFIXES` so level 3 skips it, and level 4 compares exported symbols precisely *because* the bytes differ.

So the check cannot pass on any commit. 6 libraries x 2 aliases = 12, all failing, which is why the mismatch count and the reconciled count are the same number. Azure's `LinuxReleaseCompare` is green because it does not pass `--make-symlinks-dereferenced`: both of its trees travel through pipeline artifacts, so neither has symlinks left and nothing is reconciled. The GitHub nightly is the only consumer of the flag.

## Fix

Compare the flattened copy against the file the **Make** tree holds at the path the Bazel symlink resolves to. That is exactly what the symlink asserted before the transport flattened it (`libonedal.so` and `libonedal.so.4` carried the bytes of `libonedal.so.4.0`), and it is checkable from what survives transport.

```python
target_path = rel(target, bazel_root)
make_target = make_root / target_path
if not make_target.is_file():
    missing_targets.append((path, target_path))
elif not filecmp.cmp(make_root / path, make_target, shallow=False):
    mismatches.append((path, target_path))
```

Also in this change:

* New `missing_targets` bucket — a Bazel alias whose target the Make release does not ship has nothing to be checked against, and is reported rather than silently reconciled.
* An entry that fails is no longer also printed under "reconciled", and that line now reads `N of M`, so a tolerated difference cannot read as full coverage.
* The docstring records why the cross-tree byte comparison cannot hold, so it does not come back.

The pre-existing caveat is unchanged and still documented: `resolve()` collapses the whole chain, so the *shape* of the Bazel link chain (whether `libonedal_core.so` hops through the SONAME-carrying `.so.4`) is still not asserted anywhere.

## Validation

Synthetic trees in the nightly's shape — 3 libraries, real `.so.4.0` plus `.so`/`.so.4` symlinks on the Bazel side, flattened copies with different bytes on the Make side:

| case | before | after |
|---|---|---|
| healthy trees (nightly shape) | `Release comparison failed: 6` | **passes**, `reconciled 6 of 6` |
| Make copy stale w.r.t. its Make target | caught | caught, 1 mismatch |
| Bazel alias retargeted at another library | lost in the 6 false mismatches | caught, 1 mismatch |
| Bazel alias target absent from Make | not distinguished | caught, 2 missing targets + level-1 set diff |

Real-CI confirmation needs a nightly run on this branch (`workflow_dispatch` with a `source_run_id`), since a local simulation cannot produce genuine Make and Bazel artifacts.

## Relation to #3764

#3764 adds `reconcile_dereferenced_symlinks` on a base that predates `absorb_dereferenced_links`, and its version compares the Make copy against `(bazel_root / path).resolve()` too — the same cross-tree byte comparison, so it would reconcile 0 of 12 and leave the aliases to be counted at level 1. Whichever lands second should keep the Make-side target comparison.
